### PR TITLE
Add a way how to list subscribed topics

### DIFF
--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -2,6 +2,17 @@
 [[_definitions]]
 == Definitions
 
+[[_assignedtopicpartitions]]
+=== AssignedTopicPartitions
+
+[options="header", cols=".^3,.^4"]
+|===
+|Name|Schema
+|**topic** +
+__optional__|< integer (int32) > array
+|===
+
+
 [[_consumer]]
 === Consumer
 
@@ -187,26 +198,16 @@ __optional__|< <<_producerrecordtopartition,ProducerRecordToPartition>> > array
 |===
 
 
-[[_subscribedtopics]]
-=== SubscribedTopics
+[[_subscribedtopiclist]]
+=== SubscribedTopicList
 
 [options="header", cols=".^3,.^4"]
 |===
 |Name|Schema
 |**partitions** +
-__optional__|< <<_subscribedtopics_partitions,partitions>> > array
+__optional__|< <<_assignedtopicpartitions,AssignedTopicPartitions>> > array
 |**topics** +
-__optional__|< string > array
-|===
-
-[[_subscribedtopics_partitions]]
-**partitions**
-
-[options="header", cols=".^3,.^4"]
-|===
-|Name|Schema
-|**my-topic1** +
-__optional__|< string > array
+__optional__|<<_topics,Topics>>
 |===
 
 

--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -4,13 +4,7 @@
 
 [[_assignedtopicpartitions]]
 === AssignedTopicPartitions
-
-[options="header", cols=".^3,.^4"]
-|===
-|Name|Schema
-|**topic** +
-__optional__|< integer (int32) > array
-|===
+__Type__ : < string, < integer (int32) > array > map
 
 
 [[_consumer]]

--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -187,6 +187,29 @@ __optional__|< <<_producerrecordtopartition,ProducerRecordToPartition>> > array
 |===
 
 
+[[_subscribedtopics]]
+=== SubscribedTopics
+
+[options="header", cols=".^3,.^4"]
+|===
+|Name|Schema
+|**partitions** +
+__optional__|< <<_subscribedtopics_partitions,partitions>> > array
+|**topics** +
+__optional__|< string > array
+|===
+
+[[_subscribedtopics_partitions]]
+**partitions**
+
+[options="header", cols=".^3,.^4"]
+|===
+|Name|Schema
+|**my-topic1** +
+__optional__|< string > array
+|===
+
+
 [[_topics]]
 === Topics
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -774,7 +774,7 @@ __required__|List of topics to which the consumer will subscribe.|<<_topics,Topi
 === GET /consumers/{groupid}/instances/{name}/subscription
 
 ==== Description
-Retrieves a list of the topics to which is the consumer subscribed.
+Retrieves a list of the topics to which the consumer is subscribed.
 
 
 ==== Parameters

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -770,6 +770,78 @@ __required__|List of topics to which the consumer will subscribe.|<<_topics,Topi
 ----
 
 
+[[_listsubscriptions]]
+=== GET /consumers/{groupid}/instances/{name}/subscription
+
+==== Description
+Retrieves a list of the topics to which is the consumer subscribed.
+
+
+==== Parameters
+
+[options="header", cols=".^2,.^3,.^9,.^4"]
+|===
+|Type|Name|Description|Schema
+|**Path**|**groupid** +
+__required__|ID of the consumer group to which the subscribed consumer belongs.|string
+|**Path**|**name** +
+__required__|Name of the consumer that you want to unsubscribe from topics.|string
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2,.^14,.^4"]
+|===
+|HTTP Code|Description|Schema
+|**200**|List of subscribed topics and partitions.|<<_subscribedtopics,SubscribedTopics>>
+|**404**|The specified consumer instance was not found.|<<_error,Error>>
+|===
+
+
+==== Consumes
+
+* `application/vnd.kafka.v2+json`
+
+
+==== Produces
+
+* `application/vnd.kafka.v2+json`
+
+
+==== Tags
+
+* Consumers
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+{
+  "topics" : [ "my-topic1", "my-topic2" ],
+  "partitions" : [ {
+    "my-topic1" : [ "1", "2", "3" ]
+  }, {
+    "my-topic2" : [ "1" ]
+  } ]
+}
+----
+
+
+===== Response 404
+[source,json]
+----
+{
+  "application/vnd.kafka.v2+json" : {
+    "error_code" : 404,
+    "message" : "The specified consumer instance was not found."
+  }
+}
+----
+
+
 [[_unsubscribe]]
 === DELETE /consumers/{groupid}/instances/{name}/subscription
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -794,14 +794,9 @@ __required__|Name of the consumer that you want to unsubscribe from topics.|stri
 [options="header", cols=".^2,.^14,.^4"]
 |===
 |HTTP Code|Description|Schema
