### PR TITLE
Updated VS Code part in the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ hs_err_pid*
 .idea/
 *.iml
 
-# VSCode stuff
-.vscode/
+# VS Code
+.factorypath
+.vscode
 
 .DS_Store
 


### PR DESCRIPTION
This PR adds the `.factoypath` to be ignored (as it is created by VS Code builds).

Signed-off-by: Paolo Patierno <ppatierno@live.com>