### PR TITLE
Add signoff on documentation push

### DIFF
--- a/.travis/docu-push-to-website.sh
+++ b/.travis/docu-push-to-website.sh
@@ -24,7 +24,7 @@ git config user.name "Travis CI"
 git config user.email "ci@travis.tld"
 
 git add -A
-git commit -m "Update Kafka Bridge documentation (Travis CI build ${TRAVIS_BUILD_NUMBER})" --allow-empty
+git commit -s -m "Update Kafka Bridge documentation (Travis CI build ${TRAVIS_BUILD_NUMBER})" --allow-empty
 git push origin master
 
 popd


### PR DESCRIPTION
PR #323 add signoff just to the doc error message. This PR adds the same on the documentation push command.

Signed-off-by: Paolo Patierno <ppatierno@live.com>