### PR TITLE
Override Jackson version in transitive dep to avoid CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,20 @@
 		<junit.platform.version>1.4.0</junit.platform.version>
 		<maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
 		<swagger2markup.version>1.3.3</swagger2markup.version>
+		<jackson-databind.version>2.9.9.3</jackson-databind.version>
     </properties>
+
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<!-- Not a direct dependency, but override transitive dep to avoid CVE-2019-14379-->
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>${jackson-databind.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
The bridge depends on jackson-databind transitively, via vertx. The version depended on has [CVE-2019-14379](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14379). If we're not upgrading vertx for the 0.14 release we need to override the version resolved for the dependency.

Signed-off-by: Tom Bentley <tbentley@redhat.com>