### PR TITLE
Add improved configuration for logging and memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ hs_err_pid*
 
 # VSCode stuff
 .vscode/
+
+.DS_Store

--- a/bin/docker/dynamic_resources.sh
+++ b/bin/docker/dynamic_resources.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+function get_heap_size {
+  CONTAINER_MEMORY_IN_BYTES=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`
+   # use max of 31G memory, java performs much better with Compressed Ordinary Object Pointers
+  DEFAULT_MEMORY_CEILING=$((31 * 2**20))
+  if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then
+    if [ -z $CONTAINER_HEAP_PERCENT ]; then
+      CONTAINER_HEAP_PERCENT=0.50
+    fi
+
+    CONTAINER_MEMORY_IN_MB=$((${CONTAINER_MEMORY_IN_BYTES}/1024**2))
+    CONTAINER_HEAP_MAX=$(echo "${CONTAINER_MEMORY_IN_MB} ${CONTAINER_HEAP_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
+
+    echo "${CONTAINER_HEAP_MAX}"
+  fi
+}

--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -32,7 +32,7 @@ if [ -n "$KAFKA_BRIDGE_SASL_USERNAME" ] && [ -n "$KAFKA_BRIDGE_SASL_PASSWORD_FIL
         SECURITY_PROTOCOL="SASL_PLAINTEXT"
     fi
 
-    PASSWORD=$(cat /opt/bridge/bridge-password/$KAFKA_BRIDGE_SASL_PASSWORD_FILE)
+    PASSWORD=$(cat /opt/strimzi/bridge-password/$KAFKA_BRIDGE_SASL_PASSWORD_FILE)
 
     if [ "x$KAFKA_BRIDGE_SASL_MECHANISM" = "xplain" ]; then
         SASL_MECHANISM="PLAIN"

--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -25,5 +25,36 @@ echo "Kafka Bridge configuration:"
 ${MYPATH}/kafka_bridge_config_generator.sh | tee /tmp/kafka-bridge.properties
 echo ""
 
+# Configure logging for Kubernetes deployments
+KAFKA_BRIDGE_LOG4J_OPTS="-Dlog4j.configuration=file:$STRIMZI_HOME/custom-config/log4j.properties"
+
+# Configure Memory
+. ${MYPATH}/dynamic_resources.sh
+
+MAX_HEAP=`get_heap_size`
+if [ -n "$MAX_HEAP" ]; then
+  export JAVA_OPTS="-Xms${MAX_HEAP}m -Xmx${MAX_HEAP}m $JAVA_OPTS"
+fi
+
+export MALLOC_ARENA_MAX=2
+
+# Configure GC logging for memory tracking
+function get_gc_opts {
+  if [ "${STRIMZI_GC_LOG_ENABLED}" == "true" ]; then
+    # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
+    JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
+    if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
+      echo "-Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
+    else
+      echo "-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:NativeMemoryTracking=summary"
+    fi
+  else
+    # no gc options
+    echo ""
+  fi
+}
+
+export JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
+
 # starting Kafka Bridge with final configuration
 ${MYPATH}/../kafka_bridge_run.sh --config-file=/tmp/kafka-bridge.properties "$@"

--- a/bin/kafka_bridge_run.sh
+++ b/bin/kafka_bridge_run.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# Find my path to use when calling scripts
 MYPATH="$(dirname "$0")"
 
-exec java -Dvertx.cacheDirBase=/tmp -cp "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"
+# Configure logging
+if [ -z "$KAFKA_BRIDGE_LOG4J_OPTS" ]
+then
+      KAFKA_BRIDGE_LOG4J_OPTS="-Dlog4j.configuration=file:${MYPATH}/../config/log4j.properties"
+fi
+
+# Make sure that we use /dev/urandom
+JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
+
+exec java $JAVA_OPTS $KAFKA_BRIDGE_LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"


### PR DESCRIPTION
This PR adds:
* Possibility to use the option `JAVA_OPTS` to pass properties and other options to the bridge
* Uses the `config/log4j.properties` file for logging configuration by default and allows to override it with `KAFKA_BRIDGE_LOG4J_OPTS`
* In Docker it adds memory handling based on what we have for operators
* In Docker it adds the possibility to enable / disable GC logging

(+ adds `.DS_Store` to `.gitignore` ... MacOS puts it everywhere ;-))