### PR TITLE
Bump Jackson Databind dependnecy to 2.9.10 because of CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<junit.platform.version>1.4.0</junit.platform.version>
 		<maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
 		<swagger2markup.version>1.3.3</swagger2markup.version>
-		<jackson-databind.version>2.9.9.3</jackson-databind.version>
+		<jackson-databind.version>2.9.10</jackson-databind.version>
 		<spotbugs.version>3.1.12</spotbugs.version>
 		<strimzi-oauth-callback.version>0.1.0</strimzi-oauth-callback.version>
     </properties>


### PR DESCRIPTION
We need to update Jackson Databind to 2.9.10 because of CVEs. This should be cherry-picked for 0.14.0.