### PR TITLE
Add client side OAUTH support (for Kafka clients only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Changed data types and enforced OpenAPI validation for `consumer.request.timeout.ms`, `enable.auto.commit`and `fetch.min.bytes`parameters on consumer creation. This is a breaking change.
 * Added HTTP GET method on `/consumers/{groupid}/instances/{name}/subscription` endpoint for getting subscribed topics and related assigned partitions.
 * Added automatic deletion of stale consumer after a configurable timeout if the HTTP DELETE is not called and the consumer is not used for long time.
+* Add support for OAuth authentication for connections between the Bridge and Kafka brokers (not HTTP connections)
 * Various bug fixes.
 
 ## 0.13.0

--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -38,12 +38,12 @@ if [ -n "$KAFKA_BRIDGE_SASL_MECHANISM" ]; then
         SECURITY_PROTOCOL="SASL_PLAINTEXT"
     fi
 
-    PASSWORD=$(cat /opt/strimzi/bridge-password/$KAFKA_BRIDGE_SASL_PASSWORD_FILE)
-
     if [ "x$KAFKA_BRIDGE_SASL_MECHANISM" = "xplain" ]; then
+        PASSWORD=$(cat /opt/strimzi/bridge-password/$KAFKA_BRIDGE_SASL_PASSWORD_FILE)
         SASL_MECHANISM="PLAIN"
         JAAS_CONFIG="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"${KAFKA_BRIDGE_SASL_USERNAME}\" password=\"${PASSWORD}\";"
     elif [ "x$KAFKA_BRIDGE_SASL_MECHANISM" = "xscram-sha-512" ]; then
+        PASSWORD=$(cat /opt/strimzi/bridge-password/$KAFKA_BRIDGE_SASL_PASSWORD_FILE)
         SASL_MECHANISM="SCRAM-SHA-512"
         JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_BRIDGE_SASL_USERNAME}\" password=\"${PASSWORD}\";"
     elif [ "x$KAFKA_BRIDGE_SASL_MECHANISM" = "xoauth" ]; then
@@ -59,8 +59,12 @@ if [ -n "$KAFKA_BRIDGE_SASL_MECHANISM" ]; then
             OAUTH_CLIENT_SECRET="oauth.client.secret=\"$KAFKA_BRIDGE_OAUTH_CLIENT_SECRET\""
         fi
 
+        if [ -f "/tmp/strimzi/oauth.truststore.p12" ]; then
+            OAUTH_TRUSTSTORE="oauth.ssl.truststore.location=\"/tmp/strimzi/oauth.truststore.p12\" oauth.ssl.truststore.password=\"${CERTS_STORE_PASSWORD}\" oauth.ssl.truststore.type=\"PKCS12\""
+        fi
+
         SASL_MECHANISM="OAUTHBEARER"
-        JAAS_CONFIG="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${KAFKA_BRIDGE_OAUTH_CONFIG} ${OAUTH_CLIENT_SECRET} ${OAUTH_REFRESH_TOKEN} ${OAUTH_ACCESS_TOKEN};"
+        JAAS_CONFIG="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${KAFKA_BRIDGE_OAUTH_CONFIG} ${OAUTH_CLIENT_SECRET} ${OAUTH_REFRESH_TOKEN} ${OAUTH_ACCESS_TOKEN} ${OAUTH_TRUSTSTORE};"
         OAUTH_CALLBACK_CLASS="io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
     fi
 

--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -47,6 +47,8 @@ if [ -n "$KAFKA_BRIDGE_SASL_MECHANISM" ]; then
         SASL_MECHANISM="SCRAM-SHA-512"
         JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_BRIDGE_SASL_USERNAME}\" password=\"${PASSWORD}\";"
     elif [ "x$KAFKA_BRIDGE_SASL_MECHANISM" = "xoauth" ]; then
+        SASL_MECHANISM="OAUTHBEARER"
+
         if [ ! -z "$KAFKA_BRIDGE_OAUTH_ACCESS_TOKEN" ]; then
             OAUTH_ACCESS_TOKEN="oauth.access.token=\"$KAFKA_BRIDGE_OAUTH_ACCESS_TOKEN\""
         fi
@@ -63,7 +65,6 @@ if [ -n "$KAFKA_BRIDGE_SASL_MECHANISM" ]; then
             OAUTH_TRUSTSTORE="oauth.ssl.truststore.location=\"/tmp/strimzi/oauth.truststore.p12\" oauth.ssl.truststore.password=\"${CERTS_STORE_PASSWORD}\" oauth.ssl.truststore.type=\"PKCS12\""
         fi
 
