### PR TITLE
Set basePath as the endpoints root

### DIFF
--- a/documentation/book/api/overview.adoc
+++ b/documentation/book/api/overview.adoc
@@ -26,7 +26,7 @@ __Terms of service__ : http://swagger.io/terms/
 === URI scheme
 [%hardbreaks]
 __Host__ : bridge.swagger.io
-__BasePath__ : /v2
+__BasePath__ : /
 __Schemes__ : HTTP
 
 

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -15,7 +15,7 @@
     },
     "servers": [
         {
-            "url": "http://bridge.swagger.io/v2"
+            "url": "http://bridge.swagger.io/"
         }
     ],
     "paths": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -14,7 +14,7 @@
     "version": "0.1.0"
   },
   "host": "bridge.swagger.io",
-  "basePath": "/v2",
+  "basePath": "/",
   "schemes": [
     "http"
   ],


### PR DESCRIPTION
An API management system (i.e. 3scale), when importing the OpenAPI v2 spec, uses the `basePath` as the root of all endpoints so that `/topics` for example becomes `/v2/topics`.
In our bridge, it's not the case so we can have all endpoints directly mapped to the root.