### PR TITLE
Fix logging issues and set default log level to INFO

### DIFF
--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -26,7 +26,7 @@ ${MYPATH}/kafka_bridge_config_generator.sh | tee /tmp/kafka-bridge.properties
 echo ""
 
 # Configure logging for Kubernetes deployments
-KAFKA_BRIDGE_LOG4J_OPTS="-Dlog4j.configuration=file:$STRIMZI_HOME/custom-config/log4j.properties"
+export KAFKA_BRIDGE_LOG4J_OPTS="-Dlog4j.configuration=file:$STRIMZI_HOME/custom-config/log4j.properties"
 
 # Configure Memory
 . ${MYPATH}/dynamic_resources.sh

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -2,7 +2,7 @@
 # The logging properties used
 #
 log4j.rootLogger=INFO, out
-log4j.logger.io.strimzi.kafka.bridge=DEBUG, out
+log4j.logger.io.strimzi.kafka.bridge=INFO, out
 log4j.additivity.io.strimzi.kafka.bridge=false
 
 # CONSOLE appender not used by default


### PR DESCRIPTION
The logging configuration from the Strimzi CO doesn't work because of missing `export` statement. Also, the default configuration probably shouldn't be `DEBUG` but `INFO` since `DEBUG` prints quite a lot of information for each request it receives which would be quite annoying unless someone wants to specifically debug it. 