### PR TITLE
Mask passwords in startup scripts

### DIFF
--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -21,7 +21,7 @@ ${MYPATH}/kafka_bridge_tls_prepare_certificates.sh \
 
 # Generate and print the consumer config file
 echo "Kafka Bridge configuration:"
-${MYPATH}/kafka_bridge_config_generator.sh | tee /tmp/kafka-bridge.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g'
+${MYPATH}/kafka_bridge_config_generator.sh | tee /tmp/kafka-bridge.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
 echo ""
 
 # Configure logging for Kubernetes deployments


### PR DESCRIPTION
We should make sure that passwords are not printed in the startup scripts. The JKS store passwords are only temporary passwords for JKS stores stored inside in the container (so who can access the JKS store can anyway get the password from the actual file), but we should still mask it.