### PR TITLE
Add support for tracing

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -1,6 +1,7 @@
 #Bridge related settings
 bridge.id=my-bridge
-bridge.tracing=jaeger
+# uncomment the following line to enable Jaeger tracing
+#bridge.tracing=jaeger
 
 #Apache Kafka common
 kafka.bootstrap.servers=localhost:9092

--- a/config/application.properties
+++ b/config/application.properties
@@ -1,6 +1,6 @@
 #Bridge related settings
 bridge.id=my-bridge
-# uncomment the following line to enable Jaeger tracing
+# uncomment the following line to enable Jaeger tracing, check the documentation how to configure the tracer
 #bridge.tracing=jaeger
 
 #Apache Kafka common

--- a/config/application.properties
+++ b/config/application.properties
@@ -1,5 +1,6 @@
 #Bridge related settings
 bridge.id=my-bridge
+bridge.tracing=jaeger
 
 #Apache Kafka common
 kafka.bootstrap.servers=localhost:9092

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,9 @@
 		<jackson-databind.version>2.9.10</jackson-databind.version>
 		<spotbugs.version>3.1.12</spotbugs.version>
 		<strimzi-oauth-callback.version>0.1.0</strimzi-oauth-callback.version>
+		<jaeger.version>1.0.0</jaeger.version>
+		<opentracing.version>0.33.0</opentracing.version>
+		<opentracing-kafka-client.version>0.1.4</opentracing-kafka-client.version>
     </properties>
 
 
@@ -83,6 +86,26 @@
 			<groupId>io.strimzi</groupId>
 			<artifactId>kafka-oauth-client</artifactId>
 			<version>${strimzi-oauth-callback.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jaegertracing</groupId>
+			<artifactId>jaeger-client</artifactId>
+			<version>${jaeger.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.opentracing</groupId>
+			<artifactId>opentracing-api</artifactId>
+			<version>${opentracing.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.opentracing</groupId>
+			<artifactId>opentracing-util</artifactId>
+			<version>${opentracing.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.opentracing.contrib</groupId>
+			<artifactId>opentracing-kafka-client</artifactId>
+			<version>${opentracing-kafka-client.version}</version>
 		</dependency>
 
 		<!-- Testing -->

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.bridge;
 
+import io.opentracing.contrib.kafka.TracingConsumerInterceptor;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
 import io.strimzi.kafka.bridge.tracker.OffsetTracker;
@@ -151,6 +152,9 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         props.putAll(kafkaConfig.getConfig());
         props.putAll(kafkaConfig.getConsumerConfig().getConfig());
         props.put(ConsumerConfig.GROUP_ID_CONFIG, this.groupId);
+        if (this.bridgeConfig.getTracing() != null && "jaeger".equals(this.bridgeConfig.getTracing())) {
+            props.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, TracingConsumerInterceptor.class.getName());
+        }
 
         if (config != null)
             props.putAll(config);

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -152,7 +152,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         props.putAll(kafkaConfig.getConfig());
         props.putAll(kafkaConfig.getConsumerConfig().getConfig());
         props.put(ConsumerConfig.GROUP_ID_CONFIG, this.groupId);
-        if (this.bridgeConfig.getTracing() != null && "jaeger".equals(this.bridgeConfig.getTracing())) {
+        if (this.bridgeConfig.getTracing() != null) {
             props.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, TracingConsumerInterceptor.class.getName());
         }
 

--- a/src/main/java/io/strimzi/kafka/bridge/SourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SourceBridgeEndpoint.java
@@ -103,7 +103,7 @@ public abstract class SourceBridgeEndpoint<K, V> implements BridgeEndpoint {
         Properties props = new Properties();
         props.putAll(kafkaConfig.getConfig());
         props.putAll(kafkaConfig.getProducerConfig().getConfig());
-        if (this.bridgeConfig.getTracing() != null && "jaeger".equals(this.bridgeConfig.getTracing())) {
+        if (this.bridgeConfig.getTracing() != null) {
             props.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, TracingProducerInterceptor.class.getName());
         }
 

--- a/src/main/java/io/strimzi/kafka/bridge/SourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SourceBridgeEndpoint.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.bridge;
 
+import io.opentracing.contrib.kafka.TracingProducerInterceptor;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
 import io.vertx.core.AsyncResult;
@@ -102,6 +103,9 @@ public abstract class SourceBridgeEndpoint<K, V> implements BridgeEndpoint {
         Properties props = new Properties();
         props.putAll(kafkaConfig.getConfig());
         props.putAll(kafkaConfig.getProducerConfig().getConfig());
+        if (this.bridgeConfig.getTracing() != null && "jaeger".equals(this.bridgeConfig.getTracing())) {
+            props.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, TracingProducerInterceptor.class.getName());
+        }
 
         this.producerUnsettledMode = KafkaProducer.create(this.vertx, props, this.keySerializer, this.valueSerializer);
 

--- a/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
@@ -19,6 +19,7 @@ public class BridgeConfig extends AbstractConfig {
     public static final String BRIDGE_CONFIG_PREFIX = "bridge.";
 
     public static final String BRIDGE_ID = BRIDGE_CONFIG_PREFIX + "id";
+    public static final String TRACING_TYPE = BRIDGE_CONFIG_PREFIX + "tracing";
 
     private KafkaConfig kafkaConfig;
     private AmqpConfig amqpConfig;
@@ -92,6 +93,14 @@ public class BridgeConfig extends AbstractConfig {
             return null;
         } else {
             return config.get(BridgeConfig.BRIDGE_ID).toString();
+        }
+    }
+
+    public String getTracing() {
+        if (config.get(BridgeConfig.TRACING_TYPE) == null) {
+            return null;
+        } else {
+            return config.get(BridgeConfig.TRACING_TYPE).toString();
         }
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -6,6 +6,15 @@
 package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
+import io.opentracing.propagation.TextMapAdapter;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.EmbeddedFormat;
 import io.strimzi.kafka.bridge.Endpoint;
@@ -19,6 +28,7 @@ import io.strimzi.kafka.bridge.http.model.HttpBridgeResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
@@ -30,8 +40,12 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.Map.Entry;
 
 public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
 
@@ -72,14 +86,51 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
                 return;
             }
         }
+
+        Tracer tracer = GlobalTracer.get();
+
+        MultiMap httpHeaders = routingContext.request().headers();
+        Map<String, String> headers = new HashMap<>();
+        for (Entry<String, String> header: httpHeaders.entries()) {
+            headers.put(header.getKey(), header.getValue());
+        }
+
+        String operationName = partition == null ? HttpOpenApiOperations.SEND.toString() : HttpOpenApiOperations.SEND_TO_PARTITION.toString();
+        SpanBuilder spanBuilder;
+        SpanContext parentSpan = tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(headers));
+        if (parentSpan == null) {
+            spanBuilder = tracer.buildSpan(operationName);
+        } else {
+            spanBuilder = tracer.buildSpan(operationName).asChildOf(parentSpan);
+        }
+        Span span = spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER).start();
+        HttpTracingUtils.setCommonTags(span, routingContext);
+
         try {
             records = messageConverter.toKafkaRecords(topic, partition, routingContext.getBody());
+
+            for (KafkaProducerRecord<K, V> record :records)   {
+                tracer.inject(span.context(), Format.Builtin.TEXT_MAP, new TextMap() {
+                    @Override
+                    public void put(String key, String value) {
+                        record.addHeader(key, value);
+                    }
+
+                    @Override
+                    public Iterator<Map.Entry<String, String>> iterator() {
+                        throw new UnsupportedOperationException("TextMapInjectAdapter should only be used with Tracer.inject()");
+                    }
+                });
+            }
         } catch (Exception e) {
             HttpBridgeError error = new HttpBridgeError(
                     HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
                     e.getMessage());
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
                     BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+
+            Tags.HTTP_STATUS.set(span, HttpResponseStatus.UNPROCESSABLE_ENTITY.code());
+            span.finish();
             return;
         }
         List<HttpBridgeResult<?>> results = new ArrayList<>(records.size());
@@ -109,6 +160,9 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
                     results.add(new HttpBridgeResult<>(new HttpBridgeError(code, msg)));
                 }
             }
