### PR TITLE
Added TLS related configuration for connecting to Kafka cluster

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -43,28 +43,36 @@ public class Application {
                 .setType("file")
                 .setOptional(true)
                 .setFormat("properties")
-                .setConfig(new JsonObject().put("path", getFilePath(path)));
+                .setConfig(new JsonObject().put("path", getFilePath(path)).put("raw-data", true));
 
         ConfigRetrieverOptions options = new ConfigRetrieverOptions().addStore(fileStore);
 
         ConfigRetriever retriever = ConfigRetriever.create(vertx, options);
         retriever.getConfig(ar -> {
-            AmqpConfig amqpConfig = new AmqpConfig(ar.result().getBoolean(AmqpConfig.AMQP_ENABLED, AmqpConfig.DEFAULT_AMQP_ENABLED),
-                    AmqpMode.from(ar.result().getString(AmqpConfig.DEFAULT_AMQP_MODE, AmqpConfig.DEFAULT_AMQP_MODE)),
-                    ar.result().getInteger(AmqpConfig.AMQP_FLOW_CREDIT, AmqpConfig.DEFAULT_FLOW_CREDIT),
-                    ar.result().getString(AmqpConfig.AMQP_HOST, AmqpConfig.DEFAULT_HOST),
-                    ar.result().getInteger(AmqpConfig.AMQP_PORT, AmqpConfig.DEFAULT_PORT),
-                    ar.result().getString(AmqpConfig.AMQP_MESSAGE_CONVERTER, AmqpConfig.DEFAULT_MESSAGE_CONVERTER),
-                    ar.result().getString(AmqpConfig.AMQP_CERT_DIR, AmqpConfig.DEFAULT_CERT_DIR));
 
-            HttpConfig httpConfig = new HttpConfig(ar.result().getBoolean(HttpConfig.HTTP_ENABLED, HttpConfig.DEFAULT_HTTP_ENABLED),
-                    ar.result().getString(HttpConfig.HTTP_HOST, HttpConfig.DEFAULT_HOST),
-                    ar.result().getInteger(HttpConfig.HTTP_PORT, HttpConfig.DEFAULT_PORT));
+            JsonObject config = ar.result();
 
-            KafkaConsumerConfig kafkaConsumerConfig = new KafkaConsumerConfig(ar.result().getString(KafkaConsumerConfig.KAFKA_CONSUMER_AUTO_OFFSET_RESET, KafkaConsumerConfig.DEFAULT_AUTO_OFFSET_RESET));
-            KafkaProducerConfig kafkaProducerConfig = new KafkaProducerConfig(Integer.toString(ar.result().getInteger(KafkaProducerConfig.KAFKA_PRODUCER_ACKS, Integer.parseInt(KafkaProducerConfig.DEFAULT_ACKS))));
+            AmqpConfig amqpConfig = new AmqpConfig(Boolean.valueOf(config.getString(AmqpConfig.AMQP_ENABLED, String.valueOf(AmqpConfig.DEFAULT_AMQP_ENABLED))),
+                    AmqpMode.from(config.getString(AmqpConfig.DEFAULT_AMQP_MODE, AmqpConfig.DEFAULT_AMQP_MODE)),
+                    Integer.valueOf(config.getString(AmqpConfig.AMQP_FLOW_CREDIT, String.valueOf(AmqpConfig.DEFAULT_FLOW_CREDIT))),
+                    config.getString(AmqpConfig.AMQP_HOST, AmqpConfig.DEFAULT_HOST),
+                    Integer.valueOf(config.getString(AmqpConfig.AMQP_PORT, String.valueOf(AmqpConfig.DEFAULT_PORT))),
+                    config.getString(AmqpConfig.AMQP_MESSAGE_CONVERTER, AmqpConfig.DEFAULT_MESSAGE_CONVERTER),
+                    config.getString(AmqpConfig.AMQP_CERT_DIR, AmqpConfig.DEFAULT_CERT_DIR));
 
-            KafkaConfig kafkaConfig = new KafkaConfig(ar.result().getString(KafkaConfig.KAFKA_BOOTSTRAP_SERVERS, KafkaConfig.DEFAULT_BOOTSTRAP_SERVERS),
+            HttpConfig httpConfig = new HttpConfig(Boolean.valueOf(config.getString(HttpConfig.HTTP_ENABLED, String.valueOf(HttpConfig.DEFAULT_HTTP_ENABLED))),
+                    config.getString(HttpConfig.HTTP_HOST, HttpConfig.DEFAULT_HOST),
+                    Integer.valueOf(config.getString(HttpConfig.HTTP_PORT, String.valueOf(HttpConfig.DEFAULT_PORT))));
+
+            KafkaConsumerConfig kafkaConsumerConfig = new KafkaConsumerConfig(config.getString(KafkaConsumerConfig.KAFKA_CONSUMER_AUTO_OFFSET_RESET,
+                    KafkaConsumerConfig.DEFAULT_AUTO_OFFSET_RESET));
+            KafkaProducerConfig kafkaProducerConfig = new KafkaProducerConfig(config.getString(KafkaProducerConfig.KAFKA_PRODUCER_ACKS,
+                    KafkaProducerConfig.DEFAULT_ACKS));
+
+            KafkaConfig kafkaConfig = new KafkaConfig(config.getString(KafkaConfig.KAFKA_BOOTSTRAP_SERVERS, KafkaConfig.DEFAULT_BOOTSTRAP_SERVERS),
+                    Boolean.valueOf(config.getString(KafkaConfig.KAFKA_TLS_ENABLED, String.valueOf(KafkaConfig.DEFAULT_KAFKA_TLS_ENABLED))),
+                    config.getString(KafkaConfig.KAFKA_TLS_TRUSTSTORE_LOCATION, KafkaConfig.DEFAULT_KAFKA_TLS_TRUSTSTORE_LOCATION),
+                    config.getString(KafkaConfig.KAFKA_TLS_TRUSTSTORE_PASSWORD, KafkaConfig.DEFAULT_KAFKA_TLS_TRUSTSTORE_PASSWORD),
                     kafkaProducerConfig, kafkaConsumerConfig);
 
             AmqpBridgeConfig amqpBridgeConfig = new AmqpBridgeConfig(kafkaConfig, amqpConfig);

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -18,8 +18,10 @@ import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -155,6 +157,12 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         props.put(ConsumerConfig.GROUP_ID_CONFIG, this.groupId);
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, consumerConfig.getConsumerConfig().isEnableAutoCommit());
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, consumerConfig.getConsumerConfig().getAutoOffsetReset());
+
+        if (this.bridgeConfigProperties.getKafkaConfig().isTlsEnabled()) {
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
+            props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, this.bridgeConfigProperties.getKafkaConfig().getTlsTruststoreLocation());
+            props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, this.bridgeConfigProperties.getKafkaConfig().getTlsTruststorePassword());
+        }
 
         if (config != null)
             props.putAll(config);

