### PR TITLE
Removing the jackson binding override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,25 +23,12 @@
 		<maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
 		<swagger2markup.version>1.3.7</swagger2markup.version>
 		<jackson-core.version>2.10.2</jackson-core.version>
-		<jackson-databind.version>2.10.2</jackson-databind.version>
 		<spotbugs.version>3.1.12</spotbugs.version>
 		<strimzi-oauth.version>0.3.0</strimzi-oauth.version>
 		<jaeger.version>1.1.0</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.11</opentracing-kafka-client.version>
 	</properties>
-
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<!-- Not a direct dependency, but override transitive dep to avoid CVE-2019-14379-->
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>${jackson-databind.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Currently we are overriding jackson binding (indirect dependency coming from debezium) with 2.10.2 version because of CVE-2019-14379.
The debezium 1.0.0.Final version seems to use jackson binding 2.10.0 which already fixes CVE-2019-14379 so we should not need the override anymore.
See https://github.com/advisories/GHSA-6fpp-rgj9-8rwc