### PR TITLE
Kafka headers support for HTTP

### DIFF
--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -49,6 +49,8 @@ __optional__|The unique name for the consumer instance. The name is unique withi
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
+|**headers** +
+__optional__|<<_kafkaheaderlist,KafkaHeaderList>>
 |**key** +
 __optional__|string
 |**offset** +
@@ -91,6 +93,24 @@ __optional__|integer (int32)
 |**message** +
 __optional__|string
 |===
+
+
+[[_kafkaheader]]
+=== KafkaHeader
+
+[options="header", cols=".^3a,.^4a"]
+|===
+|Name|Schema
+|**key** +
+__required__|string
+|**value** +
+__required__|string
+|===
+
+
+[[_kafkaheaderlist]]
+=== KafkaHeaderList
+__Type__ : < <<_kafkaheader,KafkaHeader>> > array
 
 
 [[_offsetcommitseek]]
@@ -188,6 +208,8 @@ __optional__|< <<_partition,Partition>> > array
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
+|**headers** +
+__optional__|<<_kafkaheaderlist,KafkaHeaderList>>
 |**partition** +
 __optional__|integer (int32)
 |===

--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -98,13 +98,14 @@ __optional__|string
 [[_kafkaheader]]
 === KafkaHeader
 
-[options="header", cols=".^3a,.^4a"]
+[options="header", cols=".^3a,.^11a,.^4a"]
 |===
-|Name|Schema
+|Name|Description|Schema
 |**key** +
-__required__|string
+__required__||string
 |**value** +
-__required__|string
+__required__|The header value in binary format, base64-encoded +
+**Pattern** : `"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==\|[A-Za-z0-9+/]{3}=)?$"`|string (byte)
 |===
 
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
@@ -12,8 +12,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
+import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
 
+import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,6 +28,7 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
         Integer partitionFromBody = null;
         byte[] key = null;
         byte[] value = null;
+        List<KafkaHeader> headers = new ArrayList<>();
 
         JsonObject json = message.toJsonObject();
 
@@ -34,6 +38,15 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
             }
             if (json.containsKey("value")) {
                 value = Json.encodeToBuffer(json.getValue("value")).getBytes();
+            }
+            if (json.containsKey("headers")) {
+                for (Object obj: json.getJsonArray("headers")) {
+                    JsonObject jsonObject = (JsonObject) obj;
+                    headers.add(new KafkaHeaderImpl(
+                        jsonObject.getString("key"),
+                        Buffer.factory.buffer(
+                            DatatypeConverter.parseBase64Binary(jsonObject.getString("value")))));
+                }
             }
             if (json.containsKey("partition")) {
                 partitionFromBody = json.getInteger("partition");
@@ -47,6 +60,7 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
         }
 
         KafkaProducerRecord<byte[], byte[]> record = KafkaProducerRecord.create(kafkaTopic, key, value, partitionFromBody);
+        record.addHeaders(headers);
 
         return record;
     }
@@ -90,6 +104,19 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
             jsonObject.put("partition", record.partition());
             jsonObject.put("offset", record.offset());
 
+            if (!record.headers().isEmpty()) {
+                JsonArray headers = new JsonArray();
+
+                for (KafkaHeader kafkaHeader: record.headers()) {
+                    JsonObject header = new JsonObject();
+
+                    header.put("key", kafkaHeader.key());
+                    header.put("value", DatatypeConverter.printBase64Binary(kafkaHeader.value().getBytes()));
+
+                    headers.add(header);
+                }
+                jsonObject.put("headers", headers);
+            }
             jsonArray.add(jsonObject);
         }
 

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1273,13 +1273,62 @@
     },
     "components": {
         "schemas": {
+            "KafkaHeader": {
+                "example": {
+                    "key": "key1",
+                    "value": "dmFsdWUx"
+                },
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "format": "byte",
+                        "type": "string",
+                        "description": "The header value in binary format, base64-encoded"
+                    }
+                },
+                "title": "KafkaHeader",
+                "required": [
+                    "value",
+                    "key"
+                ],
+                "type": "object"
+            },
+            "KafkaHeaderList": {
+                "title": "KafkaHeaderList",
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/KafkaHeader"
+                },
+                "example": [
+                    {
+                        "key": "key1",
+                        "value": "dmFsdWUx"
+                    },
+                    {
+                        "key": "key2",
+                        "value": "dmFsdWUy"
+                    }
+                ]
+            },
             "ConsumerRecord": {
                 "example": {
                     "key": "key1",
                     "offset": 2,
                     "partition": 0,
                     "topic": "topic",
-                    "value": "value1"
+                    "value": "value1",
+                    "headers": [
+                        {
+                            "key": "key1",
+                            "value": "dmFsdWUx"
+                        },
+                        {
+                            "key": "key2",
+                            "value": "dmFsdWUy"
+                        }
+                    ]
                 },
                 "properties": {
                     "key": {
@@ -1298,6 +1347,9 @@
                     },
                     "value": {
                         "type": "string"
+                    },
+                    "headers": {
+                        "$ref": "#/definitions/KafkaHeaderList"
                     }
                 },
                 "title": "ConsumerRecord",
@@ -1563,10 +1615,27 @@
                                 "type": "string"
                             }
                         ]
