### PR TITLE
Update the OpenTracing Kafka client to 0.1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<strimzi-oauth.version>0.3.0</strimzi-oauth.version>
 		<jaeger.version>1.1.0</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
-		<opentracing-kafka-client.version>0.1.4</opentracing-kafka-client.version>
+		<opentracing-kafka-client.version>0.1.11</opentracing-kafka-client.version>
     </properties>
 
 


### PR DESCRIPTION
The Bridge is currently using the OpenTracing Kafka Client version 0.1.4 which was written for KAfka 2.3.x. We should bump it to version 0.1.11 which is based on Kafka 2.4.0