### PR TITLE
Update hamcrest dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<debezium.version>0.8.3.Final</debezium.version>
 		<maven.checkstyle.version>3.0.0</maven.checkstyle.version>
 		<junit.platform.version>1.4.0</junit.platform.version>
-		<hamcrest.version>1.3</hamcrest.version>
+		<hamcrest.version>2.2</hamcrest.version>
 		<maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
 		<maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
 		<swagger2markup.version>1.3.3</swagger2markup.version>
@@ -161,7 +161,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
+			<artifactId>hamcrest-library</artifactId>
 			<version>${hamcrest.version}</version>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Use version 2.2 instead of very old 1.3