### PR TITLE
Test for consumer name prefix (bridge ID)

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -161,15 +161,17 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
 
         this.isReady = false;
 
-        //Consumers cleanup
-        this.httpBridgeContext.getHttpSinkEndpoints().forEach((consumerId, httpEndpoint) -> {
-            if (httpEndpoint != null) {
-                httpEndpoint.close();
-            }
-        });
+        // Consumers cleanup
+        Map<String, SinkBridgeEndpoint> consumers = this.httpBridgeContext.getHttpSinkEndpoints();
+
+        for (Map.Entry<String, SinkBridgeEndpoint> consumer: consumers.entrySet()) {
+            if (consumer.getValue() != null)
+                consumer.getValue().close();
+        }
+
         this.httpBridgeContext.getHttpSinkEndpoints().clear();
 
-        //producer cleanup
+        // producer cleanup
         // for each connection, we have to close the connection itself but before that
         // all the sink/source endpoints (so the related links inside each of them)
         this.httpBridgeContext.getHttpSourceEndpoints().forEach((connection, endpoint) -> {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -163,13 +163,11 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
 
         // Consumers cleanup
         this.httpBridgeContext.closeAllSinkBridgeEndpoints();
-        this.httpBridgeContext.getHttpSinkEndpoints().clear();
 
         // producer cleanup
         // for each connection, we have to close the connection itself but before that
         // all the sink/source endpoints (so the related links inside each of them)
         this.httpBridgeContext.closeAllSourceBridgeEndpoints();
-        this.httpBridgeContext.getHttpSourceEndpoints().clear();
 
         if (this.httpServer != null) {
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -162,24 +162,13 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         this.isReady = false;
 
         // Consumers cleanup
-        Map<String, SinkBridgeEndpoint> consumers = this.httpBridgeContext.getHttpSinkEndpoints();
-
-        for (Map.Entry<String, SinkBridgeEndpoint> consumer: consumers.entrySet()) {
-            if (consumer.getValue() != null)
-                consumer.getValue().close();
-        }
-
+        this.httpBridgeContext.closeAllSinkBridgeEndpoints();
         this.httpBridgeContext.getHttpSinkEndpoints().clear();
 
         // producer cleanup
         // for each connection, we have to close the connection itself but before that
         // all the sink/source endpoints (so the related links inside each of them)
-        this.httpBridgeContext.getHttpSourceEndpoints().forEach((connection, endpoint) -> {
-
-            if (endpoint != null) {
-                endpoint.close();
-            }
-        });
+        this.httpBridgeContext.closeAllSourceBridgeEndpoints();
         this.httpBridgeContext.getHttpSourceEndpoints().clear();
 
         if (this.httpServer != null) {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
@@ -62,6 +62,7 @@ public class HttpBridgeContext {
             if (sink.getValue() != null)
                 sink.getValue().close();
         }
+        getHttpSinkEndpoints().clear();
     }
 
     public void closeAllSourceBridgeEndpoints() {
@@ -69,5 +70,6 @@ public class HttpBridgeContext {
             if (source.getValue() != null)
                 source.getValue().close();
         }
+        getHttpSourceEndpoints().clear();
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
@@ -56,4 +56,18 @@ public class HttpBridgeContext {
     public HttpOpenApiOperations getOpenApiOperation() {
         return this.openApiOperation;
     }
+
+    public void closeAllSinkBridgeEndpoints() {
+        for (Map.Entry<String, SinkBridgeEndpoint> sink: getHttpSinkEndpoints().entrySet()) {
+            if (sink.getValue() != null)
+                sink.getValue().close();
+        }
+    }
+
+    public void closeAllSourceBridgeEndpoints() {
+        for (Map.Entry<HttpConnection, SourceBridgeEndpoint> source: getHttpSourceEndpoints().entrySet()) {
+            if (source.getValue() != null)
+                source.getValue().close();
+        }
+    }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTest.java
@@ -68,14 +68,13 @@ class HttpBridgeTest extends KafkaClusterTestBase {
     private static Map<String, Object> config = new HashMap<>();
 
     private static long timeout = 5L;
-    private static String bridgeID = "franta";
 
     static {
         config.put(AmqpConfig.AMQP_ENABLED, true);
         config.put(KafkaConfig.KAFKA_CONFIG_PREFIX + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         config.put(KafkaConsumerConfig.KAFKA_CONSUMER_CONFIG_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         config.put(HttpConfig.HTTP_CONSUMER_TIMEOUT, timeout);
-        config.put(BridgeConfig.BRIDGE_ID, bridgeID);
+        config.put(BridgeConfig.BRIDGE_ID, "GoldenGateBridge");
     }
 
     private static final String BRIDGE_HOST = "127.0.0.1";
@@ -3648,9 +3647,6 @@ class HttpBridgeTest extends KafkaClusterTestBase {
         String groupId = "my-group";
 
         JsonObject json = new JsonObject();
-        json.put("auto.offset.reset", "earliest");
-        json.put("enable.auto.commit", "true");
-        json.put("fetch.min.bytes", "100");
 
         postRequest("/consumers/" + groupId)
                 .putHeader("Content-length", String.valueOf(json.toBuffer().length()))
@@ -3663,7 +3659,7 @@ class HttpBridgeTest extends KafkaClusterTestBase {
                         assertEquals(HttpResponseStatus.OK.code(), response.statusCode());
                         JsonObject bridgeResponse = response.body();
                         String consumerInstanceId = bridgeResponse.getString("instance_id");
-                        assertTrue(consumerInstanceId.startsWith(bridgeID));
+                        assertTrue(consumerInstanceId.startsWith(config.get(BridgeConfig.BRIDGE_ID).toString()));
                     });
                     context.completeNow();
                 });

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTest.java
@@ -68,12 +68,14 @@ class HttpBridgeTest extends KafkaClusterTestBase {
     private static Map<String, Object> config = new HashMap<>();
 
     private static long timeout = 5L;
+    private static String bridgeID = "franta";
 
     static {
         config.put(AmqpConfig.AMQP_ENABLED, true);
         config.put(KafkaConfig.KAFKA_CONFIG_PREFIX + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         config.put(KafkaConsumerConfig.KAFKA_CONSUMER_CONFIG_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         config.put(HttpConfig.HTTP_CONSUMER_TIMEOUT, timeout);
+        config.put(BridgeConfig.BRIDGE_ID, bridgeID);
     }
 
     private static final String BRIDGE_HOST = "127.0.0.1";
@@ -3638,6 +3640,32 @@ class HttpBridgeTest extends KafkaClusterTestBase {
                         });
                     });
                     create.complete(true);
+                });
+    }
+
+    @Test
+    void createConsumerWithGeneratedName(VertxTestContext context) {
+        String groupId = "my-group";
+
+        JsonObject json = new JsonObject();
+        json.put("auto.offset.reset", "earliest");
+        json.put("enable.auto.commit", "true");
+        json.put("fetch.min.bytes", "100");
+
+        postRequest("/consumers/" + groupId)
+                .putHeader("Content-length", String.valueOf(json.toBuffer().length()))
+                .putHeader("Content-type", BridgeContentType.KAFKA_JSON)
+                .as(BodyCodec.jsonObject())
+                .sendJsonObject(json, ar -> {
+                    context.verify(() -> {
+                        assertTrue(ar.succeeded());
+                        HttpResponse<JsonObject> response = ar.result();
+                        assertEquals(HttpResponseStatus.OK.code(), response.statusCode());
+                        JsonObject bridgeResponse = response.body();
+                        String consumerInstanceId = bridgeResponse.getString("instance_id");
+                        assertTrue(consumerInstanceId.startsWith(bridgeID));
+                    });
+                    context.completeNow();
                 });
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTest.java
@@ -74,7 +74,7 @@ class HttpBridgeTest extends KafkaClusterTestBase {
         config.put(KafkaConfig.KAFKA_CONFIG_PREFIX + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         config.put(KafkaConsumerConfig.KAFKA_CONSUMER_CONFIG_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         config.put(HttpConfig.HTTP_CONSUMER_TIMEOUT, timeout);
-        config.put(BridgeConfig.BRIDGE_ID, "GoldenGateBridge");
+        config.put(BridgeConfig.BRIDGE_ID, "my-bridge");
     }
 
     private static final String BRIDGE_HOST = "127.0.0.1";


### PR DESCRIPTION
I also changed the cleaning of the consumers. It does not throw concurrent modification exception now.