-|**200**|List of subscribed topics and partitions.|<<_subscribedtopics,SubscribedTopics>>
+|**200**|List of subscribed topics and partitions.|<<_subscribedtopiclist,SubscribedTopicList>>
 |**404**|The specified consumer instance was not found.|<<_error,Error>>
 |===
-
-
-==== Consumes
-
-* `application/vnd.kafka.v2+json`
 
 
 ==== Produces
@@ -822,9 +817,9 @@ __required__|Name of the consumer that you want to unsubscribe from topics.|stri
 {
   "topics" : [ "my-topic1", "my-topic2" ],
   "partitions" : [ {
-    "my-topic1" : [ "1", "2", "3" ]
+    "my-topic1" : [ 1, 2, 3 ]
   }, {
-    "my-topic2" : [ "1" ]
+    "my-topic2" : [ 1 ]
   } ]
 }
 ----

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -81,8 +81,6 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     private Handler<AsyncResult<Void>> subscribeHandler;
     // handler called after an unsubscription request
     private Handler<AsyncResult<Void>> unsubscribeHandler;
-    // handler called after an get subscriptions request
-    private Handler<AsyncResult<Set<TopicPartition>>> listSubscriptionsHandler;
     // handler called after a request for a specific partition
     private Handler<AsyncResult<Optional<PartitionInfo>>> partitionHandler;
     // handler called after a topic partition assign request
@@ -199,9 +197,9 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     /**
      * Returns all the topics which the consumer currently subscribes
      */
-    protected void listSubscriptions() {
+    protected void listSubscriptions(Handler<AsyncResult<Set<TopicPartition>>> handler) {
         log.info("Listing subscribed topics {}", this.topicSubscriptions);
-        this.consumer.assignment(this::listSubscriptionsHandler);
+        this.consumer.assignment(handler);
     }
 
     /**
@@ -246,19 +244,6 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.handleUnsubscribe(unsubscribeResult);
 
         if (unsubscribeResult.failed()) {
-            return;
-        }
-    }
-
-    /**
-     * Handler of the get subscriptions request
-     *
-     * @param listSubscriptionsResult result of get subscriptions request
-     */
-    private void listSubscriptionsHandler(AsyncResult<Set<TopicPartition>> listSubscriptionsResult) {
-        this.handleListSubscriptions(listSubscriptionsResult);
-
-        if (listSubscriptionsResult.failed()) {
             return;
         }
     }
@@ -597,15 +582,6 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     }
 
     /**
-     * Set the handler called when an get subscription request is executed
-     *
-     * @param handler   the handler
-     */
-    protected void setListSubscriptionsHandler(Handler<AsyncResult<Set<TopicPartition>>> handler) {
-        this.listSubscriptionsHandler = handler;
-    }
-
-    /**
      * Set the handler called after a request for a specific partition is executed
      *
      * @param handler   the handler providing the info about the requested specific partition
@@ -671,12 +647,6 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     private void handleUnsubscribe(AsyncResult<Void> unsubscribeResult) {
         if (this.unsubscribeHandler != null) {
             this.unsubscribeHandler.handle(unsubscribeResult);
-        }
-    }
-
-    private void handleListSubscriptions(AsyncResult<Set<TopicPartition>> listSubscriptionsResult) {
-        if (this.listSubscriptionsHandler != null) {
-            this.listSubscriptionsHandler.handle(listSubscriptionsResult);
         }
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -81,6 +81,8 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     private Handler<AsyncResult<Void>> subscribeHandler;
     // handler called after an unsubscription request
     private Handler<AsyncResult<Void>> unsubscribeHandler;
+    // handler called after an get subscriptions request
+    private Handler<AsyncResult<Set<TopicPartition>>> listSubscriptionsHandler;
     // handler called after a request for a specific partition
     private Handler<AsyncResult<Optional<PartitionInfo>>> partitionHandler;
     // handler called after a topic partition assign request
@@ -195,6 +197,14 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     }
 
     /**
+     * Returns all the topics which the consumer currently subscribes
+     */
+    protected void listSubscriptions() {
+        log.info("Listing subscribed topics {}", this.topicSubscriptions);
+        this.consumer.assignment(this::listSubscriptionsHandler);
+    }
+
+    /**
      * Subscribe to topics via the provided pattern represented by a Java regex
      *
      * @param pattern Java regex for topics subscription
@@ -236,6 +246,19 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.handleUnsubscribe(unsubscribeResult);
 
         if (unsubscribeResult.failed()) {
+            return;
+        }
+    }
+
+    /**
+     * Handler of the get subscriptions request
+     *
+     * @param listSubscriptionsResult result of get subscriptions request
+     */
+    private void listSubscriptionsHandler(AsyncResult<Set<TopicPartition>> listSubscriptionsResult) {
+        this.handleListSubscriptions(listSubscriptionsResult);
+
+        if (listSubscriptionsResult.failed()) {
             return;
         }
     }
