### PR TITLE
Fix SASL bug caused by empty callback configuration

### DIFF
--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -66,13 +66,13 @@ if [ -n "$KAFKA_BRIDGE_SASL_MECHANISM" ]; then
         fi
 
         JAAS_CONFIG="org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required ${KAFKA_BRIDGE_OAUTH_CONFIG} ${OAUTH_CLIENT_SECRET} ${OAUTH_REFRESH_TOKEN} ${OAUTH_ACCESS_TOKEN} ${OAUTH_TRUSTSTORE};"
-        OAUTH_CALLBACK_CLASS="io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
+        OAUTH_CALLBACK_CLASS="kafka.sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler"
     fi
 
     SASL_AUTH_CONFIGURATION=$(cat <<EOF
 kafka.sasl.mechanism=${SASL_MECHANISM}
 kafka.sasl.jaas.config=${JAAS_CONFIG}
-kafka.sasl.login.callback.handler.class=${OAUTH_CALLBACK_CLASS}
+${OAUTH_CALLBACK_CLASS}
 EOF
 )
 fi


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The OAuth implementation seems to have broken the SASL SCRAM and PLAIN authentication in our images. In the SASL configuration, the empty value

```
consumer.sasl.login.callback.handler.class=
```

Is not interpreted as not set / null but as a class name and cause the pod to fail during startup. This PR changes the way this confgiuration options is generated to make sure it is used only with OAUTH.

This should be picked up for the 0.14 release branch.

### Checklist

- [x] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally