### PR TITLE
Removed workaround related to Vert.x web issue fixed in 3.8.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<slf4j-log4j12.version>1.7.18</slf4j-log4j12.version>
 		<log4j.version>1.2.17</log4j.version>
-		<vertx.version>3.8.0-SNAPSHOT</vertx.version>
+		<vertx.version>3.8.0</vertx.version>
 		<debezium.version>0.8.3.Final</debezium.version>
 		<maven.checkstyle.version>3.0.0</maven.checkstyle.version>
 		<jupiter.version>5.4.0</jupiter.version>


### PR DESCRIPTION
This trivial PR removes the workaround that was in place and related to this Vert.x Web issue (https://github.com/vert-x3/vertx-web/issues/1295) which is now fixed.
It also bumps the Vert.x release from snapshot to final 3.8.0 release