+            
+            Tags.HTTP_STATUS.set(span, HttpResponseStatus.OK.code());
+            span.finish();
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(),
                     BridgeContentType.KAFKA_JSON, buildOffsets(results).toBuffer());
             

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpTracingUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpTracingUtils.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019, Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.http;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.vertx.ext.web.RoutingContext;
+
+public class HttpTracingUtils {
+
+    public static final String COMPONENT = "strimzi-kafka-bridge";
+    public static final String KAFKA_SERVICE = "kafka";
+
+ 
+    public static void setCommonTags(Span span, RoutingContext routingContext) {
+        Tags.COMPONENT.set(span, HttpTracingUtils.COMPONENT);
+        Tags.PEER_SERVICE.set(span, HttpTracingUtils.KAFKA_SERVICE);
+        Tags.HTTP_METHOD.set(span, routingContext.request().method().name());
+        Tags.HTTP_URL.set(span, routingContext.request().uri());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 #Bridge related settings
 bridge.id=my-bridge
-bridge.tracing=jaeger
+# uncomment the following line to enable Jaeger tracing
+#bridge.tracing=jaeger
 
 #Apache Kafka common
 kafka.bootstrap.servers=localhost:9092

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 #Bridge related settings
 bridge.id=my-bridge
-# uncomment the following line to enable Jaeger tracing
+# uncomment the following line to enable Jaeger tracing, check the documentation how to configure the tracer
 #bridge.tracing=jaeger
 
 #Apache Kafka common

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 #Bridge related settings
 bridge.id=my-bridge
+bridge.tracing=jaeger
 
 #Apache Kafka common
 kafka.bootstrap.servers=localhost:9092


### PR DESCRIPTION
This PR adds support for tracing in the bridge using the "interceptor" approach.
Supported tracing implementation is just Jaeger for now.

As known issue related to the Jaeger UI, in case the bridge gets more messages through a single poll, the "poll" span is not shown for each incoming "From" message span.
I am in touch with Jaeger guys in order to open an issue to fix that.