### PR TITLE
Reword README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Apache Kafka bridge
 
 This project provides a software component which acts as a bridge between different standard protocols and an [Apache Kafka](http://kafka.apache.org/) cluster.
-The current supported protocols are:
+The available protocols are:
 
 * [AMQP 1.0 (Advanced Message Queuing Protocol)](https://www.amqp.org/)
 * [HTTP 1.1 (Hypertext Transfer Protocol)](https://tools.ietf.org/html/rfc2616)


### PR DESCRIPTION
A concerned was raised by @laidan6000 around the use of the word "support" in the readme, so this PR rewords to avoid implying anything about support. @laidan6000 is this better in your opinion?