### PR TITLE
Fix HTTP sink endpoint removing on connection close

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/BridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/BridgeEndpoint.java
@@ -14,6 +14,11 @@ import io.vertx.core.Handler;
 public interface BridgeEndpoint {
 
     /**
+     * Name of the bridge endpoint
+     */
+    String name();
+
+    /**
      * Open the bridge endpoint
      */
     void open();

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -45,6 +45,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
+    protected String name;
     protected final EmbeddedFormat format;
     protected final Deserializer<K> keyDeserializer;
     protected final Deserializer<V> valueDeserializer;
@@ -111,6 +112,11 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.format = format;
         this.keyDeserializer = keyDeserializer;
         this.valueDeserializer = valueDeserializer;
+    }
+
+    @Override
+    public String name() {
+        return this.name;
     }
 
     @Override

--- a/src/main/java/io/strimzi/kafka/bridge/SourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SourceBridgeEndpoint.java
@@ -27,6 +27,7 @@ public abstract class SourceBridgeEndpoint<K, V> implements BridgeEndpoint {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
+    protected String name;
     protected final EmbeddedFormat format;
     protected final Serializer<K> keySerializer;
     protected final Serializer<V> valueSerializer;
@@ -55,6 +56,11 @@ public abstract class SourceBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.format = format;
         this.keySerializer = keySerializer;
         this.valueSerializer = valueSerializer;
+    }
+
+    @Override
+    public String name() {
+        return this.name;
     }
 
     @Override

--- a/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpSinkBridgeEndpoint.java
@@ -92,6 +92,7 @@ public class AmqpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
             }
 
             this.sender = (ProtonSender) link;
+            this.name = this.sender.getName();
 
             // address is like this : [topic]/group.id/[group.id]
             String address = this.sender.getRemoteSource().getAddress();

--- a/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpSourceBridgeEndpoint.java
@@ -79,6 +79,7 @@ public class AmqpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
         }
 
         ProtonReceiver receiver = (ProtonReceiver) link;
+        this.name = receiver.getName();
 
         // the delivery state is related to the acknowledgement from Apache Kafka
         receiver.setTarget(receiver.getRemoteTarget())

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -183,7 +183,7 @@ public class HttpBridge extends AbstractVerticle {
         final SinkBridgeEndpoint sink = this.getHttpSinkBridgeEndpoint(format);
 
         sink.closeHandler(s -> {
-            httpBridgeContext.getHttpSinkEndpoints().remove(sink);
+            httpBridgeContext.getHttpSinkEndpoints().remove(sink.name());
         });
 
         sink.open();

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -304,7 +304,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
 
                 JsonObject json = bodyAsJson;
                 // if no name, a random one is assigned
-                this.name = json.getString("name", "kafka-bridge-consumer-" + UUID.randomUUID().toString());
+                this.name = json.getString("name", "kafka-bridge-consumer-" + UUID.randomUUID());
 
                 if (this.httpBridgeContext.getHttpSinkEndpoints().containsKey(this.name)) {
                     routingContext.response().setStatusMessage("Consumer instance with the specified name already exists.")

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -304,10 +304,9 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
 
                 JsonObject json = bodyAsJson;
                 // if no name, a random one is assigned
-                String consumerInstanceId = json.getString("name",
-                        "kafka-bridge-consumer-" + UUID.randomUUID().toString());
+                this.name = json.getString("name", "kafka-bridge-consumer-" + UUID.randomUUID().toString());
 
-                if (this.httpBridgeContext.getHttpSinkEndpoints().containsKey(consumerInstanceId)) {
+                if (this.httpBridgeContext.getHttpSinkEndpoints().containsKey(this.name)) {
                     routingContext.response().setStatusMessage("Consumer instance with the specified name already exists.")
                             .setStatusCode(ErrorCodeEnum.CONSUMER_ALREADY_EXISTS.getValue())
                             .end();
@@ -319,7 +318,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
                 if (!routingContext.request().path().endsWith("/")) {
                     requestUri += "/";
                 }
-                String consumerBaseUri = requestUri + "instances/" + consumerInstanceId;
+                String consumerBaseUri = requestUri + "instances/" + this.name;
 
                 // get supported consumer configuration parameters
                 Properties config = new Properties();
@@ -329,16 +328,16 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
                         json.getString(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, null), config);
                 addConfigParameter(ConsumerConfig.FETCH_MIN_BYTES_CONFIG,
                         json.getString(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, null), config);
-                addConfigParameter(ConsumerConfig.CLIENT_ID_CONFIG, consumerInstanceId, config);
+                addConfigParameter(ConsumerConfig.CLIENT_ID_CONFIG, this.name, config);
 
                 // create the consumer
                 this.initConsumer(false, config);
 
-                ((Handler<String>) handler).handle(consumerInstanceId);
+                ((Handler<String>) handler).handle(this.name);
 
-                log.info("Created consumer {} in group {}", consumerInstanceId, groupId);
+                log.info("Created consumer {} in group {}", this.name, groupId);
                 // send consumer instance id(name) and base URI as response
-                sendConsumerCreationResponse(routingContext.response(), consumerInstanceId, consumerBaseUri);
+                sendConsumerCreationResponse(routingContext.response(), this.name, consumerBaseUri);
                 break;
         }
     }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
 
@@ -39,6 +40,12 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
                                     EmbeddedFormat format, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         super(vertx, bridgeConfigProperties, format, keySerializer, valueSerializer);
         this.httpBridgeContext = httpBridgeContext;
+    }
+
+    @Override
+    public void open() {
+        this.name = "kafka-bridge-producer-" + UUID.randomUUID().toString();
+        super.open();
     }
 
     @Override

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -44,7 +44,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
 
     @Override
     public void open() {
-        this.name = "kafka-bridge-producer-" + UUID.randomUUID().toString();
+        this.name = "kafka-bridge-producer-" + UUID.randomUUID();
         super.open();
     }
 


### PR DESCRIPTION
This PR fixes #189 

Added sink and source name
Fixed bug on removing HTTP sink endpoint (based on name/consumer-id)