--- a/src/main/java/io/strimzi/kafka/bridge/config/KafkaConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/KafkaConfig.java
@@ -13,10 +13,19 @@ import java.util.Map;
 public class KafkaConfig {
 
     public static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrapServers";
+    public static final String KAFKA_TLS_ENABLED = "kafka.tls.enabled";
+    public static final String KAFKA_TLS_TRUSTSTORE_LOCATION = "kafka.tls.truststore.location";
+    public static final String KAFKA_TLS_TRUSTSTORE_PASSWORD = "kafka.tls.truststore.password";
 
     public static final String DEFAULT_BOOTSTRAP_SERVERS = "localhost:9092";
+    public static final boolean DEFAULT_KAFKA_TLS_ENABLED = false;
+    public static final String DEFAULT_KAFKA_TLS_TRUSTSTORE_LOCATION = null;
+    public static final String DEFAULT_KAFKA_TLS_TRUSTSTORE_PASSWORD = null;
 
     private String bootstrapServers;
+    private boolean tlsEnabled;
+    private String tlsTruststoreLocation;
+    private String tlsTruststorePassword;
     private KafkaProducerConfig producerConfig;
     private KafkaConsumerConfig consumerConfig;
 
@@ -24,13 +33,22 @@ public class KafkaConfig {
      * Constructor
      *
      * @param bootstrapServers the Kafka bootstrap servers
+     * @param tlsEnabled if the connection between the bridge and the Kafka cluster is TLS encrypted
+     * @param tlsTruststoreLocation the path of the truststore for TLS encryption with the Kafka cluster
+     * @param tlsTruststorePassword the password of the truststore for TLS encryption with the Kafka cluster
      * @param producerConfig the Kafka producer configuration
      * @param consumerConfig the Kafka consumer configuration
      */
     public KafkaConfig(String bootstrapServers,
+                       boolean tlsEnabled,
+                       String tlsTruststoreLocation,
+                       String tlsTruststorePassword,
                        KafkaProducerConfig producerConfig,
                        KafkaConsumerConfig consumerConfig) {
         this.bootstrapServers = bootstrapServers;
+        this.tlsEnabled = tlsEnabled;
+        this.tlsTruststoreLocation = tlsTruststoreLocation;
+        this.tlsTruststorePassword = tlsTruststorePassword;
         this.producerConfig = producerConfig;
         this.consumerConfig = consumerConfig;
     }
@@ -40,6 +58,27 @@ public class KafkaConfig {
      */
     public String getBootstrapServers() {
         return this.bootstrapServers;
+    }
+
+    /**
+     * @return if the connection between the bridge and the Kafka cluster is TLS encrypted
+     */
+    public boolean isTlsEnabled() {
+        return this.tlsEnabled;
+    }
+
+    /**
+     * @return the path of the truststore for TLS encryption with the Kafka cluster
+     */
+    public String getTlsTruststoreLocation() {
+        return this.tlsTruststoreLocation;
+    }
+
+    /**
+     * @return the password of the truststore for TLS encryption with the Kafka cluster
+     */
+    public String getTlsTruststorePassword() {
+        return tlsTruststorePassword;
     }
 
     /**
@@ -65,16 +104,30 @@ public class KafkaConfig {
     public static KafkaConfig fromMap(Map<String, String> map) {
 
         String bootstrapServers = map.getOrDefault(KafkaConfig.KAFKA_BOOTSTRAP_SERVERS, KafkaConfig.DEFAULT_BOOTSTRAP_SERVERS);
+
+        String tlsEnabledEnvVar = map.get(KafkaConfig.KAFKA_TLS_ENABLED);
+        boolean tlsEnabled = tlsEnabledEnvVar != null ? Boolean.valueOf(tlsEnabledEnvVar) : KafkaConfig.DEFAULT_KAFKA_TLS_ENABLED;
+
+        String tlsTruststoreLocation = map.getOrDefault(KafkaConfig.KAFKA_TLS_TRUSTSTORE_LOCATION,
+                KafkaConfig.DEFAULT_KAFKA_TLS_TRUSTSTORE_LOCATION);
+
+        String tlsTruststorePassword = map.getOrDefault(KafkaConfig.KAFKA_TLS_TRUSTSTORE_PASSWORD,
+                KafkaConfig.DEFAULT_KAFKA_TLS_TRUSTSTORE_PASSWORD);
+
         KafkaProducerConfig producerConfig = KafkaProducerConfig.fromMap(map);
         KafkaConsumerConfig consumerConfig = KafkaConsumerConfig.fromMap(map);
 
-        return new KafkaConfig(bootstrapServers, producerConfig, consumerConfig);
+        return new KafkaConfig(bootstrapServers, tlsEnabled, tlsTruststoreLocation, tlsTruststorePassword,
+                producerConfig, consumerConfig);
     }
 
     @Override
     public String toString() {
         return "KafkaConfig(" +
                 "bootstrapServers=" + this.bootstrapServers +
+                ",tlsEnabled=" + this.tlsEnabled +
+                ",tlsTruststoreLocation=" + this.tlsTruststoreLocation +
+                ",tlsTruststorePassword=" + this.tlsTruststorePassword +
                 ",producerConfig=" + this.producerConfig +
                 ",consumerConfig=" + this.consumerConfig +
                 ")";


### PR DESCRIPTION
This PR fixes #174 
I had to change the way we get configuration from the properties file specifying "raw-data" option.
I faced an issue with the TLS truststore password which is a string but could be made by all digits (i.e. 123456 in my case). It was deserialized as a Double with value 123456.0. The same happened to AMQP and HTTP ports but in that case the cast to Integer returned right values but for strings which could be numbers it's not the way to go.
With "raw-data" all values are strings that we have to cast accordingly.