+                    },
+                    "headers": {
+                        "$ref": "#/definitions/KafkaHeaderList"
                     }
                 },
                 "additionalProperties": false,
-                "example": "{\n    \"key\": \"key\"\n    \"partition\": 23\n    \"value\": {\"foo\": \"bar\"}\n}"
+                "example": {
+                    "key": "key1",
+                    "partition": 0,
+                    "value": "value1",
+                    "headers": [
+                        {
+                            "key": "key1",
+                            "value": "dmFsdWUx"
+                        },
+                        {
+                            "key": "key2",
+                            "value": "dmFsdWUy"
+                        }
+                    ]
+                }
             },
             "ProducerRecordList": {
                 "title": "ProducerRecordList",

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1161,13 +1161,62 @@
     }
   },
   "definitions": {
+    "KafkaHeader": {
+      "example": {
+        "key": "key1",
+        "value": "dmFsdWUx"
+      },
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "format": "byte",
+          "type": "string",
+          "description": "The header value in binary format, base64-encoded"
+        }
+      },
+      "title": "KafkaHeader",
+      "required": [
+        "value",
+        "key"
+      ],
+      "type": "object"
+    },
+    "KafkaHeaderList": {
+      "title": "KafkaHeaderList",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/KafkaHeader"
+      },
+      "example": [
+        {
+          "key": "key1",
+          "value": "dmFsdWUx"
+        },
+        {
+          "key": "key2",
+          "value": "dmFsdWUy"
+        }
+      ]
+    },
     "ConsumerRecord": {
       "example": {
         "key": "key1",
         "offset": 2,
         "partition": 0,
         "topic": "topic",
-        "value": "value1"
+        "value": "value1",
+        "headers": [
+          {
+            "key": "key1",
+            "value": "dmFsdWUx"
+          },
+          {
+            "key": "key2",
+            "value": "dmFsdWUy"
+          }
+        ]
       },
       "properties": {
         "key": {
@@ -1186,6 +1235,9 @@
         },
         "value": {
           "type": "string"
+        },
+        "headers": {
+          "$ref": "#/definitions/KafkaHeaderList"
         }
       },
       "title": "ConsumerRecord",
@@ -1443,10 +1495,27 @@
             "object",
             "string"
           ]
+        },
+        "headers": {
+          "$ref": "#/definitions/KafkaHeaderList"
         }
       },
       "additionalProperties": false,
-      "example": "{\n    \"key\": \"key\"\n    \"partition\": 23\n    \"value\": {\"foo\": \"bar\"}\n}"
+      "example": {
+        "key": "key1",
+        "partition": 0,
+        "value": "value1",
+        "headers": [
+          {
+            "key": "key1",
+            "value": "dmFsdWUx"
+          },
+          {
+            "key": "key2",
+            "value": "dmFsdWUy"
+          }
+        ]
+      }
     },
     "ProducerRecordList": {
       "title": "ProducerRecordList",

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -115,7 +115,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertThat(paths.containsKey("/"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.INFO.toString()));
                         assertThat(paths.containsKey("/karel"), is(false));
-                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(22));
+                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(24));
                         assertThat(bridgeResponse.getJsonArray("tags").size(), is(4));
                     });
                     context.completeNow();


### PR DESCRIPTION
Purpose of the change is to allow usage of [Kafka Headers](https://issues.apache.org/jira/browse/KAFKA-4208) within strimzi-kafka-bridge HTTP API.
Kafka Headers would be attached to the [ConsumerRecord](https://strimzi.io/docs/bridge/latest/#_consumerrecord) and the [ProducerRecord](https://strimzi.io/docs/bridge/latest/#_producerrecord) definitions as an _optional_ array of key/value pairs.

Example

```
"kafkaRecord": {
  "key": "key1",
  "partition": 0,
  "value": "value1",
  "headers": [
    {
      "key": "key1",
      "value": "value1"
    },
    {
      "key": "key2",
      "value": "value2"
    }
  ]
}
```

 The feature is also tracked by this issue : https://github.com/strimzi/strimzi-kafka-bridge/issues/183