### PR TITLE
Bump OAuth and Tracing dependencies before the 0.16.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,10 @@
 		<swagger2markup.version>1.3.7</swagger2markup.version>
 		<jackson-core.version>2.10.2</jackson-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
-		<strimzi-oauth.version>0.3.0</strimzi-oauth.version>
+		<strimzi-oauth.version>0.5.0</strimzi-oauth.version>
 		<jaeger.version>1.1.0</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
-		<opentracing-kafka-client.version>0.1.11</opentracing-kafka-client.version>
+		<opentracing-kafka-client.version>0.1.12</opentracing-kafka-client.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
We should bump some dependencies before the planned 0.16.0 release:
* OAuth library to the new 0.5.0
* OpenTracing Kafka library to 0.1.12