### PR TITLE
Exposing openapi endpoint for getting OpenAPI v2 spec in JSON format

### DIFF
--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -832,6 +832,27 @@ Check if the bridge is running. This does not necessarily imply that it is ready
 |===
 
 
+[[_openapi]]
+=== GET /openapi
+
+==== Description
+Retrieves the OpenAPI v2 specification in JSON format.
+
+
+==== Responses
+
+[options="header", cols=".^2,.^14,.^4"]
+|===
+|HTTP Code|Description|Schema
+|**200**|OpenAPI v2 specification in JSON format retrieved successfully.|string
+|===
+
+
+==== Produces
+
+* `application/json`
+
+
 [[_ready]]
 === GET /ready
 

--- a/src/main/java/io/strimzi/kafka/bridge/BridgeContentType.java
+++ b/src/main/java/io/strimzi/kafka/bridge/BridgeContentType.java
@@ -16,4 +16,5 @@ public class BridgeContentType {
     public static final String KAFKA_JSON_BINARY = "application/vnd.kafka.binary.v2+json";
     // JSON encoding
     public static final String KAFKA_JSON = "application/vnd.kafka.v2+json";
+    public static final String JSON = "application/json";
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -357,7 +357,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         FileSystem fileSystem = vertx.fileSystem();
         fileSystem.readFile("openapiv2.json", readFile -> {
             if (readFile.succeeded()) {
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, readFile.result());
+                HttpUtils.sendFile(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, "openapiv2.json");
             } else {
                 HttpBridgeError error = new HttpBridgeError(
                     HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -23,7 +23,8 @@ public enum HttpOpenApiOperations {
     SEEK_TO_BEGINNING("seekToBeginning"),
     SEEK_TO_END("seekToEnd"),
     HEALTHY("healthy"),
-    READY("ready");
+    READY("ready"),
+    OPENAPI("openapi");
 
     private final String text;
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
@@ -32,6 +32,16 @@ public class HttpUtils {
         }
     }
 
+    public static void sendFile(RoutingContext routingContext, int statusCode, String contentType, String filename) {
+        if (!routingContext.response().closed() && !routingContext.response().ended()) {
+            routingContext.response().setStatusCode(statusCode);
+            log.debug("[{}] Response: filename = {}", routingContext.get("request-id"), filename);
+            routingContext.response().putHeader(HttpHeaderNames.CONTENT_TYPE, contentType).sendFile(filename);
+        } else if (routingContext.response().ended()) {
+            log.warn("[{}] Response: already ended!", routingContext.get("request-id").toString());
+        } 
+    }
+
     public static void logRequest(RoutingContext routingContext) {
         log.info("[{}] Request: method = {}, path = {}", routingContext.get("request-id"), routingContext.request().method(), routingContext.request().path());
         log.debug("[{}] Request: headers = {}", routingContext.get("request-id"), routingContext.request().headers());

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1044,6 +1044,24 @@
                 "operationId": "ready",
                 "description": "Check if the bridge is ready and can accept requests."
             }
+        },
+        "/openapi": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "OpenAPI v2 specification in JSON format retrieved successfully."
+                    }
+                },
+                "operationId": "openapi",
+                "description": "Retrieves the OpenAPI v2 specification in JSON format."
+            }
         }
     },
     "components": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -876,6 +876,23 @@
         "operationId": "ready",
         "description": "Check if the bridge is ready and can accept requests."
       }
+    },
+    "/openapi": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OpenAPI v2 specification in JSON format retrieved successfully.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "operationId": "openapi",
+        "description": "Retrieves the OpenAPI v2 specification in JSON format."
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
This PR exposes the OpenAPI v2 specification in JSON format on the `/openapi` endpoint.