### PR TITLE
Separate api doc generation from main build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,12 @@ docu_htmlnoheader: docu_htmlnoheaderclean docu_check
 	$(CP) -vrL documentation/book/images documentation/htmlnoheader/images
 	asciidoctor -v --failure-level WARN -t -dbook -a ProductVersion=$(RELEASE_VERSION) -s documentation/book/master.adoc -o documentation/htmlnoheader/master.html
 
+.PHONY: docu_api
+docu_api: 
+	mvn -P apidoc io.github.swagger2markup:swagger2markup-maven-plugin:convertSwagger2markup@generate-apidoc
+
 .PHONY: docu_check
-docu_check:
+docu_check: docu_api
 	./.travis/check_docs.sh
 
 .PHONY: docu_clean

--- a/pom.xml
+++ b/pom.xml
@@ -203,29 +203,39 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
-			</plugin>
-			<plugin>
-				<groupId>io.github.swagger2markup</groupId>
-				<artifactId>swagger2markup-maven-plugin</artifactId>
-				<version>${swagger2markup.version}</version>
-				<configuration>
-					<swaggerInput>${project.basedir}/src/main/resources/openapiv2.json</swaggerInput>
-					<outputDir>${project.basedir}/documentation/book/api/</outputDir>
-					<config>
-						<swagger2markup.markupLanguage>ASCIIDOC</swagger2markup.markupLanguage>
-					</config>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>convertSwagger2markup</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+			</plugin>        
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>apidoc</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>io.github.swagger2markup</groupId>
+						<artifactId>swagger2markup-maven-plugin</artifactId>
+						<version>${swagger2markup.version}</version>
+						<configuration>
+							<swaggerInput>${project.basedir}/src/main/resources/openapiv2.json</swaggerInput>
+							<outputDir>${project.basedir}/documentation/book/api/</outputDir>
+							<config>
+								<swagger2markup.markupLanguage>ASCIIDOC</swagger2markup.markupLanguage>
+							</config>
+						</configuration>
+						<executions>
+							<execution>
+								<id>generate-apidoc</id>
+								<goals>
+									<goal>convertSwagger2markup</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<licenses>
 		<license>


### PR DESCRIPTION
This PR separates the generation of the API documentation from the main maven build and adjusts the `Makefile` so the API docs are generated as part of the `docu_html` target. In addition the `docu_check` target will also check the generated docs, ensuring that the generated docs stay in sync with the `openapiv2.json`.