### PR TITLE
Add CORS to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.16.0
 
+* Add support for CORS
+
 ## 0.15.0
 
 * Added support for Jaeger tracing


### PR DESCRIPTION
The PR #401 added CORS support. But it is missing in the CHANGELOG.md file. This PR adds it there.