### PR TITLE
Consumer name is prefixed by Bridge ID when available

### DIFF
--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+BRIDGE_PROPERTIES=$(cat <<-EOF
+#Bridge configuration
+bridge.id=${KAFKA_BRIDGE_ID}
+EOF
+)
+
 SECURITY_PROTOCOL=PLAINTEXT
 
 if [ "$KAFKA_BRIDGE_TLS" = "true" ]; then
@@ -105,6 +111,8 @@ EOF
 
 # if http/amqp is disabled, do not print its configuration
 PROPERTIES=$(cat <<EOF
+BRIDGE_PROPERTIES
+
 $KAFKA_PROPERTIES
 
 $PRODUCER_PROPERTIES

--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -111,7 +111,7 @@ EOF
 
 # if http/amqp is disabled, do not print its configuration
 PROPERTIES=$(cat <<EOF
-BRIDGE_PROPERTIES
+$BRIDGE_PROPERTIES
 
 $KAFKA_PROPERTIES
 

--- a/config/application.properties
+++ b/config/application.properties
@@ -1,3 +1,6 @@
+#Bridge related settings
+bridge.id=my-bridge
+
 #Apache Kafka common
 kafka.bootstrap.servers=localhost:9092
 

--- a/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
@@ -88,6 +88,10 @@ public class BridgeConfig extends AbstractConfig {
     }
 
     public String getBridgeID() {
-        return config.get(BridgeConfig.BRIDGE_ID) == null ? null : config.get(BridgeConfig.BRIDGE_ID).toString();
+        if (config.get(BridgeConfig.BRIDGE_ID) == null) {
+            return null;
+        } else {
+            return config.get(BridgeConfig.BRIDGE_ID).toString();
+        }
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
@@ -18,6 +18,8 @@ public class BridgeConfig extends AbstractConfig {
 
     public static final String BRIDGE_CONFIG_PREFIX = "bridge.";
 
+    public static final String BRIDGE_ID = BRIDGE_CONFIG_PREFIX + "id";
+
     private KafkaConfig kafkaConfig;
     private AmqpConfig amqpConfig;
     private HttpConfig httpConfig;
@@ -83,5 +85,9 @@ public class BridgeConfig extends AbstractConfig {
                 ",amqpConfig=" + this.amqpConfig +
                 ",httpConfig=" + this.httpConfig +
                 ")";
+    }
+
+    public String getBridgeID() {
+        return config.get(BridgeConfig.BRIDGE_ID) == null ? null : config.get(BridgeConfig.BRIDGE_ID).toString();
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
@@ -24,7 +24,7 @@ public class BridgeConfig extends AbstractConfig {
 
     /**
      * Constructor
-     * 
+     *
      * @param config bridge common configuration parameters map
      * @param kafkaConfig Kafka related configuration
      * @param amqpConfig AMQP endpoint related configuration
@@ -71,7 +71,7 @@ public class BridgeConfig extends AbstractConfig {
 
         return new BridgeConfig(map.entrySet().stream()
                 .filter(e -> e.getKey().startsWith(BridgeConfig.BRIDGE_CONFIG_PREFIX))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)), 
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
                 kafkaConfig, amqpConfig, httpConfig);
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -73,7 +73,9 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         groupId = routingContext.pathParam("groupid");
 
         // if no name, a random one is assigned
-        this.name = bodyAsJson.getString("name", "kafka-bridge-consumer-" + UUID.randomUUID());
+        this.name = bodyAsJson.getString("name", bridgeConfigProperties.getBridgeID() == null
+                ? "kafka-bridge-consumer-" + UUID.randomUUID()
+                : bridgeConfigProperties.getBridgeID() + "-" + UUID.randomUUID());
 
         if (this.httpBridgeContext.getHttpSinkEndpoints().containsKey(this.name)) {
             HttpBridgeError error = new HttpBridgeError(
@@ -371,7 +373,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         try {
             bodyAsJson = routingContext.getBodyAsJson();
         } catch (DecodeException ex) {
-            
+
         }
         log.debug("[{}] Request: body = {}", routingContext.get("request-id"), bodyAsJson);
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -73,9 +73,9 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         groupId = routingContext.pathParam("groupid");
 
         // if no name, a random one is assigned
-        this.name = bodyAsJson.getString("name", bridgeConfigProperties.getBridgeID() == null
+        this.name = bodyAsJson.getString("name", bridgeConfig.getBridgeID() == null
                 ? "kafka-bridge-consumer-" + UUID.randomUUID()
-                : bridgeConfigProperties.getBridgeID() + "-" + UUID.randomUUID());
+                : bridgeConfig.getBridgeID() + "-" + UUID.randomUUID());
 
         if (this.httpBridgeContext.getHttpSinkEndpoints().containsKey(this.name)) {
             HttpBridgeError error = new HttpBridgeError(

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -43,7 +43,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
 
     @Override
     public void open() {
-        this.name = this.bridgeConfigProperties.getBridgeID() == null ? "kafka-bridge-producer-" + UUID.randomUUID() : this.bridgeConfigProperties.getBridgeID() + "-" + UUID.randomUUID();
+        this.name = this.bridgeConfig.getBridgeID() == null ? "kafka-bridge-producer-" + UUID.randomUUID() : this.bridgeConfig.getBridgeID() + "-" + UUID.randomUUID();
         super.open();
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -43,7 +43,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
 
     @Override
     public void open() {
-        this.name = "kafka-bridge-producer-" + UUID.randomUUID();
+        this.name = this.bridgeConfigProperties.getBridgeID() == null ? "kafka-bridge-producer-" + UUID.randomUUID() : this.bridgeConfigProperties.getBridgeID() + "-" + UUID.randomUUID();
         super.open();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+#Bridge related settings
+bridge.id=my-bridge
+
 #Apache Kafka common
 kafka.bootstrap.servers=localhost:9092
 


### PR DESCRIPTION
https://github.com/strimzi/strimzi-kafka-bridge/issues/273

`name` neither `bridge.id` set.
```
{
    "instance_id": "kafka-bridge-consumer-a613d84b-4842-4a91-a5e3-ffe251b285e6",
    "base_uri": "http://localhost:8080/consumers/my-group/instances/kafka-bridge-consumer-a613d84b-4842-4a91-a5e3-ffe251b285e6"
}
```

`name` not set, `bridge.id` set to "my-bridge"
```
{
    "instance_id": "my-bridge-aafec785-0dab-4a49-830f-5339b664a2f5",
    "base_uri": "http://localhost:8080/consumers/my-group/instances/my-bridge-aafec785-0dab-4a49-830f-5339b664a2f5"
}
```