### PR TITLE
Make TLS work again when used with StrimziCO

### DIFF
--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -8,7 +8,7 @@ if [ "$KAFKA_BRIDGE_TLS" = "true" ]; then
     if [ -n "$KAFKA_BRIDGE_TRUSTED_CERTS" ]; then
         TLS_CONFIGURATION=$(cat <<EOF
 #TLS/SSL
-kafka.ssl.truststore.location=/tmp/kafka/bridge.truststore.p12
+kafka.ssl.truststore.location=/tmp/strimzi/bridge.truststore.p12
 kafka.ssl.truststore.password=${CERTS_STORE_PASSWORD}
 kafka.ssl.truststore.type=PKCS12
 EOF
@@ -17,7 +17,7 @@ EOF
 
     if [ -n "$KAFKA_BRIDGE_TLS_AUTH_CERT" ] && [ -n "$KAFKA_BRIDGE_TLS_AUTH_KEY" ]; then
         TLS_AUTH_CONFIGURATION=$(cat <<EOF
-kafka.ssl.keystore.location=/tmp/kafka/bridge.keystore.p12
+kafka.ssl.keystore.location=/tmp/strimzi/bridge.keystore.p12
 kafka.ssl.keystore.password=${CERTS_STORE_PASSWORD}
 kafka.ssl.keystore.type=PKCS12
 EOF

--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -7,7 +7,7 @@ if [ -n "$KAFKA_BRIDGE_TRUSTED_CERTS" ]; then
     # Generate temporary keystore password
     export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
 
-    mkdir -p /tmp/kafka
+    mkdir -p /tmp/strimzi
 
     # Import certificates into keystore and truststore
     # $1 = trusted certs, $2 = TLS auth cert, $3 = TLS auth key, $4 = truststore path, $5 = keystore path, $6 = certs and key path
@@ -15,9 +15,9 @@ if [ -n "$KAFKA_BRIDGE_TRUSTED_CERTS" ]; then
         "$KAFKA_BRIDGE_TRUSTED_CERTS" \
         "$KAFKA_BRIDGE_TLS_AUTH_CERT" \
         "$KAFKA_BRIDGE_TLS_AUTH_KEY" \
-        "/tmp/kafka/bridge.truststore.p12" \
-        "/tmp/kafka/bridge.keystore.p12" \
-        "/opt/kafka/bridge-certs"
+        "/tmp/strimzi/bridge.truststore.p12" \
+        "/tmp/strimzi/bridge.keystore.p12" \
+        "${STRIMZI_HOME}/bridge-certs"
 fi
 
 # Generate and print the consumer config file


### PR DESCRIPTION
The TLs doesn't work currently when the image is used from Docker. This is because the startup scripts expect the certificates to be under `/opt/kafka` but they are under `/opt/strimzi`. So it never finds them and the Bridge will never connect. This PR changes the paths to use the right ones.