### PR TITLE
Use apps/v1 Deployment to make things work in Kubernetes 1.16

### DIFF
--- a/deployment/kafka-bridge-deployment.yml
+++ b/deployment/kafka-bridge-deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: strimzi-kafka-bridge
@@ -6,6 +6,9 @@ metadata:
     app: strimzi
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: strimzi-kafka-bridge
   template:
     metadata:
       labels:


### PR DESCRIPTION
Kubernetes 1.16 drops support for `extensions/v1beta1`. We should update our Deployments to apps/v1 to make sure we are compatible.