-        SASL_MECHANISM="OAUTHBEARER"
         JAAS_CONFIG="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${KAFKA_BRIDGE_OAUTH_CONFIG} ${OAUTH_CLIENT_SECRET} ${OAUTH_REFRESH_TOKEN} ${OAUTH_ACCESS_TOKEN} ${OAUTH_TRUSTSTORE};"
         OAUTH_CALLBACK_CLASS="io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
     fi

--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -31,7 +31,7 @@ EOF
     fi
 fi
 
-if [ -n "$KAFKA_BRIDGE_SASL_USERNAME" ] && [ -n "$KAFKA_BRIDGE_SASL_PASSWORD_FILE" ]; then
+if [ -n "$KAFKA_BRIDGE_SASL_MECHANISM" ]; then
     if [ "$SECURITY_PROTOCOL" = "SSL" ]; then
         SECURITY_PROTOCOL="SASL_SSL"
     else
@@ -42,15 +42,32 @@ if [ -n "$KAFKA_BRIDGE_SASL_USERNAME" ] && [ -n "$KAFKA_BRIDGE_SASL_PASSWORD_FIL
 
     if [ "x$KAFKA_BRIDGE_SASL_MECHANISM" = "xplain" ]; then
         SASL_MECHANISM="PLAIN"
-        JAAS_SECURITY_MODULE="plain.PlainLoginModule"
+        JAAS_CONFIG="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"${KAFKA_BRIDGE_SASL_USERNAME}\" password=\"${PASSWORD}\";"
     elif [ "x$KAFKA_BRIDGE_SASL_MECHANISM" = "xscram-sha-512" ]; then
         SASL_MECHANISM="SCRAM-SHA-512"
-        JAAS_SECURITY_MODULE="scram.ScramLoginModule"
+        JAAS_CONFIG="org.apache.kafka.common.security.scram.ScramLoginModule required username=\"${KAFKA_BRIDGE_SASL_USERNAME}\" password=\"${PASSWORD}\";"
+    elif [ "x$KAFKA_BRIDGE_SASL_MECHANISM" = "xoauth" ]; then
+        if [ ! -z "$KAFKA_BRIDGE_OAUTH_ACCESS_TOKEN" ]; then
+            OAUTH_ACCESS_TOKEN="oauth.access.token=\"$KAFKA_BRIDGE_OAUTH_ACCESS_TOKEN\""
+        fi
+
+        if [ ! -z "$KAFKA_BRIDGE_OAUTH_REFRESH_TOKEN" ]; then
+            OAUTH_REFRESH_TOKEN="oauth.refresh.token=\"$KAFKA_BRIDGE_OAUTH_REFRESH_TOKEN\""
+        fi
+
+        if [ ! -z "$KAFKA_BRIDGE_OAUTH_CLIENT_SECRET" ]; then
+            OAUTH_CLIENT_SECRET="oauth.client.secret=\"$KAFKA_BRIDGE_OAUTH_CLIENT_SECRET\""
+        fi
+
+        SASL_MECHANISM="OAUTHBEARER"
+        JAAS_CONFIG="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${KAFKA_BRIDGE_OAUTH_CONFIG} ${OAUTH_CLIENT_SECRET} ${OAUTH_REFRESH_TOKEN} ${OAUTH_ACCESS_TOKEN};"
+        OAUTH_CALLBACK_CLASS="io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
     fi
 
     SASL_AUTH_CONFIGURATION=$(cat <<EOF
 kafka.sasl.mechanism=${SASL_MECHANISM}
-kafka.sasl.jaas.config=org.apache.kafka.common.security.${JAAS_SECURITY_MODULE} required username="${KAFKA_BRIDGE_SASL_USERNAME}" password="${PASSWORD}";
+kafka.sasl.jaas.config=${JAAS_CONFIG}
+kafka.sasl.login.callback.handler.class=${OAUTH_CALLBACK_CLASS}
 EOF
 )
 fi

--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -22,7 +22,7 @@ fi
 
 # Generate and print the consumer config file
 echo "Kafka Bridge configuration:"
-${MYPATH}/kafka_bridge_config_generator.sh | tee /tmp/kafka-bridge.properties
+${MYPATH}/kafka_bridge_config_generator.sh | tee /tmp/kafka-bridge.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g'
 echo ""
 
 # Configure logging for Kubernetes deployments

--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -3,22 +3,21 @@ set +x
 
 MYPATH="$(dirname "$0")"
 
-if [ -n "$KAFKA_BRIDGE_TRUSTED_CERTS" ]; then
-    # Generate temporary keystore password
-    export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
+# Generate temporary keystore password
+export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
 
-    mkdir -p /tmp/strimzi
+# Create dir where keystores and truststores will be stored
+mkdir -p /tmp/strimzi
 
-    # Import certificates into keystore and truststore
-    # $1 = trusted certs, $2 = TLS auth cert, $3 = TLS auth key, $4 = truststore path, $5 = keystore path, $6 = certs and key path
-    ${MYPATH}/kafka_bridge_tls_prepare_certificates.sh \
-        "$KAFKA_BRIDGE_TRUSTED_CERTS" \
-        "$KAFKA_BRIDGE_TLS_AUTH_CERT" \
-        "$KAFKA_BRIDGE_TLS_AUTH_KEY" \
-        "/tmp/strimzi/bridge.truststore.p12" \
-        "/tmp/strimzi/bridge.keystore.p12" \
-        "${STRIMZI_HOME}/bridge-certs"
-fi
+# Import certificates into keystore and truststore
+# $1 = trusted certs, $2 = TLS auth cert, $3 = TLS auth key, $4 = truststore path, $5 = keystore path, $6 = certs and key path
+${MYPATH}/kafka_bridge_tls_prepare_certificates.sh \
+    "$KAFKA_BRIDGE_TRUSTED_CERTS" \
+    "$KAFKA_BRIDGE_TLS_AUTH_CERT" \
+    "$KAFKA_BRIDGE_TLS_AUTH_KEY" \
+    "/tmp/strimzi/bridge.truststore.p12" \
+    "/tmp/strimzi/bridge.keystore.p12" \
+    "${STRIMZI_HOME}/bridge-certs"
 
 # Generate and print the consumer config file
 echo "Kafka Bridge configuration:"

--- a/bin/docker/kafka_bridge_tls_prepare_certificates.sh
+++ b/bin/docker/kafka_bridge_tls_prepare_certificates.sh
@@ -54,5 +54,5 @@ if [ -d /opt/strimzi/oauth-certs ]; then
     create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
     INDEX+=1
   done
-  echo "Preparing truststore for OAuth"
+  echo "Preparing truststore for OAuth is complete"
 fi

--- a/bin/docker/kafka_bridge_tls_prepare_certificates.sh
+++ b/bin/docker/kafka_bridge_tls_prepare_certificates.sh
@@ -42,3 +42,17 @@ if [ -n "$tls_auth_cert" ] && [ -n "$tls_auth_key" ]; then
     create_keystore $keystore_path $CERTS_STORE_PASSWORD $certs_key_path/$tls_auth_cert $certs_key_path/$tls_auth_key $tls_auth_cert
     echo "Preparing keystore is complete"
 fi
+
+if [ -d /opt/strimzi/oauth-certs ]; then
+  echo "Preparing truststore for OAuth"
+  # Add each certificate to the trust store
+  STORE=/tmp/strimzi/oauth.truststore.p12
+  declare -i INDEX=0
+  for CRT in /opt/strimzi/oauth-certs/**/*; do
+    ALIAS="oauth-${INDEX}"
+    echo "Adding $CRT to truststore $STORE with alias $ALIAS"
+    create_truststore "$STORE" "$CERTS_STORE_PASSWORD" "$CRT" "$ALIAS"
+    INDEX+=1
+  done
+  echo "Preparing truststore for OAuth"
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
 			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.strimzi.oauth</groupId>
-			<artifactId>strimzi-kafka-oauth-client</artifactId>
+			<groupId>io.strimzi</groupId>
+			<artifactId>kafka-oauth-client</artifactId>
 			<version>${strimzi-oauth-callback.version}</version>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
 		<swagger2markup.version>1.3.3</swagger2markup.version>
 		<jackson-databind.version>2.9.9.3</jackson-databind.version>
+		<strimzi-oauth-callback.version>1.0.0-SNAPSHOT</strimzi-oauth-callback.version>
     </properties>
 
 
@@ -71,6 +72,11 @@
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>${log4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.strimzi.oauth</groupId>
+			<artifactId>strimzi-kafka-oauth-client</artifactId>
+			<version>${strimzi-oauth-callback.version}</version>
 		</dependency>
 
 		<!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
 		<swagger2markup.version>1.3.3</swagger2markup.version>
 		<jackson-databind.version>2.9.9.3</jackson-databind.version>
-		<strimzi-oauth-callback.version>1.0.0-SNAPSHOT</strimzi-oauth-callback.version>
+		<strimzi-oauth-callback.version>0.1.0</strimzi-oauth-callback.version>
     </properties>
 
 
@@ -149,13 +149,6 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
-	<repositories>
-		<repository>
-			<id>oss.sonatype.org-snapshot</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</repository>
-	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>


### PR DESCRIPTION
This PR adds support to the OAuth authentication for the Kafka client when connecting to the Kafka brokers. It:
* Adds the dependency to the client callback library
* Updates the Docker scripts to be able to configure OAuth