### PR TITLE
Fixed log error message

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -102,7 +102,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
                 } else {
                     String msg = done.cause().getMessage();
                     int code = getCodeFromMsg(msg);
-                    log.error("Failed to deliver record " + finalRecords.get(i) + " due to {}", done.cause());
+                    log.error("Failed to deliver record {}", finalRecords.get(i), done.cause());
                     results.add(new HttpBridgeResult<>(new HttpBridgeError(code, msg)));
                 }
             }


### PR DESCRIPTION
This trivial PR just fixes the following wrong error logging

```
2019-09-02 12:57:15,438 [        vert.x-worker-thread-3] HttpSourceBridgeEndpoint       ERROR Failed to deliver record KafkaProducerRecord{topic=test,partition=121,timestamp=null,key=null,value=[B@2b5cfa6b,headers=[]} due to {}
org.apache.kafka.common.KafkaException: Invalid partition given with record: 121 is not in the range [0...1).
        at org.apache.kafka.clients.producer.KafkaProducer.waitOnMetadata(KafkaProducer.java:1000)
        at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:861)
        at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:841)
        at io.vertx.kafka.client.producer.impl.KafkaWriteStreamImpl.lambda$send$4(KafkaWriteStreamImpl.java:93)
        at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$2(ContextImpl.java:316)
        at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:748)
```

where the `{}` is used as placeholder for the exception cause.