### PR TITLE
Align pom version with github tag versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   
 	<groupId>io.strimzi</groupId>
 	<artifactId>kafka-bridge</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>0.12.0-SNAPSHOT</version>
 
 	<name>kafka-bridge</name>
 	<description>Apache Kafka bridge</description>


### PR DESCRIPTION
If we're expecting the next github tag to be 0.12.0 we should reflect that in the pom.xml