### PR TITLE
Moving the "healthy" and "ready" endpoints as part of the OpenAPI spec

### DIFF
--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -820,7 +820,7 @@ __required__|Name of the consumer that you want to unsubscribe from topics.|stri
 === GET /healthy
 
 ==== Description
-Check if the bridge is healthy and can accept requests.
+Check if the bridge is running. This does not necessarily imply that it is ready to accept requests.
 
 
 ==== Responses

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -816,6 +816,38 @@ __required__|Name of the consumer that you want to unsubscribe from topics.|stri
 ----
 
 
+[[_healthy]]
+=== GET /healthy
+
+==== Description
+Check if the bridge is healthy and can accept requests.
+
+
+==== Responses
+
+[options="header", cols=".^2,.^14,.^4"]
+|===
+|HTTP Code|Description|Schema
+|**200**|The bridge is healthy|No Content
+|===
+
+
+[[_ready]]
+=== GET /ready
+
+==== Description
+Check if the bridge is ready and can accept requests.
+
+
+==== Responses
+
+[options="header", cols=".^2,.^14,.^4"]
+|===
+|HTTP Code|Description|Schema
+|**200**|The bridge is ready|No Content
+|===
+
+
 [[_send]]
 === POST /topics/{topicname}
 

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -71,7 +71,7 @@ public class Application {
             int healthServerPort = Integer.valueOf(config.getOrDefault(HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_PORT).toString());
 
             if (amqpBridgeConfig.getEndpointConfig().isEnabled() && amqpBridgeConfig.getEndpointConfig().getPort() == healthServerPort) {
-                log.error("Health server port {} conflicts with enabled protocols ports", healthServerPort);
+                log.error("Health server port {} conflicts with configured AMQP port", healthServerPort);
                 System.exit(1);
             }
 

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -5,7 +5,6 @@
 
 package io.strimzi.kafka.bridge;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.amqp.AmqpBridge;
 import io.strimzi.kafka.bridge.amqp.AmqpBridgeConfig;
 import io.strimzi.kafka.bridge.http.HttpBridge;

--- a/src/main/java/io/strimzi/kafka/bridge/HealthCheckable.java
+++ b/src/main/java/io/strimzi/kafka/bridge/HealthCheckable.java
@@ -1,0 +1,17 @@
+package io.strimzi.kafka.bridge;
+
+/**
+ * Represents a component which exposes information about its health
+ */
+public interface HealthCheckable {
+
+    /**
+     * @return if it's healthy answering to requests
+     */
+    boolean isHealthy();
+
+    /**
+     * @return if it's ready to start answering to requests
+     */
+    boolean isReady();
+}

--- a/src/main/java/io/strimzi/kafka/bridge/HealthCheckable.java
+++ b/src/main/java/io/strimzi/kafka/bridge/HealthCheckable.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
 package io.strimzi.kafka.bridge;
 
 /**

--- a/src/main/java/io/strimzi/kafka/bridge/HealthCheckable.java
+++ b/src/main/java/io/strimzi/kafka/bridge/HealthCheckable.java
@@ -13,7 +13,7 @@ public interface HealthCheckable {
     /**
      * @return if it's healthy answering to requests
      */
-    boolean isHealthy();
+    boolean isAlive();
 
     /**
      * @return if it's ready to start answering to requests

--- a/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
+++ b/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
@@ -19,7 +19,7 @@ import io.vertx.core.Vertx;
  */
 public class HealthChecker {
 
-    private static final Logger log = LoggerFactory.getLogger(Application.class);
+    private static final Logger log = LoggerFactory.getLogger(HealthChecker.class);
 
     private final List<HealthCheckable> healthCheckableList;
     
@@ -36,17 +36,27 @@ public class HealthChecker {
         this.healthCheckableList.add(healthCheckable);
     }
 
-    public boolean isHealthy() {
-        boolean isHealthy = true;
+    /**
+     * Check if all the added services are alive and able to answer requests
+     * 
+     * @return if all the added services are alive and able to answer requests
+     */
+    public boolean isAlive() {
+        boolean isAlive = true;
         for (HealthCheckable healthCheckable : this.healthCheckableList) {
-            isHealthy &= healthCheckable.isHealthy();
-            if (!isHealthy) {
+            isAlive &= healthCheckable.isAlive();
+            if (!isAlive) {
                 break;
             }
         }
-        return isHealthy;
+        return isAlive;
     }
 
+    /**
+     * Check if all the added services are ready to answer requests
+     * 
+     * @return if all the added services are ready to answer requests
+     */
     public boolean isReady() {
         boolean isReady = true;
         for (HealthCheckable healthCheckable : this.healthCheckableList) {
@@ -67,7 +77,7 @@ public class HealthChecker {
                 .requestHandler(request -> {
                     HttpResponseStatus httpResponseStatus = HttpResponseStatus.OK;
                     if (request.path().equals("/healthy")) {
-                        httpResponseStatus = this.isHealthy() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+                        httpResponseStatus = this.isAlive() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
                         request.response().setStatusCode(httpResponseStatus.code()).end();
                     } else if (request.path().equals("/ready")) {
                         httpResponseStatus = this.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;

--- a/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
+++ b/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
 package io.strimzi.kafka.bridge;
 
 import java.util.ArrayList;

--- a/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
+++ b/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
@@ -1,0 +1,82 @@
+package io.strimzi.kafka.bridge;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.Vertx;
+
+/**
+ * Check the healthiness and readiness of the registered services
+ */
+public class HealthChecker {
+
+    private static final Logger log = LoggerFactory.getLogger(Application.class);
+
+    private final List<HealthCheckable> healthCheckableList;
+    
+    public HealthChecker() {
+        this.healthCheckableList = new ArrayList<>();
+    }
+
+    /**
+     * Add a service for checking its healthiness and readiness
+     * 
+     * @param healthCheckable service to check
+     */
+    public void addHealthCheckable(HealthCheckable healthCheckable) {
+        this.healthCheckableList.add(healthCheckable);
+    }
+
+    public boolean isHealthy() {
+        boolean isHealthy = true;
+        for (HealthCheckable healthCheckable : this.healthCheckableList) {
+            isHealthy &= healthCheckable.isHealthy();
+            if (!isHealthy) {
+                break;
+            }
+        }
+        return isHealthy;
+    }
+
+    public boolean isReady() {
+        boolean isReady = true;
+        for (HealthCheckable healthCheckable : this.healthCheckableList) {
+            isReady &= healthCheckable.isReady();
+            if (!isReady) {
+                break;
+            }
+        }
+        return isReady;
+    }
+
+    /**
+     * Start an HTTP health server
+     */
+    public void startHealthServer(Vertx vertx, int port) {
+
+        vertx.createHttpServer()
+                .requestHandler(request -> {
+                    HttpResponseStatus httpResponseStatus = HttpResponseStatus.OK;
+                    if (request.path().equals("/healthy")) {
+                        httpResponseStatus = this.isHealthy() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+                        request.response().setStatusCode(httpResponseStatus.code()).end();
+                    } else if (request.path().equals("/ready")) {
+                        httpResponseStatus = this.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+                        request.response().setStatusCode(httpResponseStatus.code()).end();
+                    } else {
+                        request.response().setStatusCode(HttpResponseStatus.NOT_FOUND.code()).end();
+                    }
+                })
+                .listen(port, done -> {
+                    if (done.succeeded()) {
+                        log.info("Health server started, listening on port {}", port);
+                    } else {
+                        log.error("Failed to start Health server", done.cause());
+                    }
+                });
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
+++ b/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
@@ -77,10 +77,10 @@ public class HealthChecker {
                 .requestHandler(request -> {
                     HttpResponseStatus httpResponseStatus = HttpResponseStatus.OK;
                     if (request.path().equals("/healthy")) {
-                        httpResponseStatus = this.isAlive() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+                        httpResponseStatus = this.isAlive() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
                         request.response().setStatusCode(httpResponseStatus.code()).end();
                     } else if (request.path().equals("/ready")) {
-                        httpResponseStatus = this.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+                        httpResponseStatus = this.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
                         request.response().setStatusCode(httpResponseStatus.code()).end();
                     } else {
                         request.response().setStatusCode(HttpResponseStatus.NOT_FOUND.code()).end();

--- a/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
@@ -497,7 +497,7 @@ public class AmqpBridge extends AbstractVerticle implements HealthCheckable {
     }
 
     @Override
-    public boolean isHealthy() {
+    public boolean isAlive() {
         return this.isReady;
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
@@ -7,6 +7,7 @@ package io.strimzi.kafka.bridge.amqp;
 
 import io.strimzi.kafka.bridge.ConnectionEndpoint;
 import io.strimzi.kafka.bridge.EmbeddedFormat;
+import io.strimzi.kafka.bridge.HealthCheckable;
 import io.strimzi.kafka.bridge.SinkBridgeEndpoint;
 import io.strimzi.kafka.bridge.SourceBridgeEndpoint;
 import io.strimzi.kafka.bridge.amqp.converter.AmqpDefaultMessageConverter;
@@ -44,7 +45,7 @@ import java.util.Map;
  * and handling AMQP senders and receivers
  */
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
-public class AmqpBridge extends AbstractVerticle {
+public class AmqpBridge extends AbstractVerticle implements HealthCheckable {
 
     private static final Logger log = LoggerFactory.getLogger(AmqpBridge.class);
 
@@ -495,4 +496,13 @@ public class AmqpBridge extends AbstractVerticle {
         }
     }
 
+    @Override
+    public boolean isHealthy() {
+        return this.isReady;
+    }
+
+    @Override
+    public boolean isReady() {
+        return this.isReady;
+    }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -341,8 +341,8 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
     }
 
     private void healthy(RoutingContext routingContext) {
-        HttpResponseStatus httpResponseStatus = this.healthChecker.isHealthy() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
-        HttpUtils.sendResponse(routingContext, httpResponseStatus.OK.code(), null, null);
+        HttpResponseStatus httpResponseStatus = this.healthChecker.isAlive() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+        HttpUtils.sendResponse(routingContext, httpResponseStatus.code(), null, null);
     }
 
     private void ready(RoutingContext routingContext) {
@@ -402,7 +402,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
     }
 
     @Override
-    public boolean isHealthy() {
+    public boolean isAlive() {
         return this.isReady;
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -341,12 +341,12 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
     }
 
     private void healthy(RoutingContext routingContext) {
-        HttpResponseStatus httpResponseStatus = this.healthChecker.isAlive() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+        HttpResponseStatus httpResponseStatus = this.healthChecker.isAlive() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
         HttpUtils.sendResponse(routingContext, httpResponseStatus.code(), null, null);
     }
 
     private void ready(RoutingContext routingContext) {
-        HttpResponseStatus httpResponseStatus = this.healthChecker.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+        HttpResponseStatus httpResponseStatus = this.healthChecker.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
         HttpUtils.sendResponse(routingContext, httpResponseStatus.code(), null, null);
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -8,6 +8,8 @@ package io.strimzi.kafka.bridge.http;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.EmbeddedFormat;
+import io.strimzi.kafka.bridge.HealthCheckable;
+import io.strimzi.kafka.bridge.HealthChecker;
 import io.strimzi.kafka.bridge.SinkBridgeEndpoint;
 import io.strimzi.kafka.bridge.SourceBridgeEndpoint;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
@@ -29,10 +31,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Main bridge class listening for connections
- * and handling HTTP requests.
+ * Main bridge class listening for connections and handling HTTP requests.
  */
-public class HttpBridge extends AbstractVerticle {
+public class HttpBridge extends AbstractVerticle implements HealthCheckable {
 
     private static final Logger log = LoggerFactory.getLogger(HttpBridge.class);
 
@@ -46,6 +47,8 @@ public class HttpBridge extends AbstractVerticle {
     private boolean isReady = false;
 
     private Router router;
+
+    private HealthChecker healthChecker;
 
     /**
      * Constructor
@@ -97,6 +100,8 @@ public class HttpBridge extends AbstractVerticle {
                 routerFactory.addHandlerByOperationId(HttpOpenApiOperations.SEEK.toString(), this::seek);
                 routerFactory.addHandlerByOperationId(HttpOpenApiOperations.SEEK_TO_BEGINNING.toString(), this::seekToBeginning);
                 routerFactory.addHandlerByOperationId(HttpOpenApiOperations.SEEK_TO_END.toString(), this::seekToEnd);
+                routerFactory.addHandlerByOperationId(HttpOpenApiOperations.HEALTHY.toString(), this::healthy);
+                routerFactory.addHandlerByOperationId(HttpOpenApiOperations.READY.toString(), this::ready);
 
                 routerFactory.addGlobalHandler(rc -> {
                     int requestId = System.identityHashCode(rc.request());
@@ -335,6 +340,16 @@ public class HttpBridge extends AbstractVerticle {
         }
     }
 
+    private void healthy(RoutingContext routingContext) {
+        HttpResponseStatus httpResponseStatus = this.healthChecker.isHealthy() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+        HttpUtils.sendResponse(routingContext, httpResponseStatus.OK.code(), null, null);
+    }
+
+    private void ready(RoutingContext routingContext) {
+        HttpResponseStatus httpResponseStatus = this.healthChecker.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.INTERNAL_SERVER_ERROR;
+        HttpUtils.sendResponse(routingContext, httpResponseStatus.code(), null, null);
+    }
+
     private void errorHandler(int statusCode, RoutingContext routingContext) {
         String message = null;
         // in case of validation exception, building a meaningful error message
@@ -384,5 +399,19 @@ public class HttpBridge extends AbstractVerticle {
                 return EmbeddedFormat.JSON;
         }
         throw new IllegalArgumentException(contentType);
+    }
+
+    @Override
+    public boolean isHealthy() {
+        return this.isReady;
+    }
+
+    @Override
+    public boolean isReady() {
+        return this.isReady;
+    }
+
+    public void setHealthChecker(HealthChecker healthChecker) {
+        this.healthChecker = healthChecker;
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -21,7 +21,9 @@ public enum HttpOpenApiOperations {
     COMMIT("commit"),
     SEEK("seek"),
     SEEK_TO_BEGINNING("seekToBeginning"),
-    SEEK_TO_END("seekToEnd");
+    SEEK_TO_END("seekToEnd"),
+    HEALTHY("healthy"),
+    READY("ready");
 
     private final String text;
 

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1031,7 +1031,7 @@
                     }
                 },
                 "operationId": "healthy",
-                "description": "Check if the bridge is healthy and can accept requests."
+                "description": "Check if the bridge is running. This does not necessarily imply that it is ready to accept requests."
             }
         },
         "/ready": {

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1022,6 +1022,28 @@
                     }
                 }
             ]
+        },
+        "/healthy": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "The bridge is healthy"
+                    }
+                },
+                "operationId": "healthy",
+                "description": "Check if the bridge is healthy and can accept requests."
+            }
+        },
+        "/ready": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "The bridge is ready"
+                    }
+                },
+                "operationId": "ready",
+                "description": "Check if the bridge is ready and can accept requests."
+            }
         }
     },
     "components": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -863,7 +863,7 @@
           }
         },
         "operationId": "healthy",
-        "description": "Check if the bridge is healthy and can accept requests."
+        "description": "Check if the bridge is running. This does not necessarily imply that it is ready to accept requests."
       }
     },
     "/ready": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -854,6 +854,28 @@
           "type": "string"
         }
       ]
+    },
+    "/healthy": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "The bridge is healthy"
+          }
+        },
+        "operationId": "healthy",
+        "description": "Check if the bridge is healthy and can accept requests."
+      }
+    },
+    "/ready": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "The bridge is ready"
+          }
+        },
+        "operationId": "ready",
+        "description": "Check if the bridge is ready and can accept requests."
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
This PR fixes #264.
Other than that it factors out a class for doing health checks relying on the status of enabled protocols (bridges). Currently, there is not so much logic about when a protocol bridge is ready/healthy (just reusing a `isReady` member that was already there). More complex logic could be added in the future with another PR.