### PR TITLE
JSON payload test

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerTest.java
@@ -644,4 +644,82 @@ public class ProducerTest extends HttpBridgeTestBase {
                     context.completeNow();
                 });
     }
+
+    @Test
+    void jsonPayloadTest(VertxTestContext context) {
+        String kafkaTopic = "breakOpenApiRules";
+        kafkaCluster.createTopic(kafkaTopic, 3, 1);
+
+        String value = "Hello from the other side";
+        String key = "message-key";
+
+        JsonArray records = new JsonArray();
+        JsonObject json = new JsonObject();
+        json.put("value", value);
+        json.put("key", key);
+        json.put("partition", 0);
+        records.add(json);
+
+        JsonObject root = new JsonObject();
+        root.put("records", records);
+
+        producerService()
+            .sendRecordsToPartitionRequest(kafkaTopic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
+            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: body.records[0] - " +
+                "$.records[0].partition: is not defined in the schema and the schema does not allow additional properties"));
+
+        records.remove(json);
+        json.remove("partition");
+        root.remove("records");
+
+        records.add(json);
+        root.put("records", records);
+
+        producerService()
+            .sendRecordsToPartitionRequest(kafkaTopic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
+            .sendJsonObject(root, ar -> {
+                context.verify(() -> {
+                    assertThat(ar.succeeded(), is(true));
+                    HttpResponse<JsonObject> response = ar.result();
+                    assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+
+                    JsonObject bridgeResponse = response.body();
+                    JsonArray offsets = bridgeResponse.getJsonArray("offsets");
+                    assertThat(offsets.size(), is(1));
+
+                    JsonObject metadata = offsets.getJsonObject(0);
+                    assertThat(metadata.getInteger("partition"), notNullValue());
+                    assertThat(metadata.getInteger("offset"), is(1));
+                });
+            });
+
+        records.remove(json);
+        json.remove("value");
+        root.remove("records");
+
+        JsonObject jsonValue = new JsonObject();
+        jsonValue.put("first-object", "hello-there");
+
+        json.put("value", jsonValue);
+        records.add(json);
+        root.put("records", records);
+
+        producerService()
+            .sendRecordsToPartitionRequest(kafkaTopic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
+            .sendJsonObject(root, ar -> {
+                context.verify(() -> {
+                    assertThat(ar.succeeded(), is(true));
+                    HttpResponse<JsonObject> response = ar.result();
+                    assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+
+                    JsonObject bridgeResponse = response.body();
+                    JsonArray offsets = bridgeResponse.getJsonArray("offsets");
+                    assertThat(offsets.size(), is(1));
+
+                    JsonObject metadata = offsets.getJsonObject(0);
+                    assertThat(metadata.getInteger("partition"), notNullValue());
+                    assertThat(metadata.getInteger("offset"), is(2));
+                });
+            });
+    }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerTest.java
@@ -689,7 +689,7 @@ public class ProducerTest extends HttpBridgeTestBase {
                     assertThat(offsets.size(), is(1));
 
                     JsonObject metadata = offsets.getJsonObject(0);
-                    assertThat(metadata.getInteger("partition"), notNullValue());
+                    assertThat(metadata.getInteger("partition"), is(0));
                     assertThat(metadata.getInteger("offset"), is(1));
                 });
             });
@@ -719,7 +719,7 @@ public class ProducerTest extends HttpBridgeTestBase {
                     assertThat(offsets.size(), is(1));
 
                     JsonObject metadata = offsets.getJsonObject(0);
-                    assertThat(metadata.getInteger("partition"), notNullValue());
+                    assertThat(metadata.getInteger("partition"), is(0));
                     assertThat(metadata.getInteger("offset"), is(2));
                 });
             });

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerTest.java
@@ -669,6 +669,7 @@ public class ProducerTest extends HttpBridgeTestBase {
                 "$.records[0].partition: is not defined in the schema and the schema does not allow additional properties"));
 
         records.remove(json);
+        records.clear();
         json.remove("partition");
         root.remove("records");
 
@@ -694,6 +695,7 @@ public class ProducerTest extends HttpBridgeTestBase {
             });
 
         records.remove(json);
+        records.clear();
         json.remove("value");
         root.remove("records");
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lkral@redhat.com>

**Type of change**
- new test

**Description**
This PR will add test for JSON payload:

Send message that will contains: `key, value, partition` to Kafka Bridge endpoint _partition_ -> here should be verification error.
After that try to send string type message that will contains: `key, value` to Kafka Bridge endpoint _topic_ and the same thing but with JSON type message value.