@@ -573,6 +596,14 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.unsubscribeHandler = handler;
     }
 
+    /**
+     * Set the handler called when an get subscription request is executed
+     *
+     * @param handler   the handler
+     */
+    protected void setListSubscriptionsHandler(Handler<AsyncResult<Set<TopicPartition>>> handler) {
+        this.listSubscriptionsHandler = handler;
+    }
 
     /**
      * Set the handler called after a request for a specific partition is executed
@@ -640,6 +671,12 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     private void handleUnsubscribe(AsyncResult<Void> unsubscribeResult) {
         if (this.unsubscribeHandler != null) {
             this.unsubscribeHandler.handle(unsubscribeResult);
+        }
+    }
+
+    private void handleListSubscriptions(AsyncResult<Set<TopicPartition>> listSubscriptionsResult) {
+        if (this.listSubscriptionsHandler != null) {
+            this.listSubscriptionsHandler.handle(listSubscriptionsResult);
         }
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -128,6 +128,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
                 routerFactory.addHandlerByOperationId(this.DELETE_CONSUMER.getOperationId().toString(), this.DELETE_CONSUMER);
                 routerFactory.addHandlerByOperationId(this.SUBSCRIBE.getOperationId().toString(), this.SUBSCRIBE);
                 routerFactory.addHandlerByOperationId(this.UNSUBSCRIBE.getOperationId().toString(), this.UNSUBSCRIBE);
+                routerFactory.addHandlerByOperationId(this.LIST_SUBSCRIPTIONS.getOperationId().toString(), this.LIST_SUBSCRIPTIONS);
                 routerFactory.addHandlerByOperationId(this.ASSIGN.getOperationId().toString(), this.ASSIGN);
                 routerFactory.addHandlerByOperationId(this.POLL.getOperationId().toString(), this.POLL);
                 routerFactory.addHandlerByOperationId(this.COMMIT.getOperationId().toString(), this.COMMIT);
@@ -260,6 +261,11 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
 
     private void unsubscribe(RoutingContext routingContext) {
         this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.UNSUBSCRIBE);
+        processConsumer(routingContext);
+    }
+
+    private void listSubscriptions(RoutingContext routingContext) {
+        this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.LIST_SUBSCRIPTIONS);
         processConsumer(routingContext);
     }
 
@@ -503,6 +509,14 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         @Override
         public void process(RoutingContext routingContext) {
             unsubscribe(routingContext);
+        }
+    };
+
+    HttpOpenApiOperation LIST_SUBSCRIPTIONS = new HttpOpenApiOperation(HttpOpenApiOperations.LIST_SUBSCRIPTIONS) {
+
+        @Override
+        public void process(RoutingContext routingContext) {
+            listSubscriptions(routingContext);
         }
     };
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -16,6 +16,7 @@ public enum HttpOpenApiOperations {
     DELETE_CONSUMER("deleteConsumer"),
     SUBSCRIBE("subscribe"),
     UNSUBSCRIBE("unsubscribe"),
+    LIST_SUBSCRIPTIONS("listSubscriptions"),
     ASSIGN("assign"),
     POLL("poll"),
     COMMIT("commit"),

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -346,19 +346,19 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
     }
 
     public void doListSubscriptions(RoutingContext routingContext) {
-        this.listSubscriptions(listSubscriptions -> {
+        this.listSubscriptions(listSubscriptionsResult -> {
 
-            if (listSubscriptions.succeeded()) {
+            if (listSubscriptionsResult.succeeded()) {
                 JsonObject root = new JsonObject();
                 JsonArray topicsArray = new JsonArray();
                 JsonArray partitionsArray = new JsonArray();
 
                 HashMap<String, JsonArray> partitions = new HashMap<>();
-                for (TopicPartition topicPartition: listSubscriptions.result()) {
+                for (TopicPartition topicPartition: listSubscriptionsResult.result()) {
                     if (!topicsArray.contains(topicPartition.getTopic())) {
                         topicsArray.add(topicPartition.getTopic());
                     }
-                    if (partitions.get(topicPartition.getTopic()) == null) {
+                    if (!partitions.containsKey(topicPartition.getTopic())) {
                         partitions.put(topicPartition.getTopic(), new JsonArray());
                     }
                     partitions.put(topicPartition.getTopic(), partitions.get(topicPartition.getTopic()).add(topicPartition.getPartition()));
@@ -375,7 +375,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
             } else {
                 HttpBridgeError error = new HttpBridgeError(
                         HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        listSubscriptions.cause().getMessage()
+                        listSubscriptionsResult.cause().getMessage()
                 );
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                         BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -346,7 +346,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
     }
 
     public void doListSubscriptions(RoutingContext routingContext) {
-        this.setListSubscriptionsHandler(listSubscriptions -> {
+        this.listSubscriptions(listSubscriptions -> {
 
             if (listSubscriptions.succeeded()) {
                 JsonObject root = new JsonObject();
@@ -381,7 +381,6 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
                         BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
             }
         });
-        this.listSubscriptions();
     }
 
     public void doUnsubscribe(RoutingContext routingContext) {

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -235,6 +235,43 @@
             ]
         },
         "/consumers/{groupid}/instances/{name}/subscription": {
+            "get": {
+                "tags": [
+                    "Consumers"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of subscribed topics and partitions.",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubscribedTopics"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The specified consumer instance was not found.",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "response": {
+                                        "value": {
+                                            "error_code": 404,
+                                            "message": "The specified consumer instance was not found."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "listSubscriptions",
+                "description": "Retrieves a list of the topics to which is the consumer subscribed."
+            },
             "post": {
                 "tags": [
                     "Consumers"
@@ -1471,6 +1508,53 @@
                     "topics": [
                         "topic1",
                         "topic2"
+                    ]
+                }
+            },
+            "SubscribedTopics": {
+                "title": "Root Type for SubscribedTopics",
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "topics": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "partitions": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "my-topic1": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "example": {
+                    "topics": [
+                        "my-topic1",
+                        "my-topic2"
+                    ],
+                    "partitions": [
+                        {
+                            "my-topic1": [
+                                "1",
+                                "2",
+                                "3"
+                            ]
+                        },
+                        {
+                            "my-topic2": [
+                                "1"
+                            ]
+                        }
                     ]
                 }
             }

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1514,13 +1514,11 @@
             "AssignedTopicPartitions": {
                 "title": "AssignedTopicPartitions",
                 "type": "object",
-                "properties": {
-                    "topic": {
-                        "type": "array",
-                        "items": {
-                            "format": "int32",
-                            "type": "integer"
-                        }
+                "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                        "format": "int32",
+                        "type": "integer"
                     }
                 },
                 "example": {

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -245,7 +245,7 @@
                         "content": {
                             "application/vnd.kafka.v2+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/SubscribedTopics"
+                                    "$ref": "#/components/schemas/SubscribedTopicList"
                                 }
                             }
                         }
@@ -1511,29 +1511,37 @@
                     ]
                 }
             },
-            "SubscribedTopics": {
-                "title": "Root Type for SubscribedTopics",
-                "description": "",
+            "AssignedTopicPartitions": {
+                "title": "AssignedTopicPartitions",
+                "type": "object",
+                "properties": {
+                    "topic": {
+                        "type": "array",
+                        "items": {
+                            "format": "int32",
+                            "type": "integer"
+                        }
+                    }
+                },
+                "example": {
+                    "my-topic1": [
+                        1,
+                        2,
+                        3
+                    ]
+                }
+            },
+            "SubscribedTopicList": {
+                "title": "SubscribedTopicList",
                 "type": "object",
                 "properties": {
                     "topics": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/Topics"
                     },
                     "partitions": {
                         "type": "array",
                         "items": {
-                            "type": "object",
-                            "properties": {
-                                "my-topic1": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
+                            "$ref": "#/components/schemas/AssignedTopicPartitions"
                         }
                     }
                 },
@@ -1545,14 +1553,14 @@
                     "partitions": [
                         {
                             "my-topic1": [
-                                "1",
-                                "2",
-                                "3"
+                                1,
+                                2,
+                                3
                             ]
                         },
                         {
                             "my-topic2": [
-                                "1"
+                                1
                             ]
                         }
                     ]

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -270,7 +270,7 @@
                     }
                 },
                 "operationId": "listSubscriptions",
-                "description": "Retrieves a list of the topics to which is the consumer subscribed."
+                "description": "Retrieves a list of the topics to which the consumer is subscribed."
             },
             "post": {
                 "tags": [

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -219,6 +219,39 @@
       ]
     },
     "/consumers/{groupid}/instances/{name}/subscription": {
+      "get": {
+        "consumes": [
+          "application/vnd.kafka.v2+json"
+        ],
+        "produces": [
+          "application/vnd.kafka.v2+json"
+        ],
+        "tags": [
+          "Consumers"
+        ],
+        "responses": {
+          "200": {
+            "description": "List of subscribed topics and partitions.",
+            "schema": {
+              "$ref": "#/definitions/SubscribedTopics"
+            }
+          },
+          "404": {
+            "description": "The specified consumer instance was not found.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/vnd.kafka.v2+json": {
+                "error_code": 404,
+                "message": "The specified consumer instance was not found."
+              }
+            }
+          }
+        },
+        "operationId": "listSubscriptions",
+        "description": "Retrieves a list of the topics to which is the consumer subscribed."
+      },
       "post": {
         "tags": [
           "Consumers"
@@ -1285,6 +1318,53 @@
         "topics": [
           "topic1",
           "topic2"
+        ]
+      }
+    },
+    "SubscribedTopics": {
+      "title": "Root Type for SubscribedTopics",
+      "description": "",
+      "type": "object",
+      "properties": {
+        "topics": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "partitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "my-topic1": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "example": {
+        "topics": [
+          "my-topic1",
+          "my-topic2"
+        ],
+        "partitions": [
+          {
+            "my-topic1": [
+              "1",
+              "2",
+              "3"
+            ]
+          },
+          {
+            "my-topic2": [
+              "1"
+            ]
+          }
         ]
       }
     }

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -220,9 +220,6 @@
     },
     "/consumers/{groupid}/instances/{name}/subscription": {
       "get": {
-        "consumes": [
-          "application/vnd.kafka.v2+json"
-        ],
         "produces": [
           "application/vnd.kafka.v2+json"
         ],
@@ -233,7 +230,7 @@
           "200": {
             "description": "List of subscribed topics and partitions.",
             "schema": {
-              "$ref": "#/definitions/SubscribedTopics"
+              "$ref": "#/definitions/SubscribedTopicList"
             }
           },
           "404": {
@@ -1321,29 +1318,37 @@
         ]
       }
     },
-    "SubscribedTopics": {
-      "title": "Root Type for SubscribedTopics",
-      "description": "",
+    "AssignedTopicPartitions": {
+      "title": "AssignedTopicPartitions",
+      "type": "object",
+      "properties": {
+        "topic": {
+          "type": "array",
+          "items": {
+            "format": "int32",
+            "type": "integer"
+          }
+        }
+      },
+      "example": {
+        "my-topic1": [
+          1,
+          2,
+          3
+        ]
+      }
+    },
+    "SubscribedTopicList": {
+      "title": "SubscribedTopicList",
       "type": "object",
       "properties": {
         "topics": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/Topics"
         },
         "partitions": {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "my-topic1": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
+            "$ref": "#/definitions/AssignedTopicPartitions"
           }
         }
       },
@@ -1355,14 +1360,14 @@
         "partitions": [
           {
             "my-topic1": [
-              "1",
-              "2",
-              "3"
+              1,
+              2,
+              3
             ]
           },
           {
             "my-topic2": [
-              "1"
+              1
             ]
           }
         ]

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -247,7 +247,7 @@
           }
         },
         "operationId": "listSubscriptions",
-        "description": "Retrieves a list of the topics to which is the consumer subscribed."
+        "description": "Retrieves a list of the topics to which the consumer is subscribed."
       },
       "post": {
         "tags": [

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1321,13 +1321,11 @@
     "AssignedTopicPartitions": {
       "title": "AssignedTopicPartitions",
       "type": "object",
-      "properties": {
-        "topic": {
-          "type": "array",
-          "items": {
-            "format": "int32",
-            "type": "integer"
-          }
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "format": "int32",
+          "type": "integer"
         }
       },
       "example": {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionTest.java
@@ -186,7 +186,7 @@ public class ConsumerSubscriptionTest extends HttpBridgeTestBase {
 
         CompletableFuture<Boolean> consume = new CompletableFuture<>();
 
-        // hack to subscribe immediately
+        // poll to subscribe
         consumerService()
                 .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonObject())

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -105,7 +105,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertTrue(paths.containsKey("/openapi"));
                         assertEquals(HttpOpenApiOperations.OPENAPI.toString(), bridgeResponse.getJsonObject("paths").getJsonObject("/openapi").getJsonObject("get").getString("operationId"));
                         assertFalse(paths.containsKey("/karel"));
-                        assertEquals(16, bridgeResponse.getJsonObject("definitions").getMap().size());
+                        assertEquals(17, bridgeResponse.getJsonObject("definitions").getMap().size());
                         assertEquals(4, bridgeResponse.getJsonArray("tags").size());
                     });
                     context.completeNow();

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -73,8 +73,8 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         JsonObject bridgeResponse = response.body();
 
                         Map<String, Object> paths = bridgeResponse.getJsonObject("paths").getMap();
-                        // subscribe and unsubscribe are using the same endpoint but different methods
-                        int pathsSize = HttpOpenApiOperations.values().length - 1;
+                        // subscribe, list subscribtions and unsubscribe are using the same endpoint but different methods
+                        int pathsSize = HttpOpenApiOperations.values().length - 2;
                         assertEquals(pathsSize, paths.size());
                         assertTrue(paths.containsKey("/consumers/{groupid}"));
                         assertEquals(HttpOpenApiOperations.CREATE_CONSUMER.toString(), bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}").getJsonObject("post").getString("operationId"));
@@ -87,6 +87,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertTrue(paths.containsKey("/consumers/{groupid}/instances/{name}/subscription"));
                         assertEquals(HttpOpenApiOperations.SUBSCRIBE.toString(), bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/subscription").getJsonObject("post").getString("operationId"));
                         assertEquals(HttpOpenApiOperations.UNSUBSCRIBE.toString(), bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/subscription").getJsonObject("delete").getString("operationId"));
+                        assertEquals(HttpOpenApiOperations.LIST_SUBSCRIPTIONS.toString(), bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/subscription").getJsonObject("get").getString("operationId"));
                         assertTrue(paths.containsKey("/consumers/{groupid}/instances/{name}/assignments"));
                         assertEquals(HttpOpenApiOperations.ASSIGN.toString(), bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/assignments").getJsonObject("post").getString("operationId"));
                         assertTrue(paths.containsKey("/consumers/{groupid}/instances/{name}/records"));

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -105,7 +105,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertTrue(paths.containsKey("/openapi"));
                         assertEquals(HttpOpenApiOperations.OPENAPI.toString(), bridgeResponse.getJsonObject("paths").getJsonObject("/openapi").getJsonObject("get").getString("operationId"));
                         assertFalse(paths.containsKey("/karel"));
-                        assertEquals(17, bridgeResponse.getJsonObject("definitions").getMap().size());
+                        assertEquals(18, bridgeResponse.getJsonObject("definitions").getMap().size());
                         assertEquals(4, bridgeResponse.getJsonArray("tags").size());
                     });
                     context.completeNow();

--- a/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
@@ -71,6 +71,11 @@ public class ConsumerService extends BaseService {
                 .putHeader(CONTENT_TYPE.toString(), BridgeContentType.KAFKA_JSON);
     }
 
+    public HttpRequest<Buffer> listSubscriptionsConsumerRequest(String groupId, String name) {
+        return getRequest(Urls.consumerInstanceSubscription(groupId, name))
+                .putHeader(ACCEPT.toString(), BridgeContentType.KAFKA_JSON);
+    }
+
     public HttpRequest<JsonObject> offsetsRequest(String groupId, String name, JsonObject json) {
         return postRequest(Urls.consumerInstanceOffsets(groupId, name))
                 .putHeader(CONTENT_LENGTH.toString(), String.valueOf(json.toBuffer().length()))


### PR DESCRIPTION
Fixes #298 

Created a topic with 5 partitions, subscribed a consumer via the bridge, then added a new consumer via console.
Before
```
{
    "topics": [
        "test"
    ],
    "partitions": [
        {
            "test": [
                1,
                0,
                3,
                2,
                4
            ]
        }
    ]
}
```

After
```
{
    "topics": [
        "test"
    ],
    "partitions": [
        {
            "test": [
                3,
                4
            ]
        }
    ]
}
```