### PR TITLE
Bump Vert.x to 3.9.1 and deprecate setHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.13.0</log4j.version>
-		<vertx.version>3.9.0</vertx.version>
+		<vertx.version>3.9.1</vertx.version>
 		<debezium.version>1.0.0.Final</debezium.version>
 		<maven.checkstyle.version>3.1.0</maven.checkstyle.version>
 		<junit.platform.version>1.5.2</junit.platform.version>

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -82,7 +82,7 @@ public class Application {
                 futures.add(deployAmqpBridge(vertx, bridgeConfig));
                 futures.add(deployHttpBridge(vertx, bridgeConfig));
 
-                CompositeFuture.join(futures).setHandler(done -> {
+                CompositeFuture.join(futures).onComplete(done -> {
                     if (done.succeeded()) {
                         HealthChecker healthChecker = new HealthChecker();
                         for (int i = 0; i < futures.size(); i++) {

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -279,7 +279,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
             this.consumer.partitionsFor(topicSubscription.getTopic(), fut.completer());
         }
 
-        CompositeFuture.join(partitionsForHandlers).setHandler(partitionsResult -> {
+        CompositeFuture.join(partitionsForHandlers).onComplete(partitionsResult -> {
 
             if (partitionsResult.failed()) {
                 this.handlePartition(Future.failedFuture(partitionsResult.cause()));

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -154,7 +154,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
             this.seek(topicPartition, offset, fut.completer());
         }
 
-        CompositeFuture.join(seekHandlers).setHandler(done -> {
+        CompositeFuture.join(seekHandlers).onComplete(done -> {
             if (done.succeeded()) {
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.NO_CONTENT.code(), null, null);
             } else {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -155,7 +155,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
 
         // wait for ALL futures completed
         List<KafkaProducerRecord<K, V>> finalRecords = records;
-        CompositeFuture.join(sendHandlers).setHandler(done -> {
+        CompositeFuture.join(sendHandlers).onComplete(done -> {
 
             for (int i = 0; i < sendHandlers.size(); i++) {
                 // check if, for each future, the sending operation is completed successfully or failed


### PR DESCRIPTION
This PR bumps Vert.x to 3.9.1 and remove deprecated `setHandler` method using `onComplete` instead.

Signed-off-by: Paolo Patierno <ppatierno@live.com>