### PR TITLE
FIX: allow load openapi.json outside project root folder

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -82,7 +82,7 @@ public class HttpBridge extends AbstractVerticle {
     @Override
     public void start(Future<Void> startFuture) throws Exception {
 
-        OpenAPI3RouterFactory.create(vertx, "src/main/resources/openapi.json", ar -> {
+        OpenAPI3RouterFactory.create(vertx, "openapi.json", ar -> {
             if (ar.succeeded()) {
                 OpenAPI3RouterFactory routerFactory = ar.result();
                 routerFactory.addHandlerByOperationId(HttpOpenApiOperations.SEND.toString(), this::send);


### PR DESCRIPTION
Fix for https://github.com/strimzi/strimzi-kafka-bridge/issues/165