### PR TITLE
Run with tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,15 @@ WORKDIR ${STRIMZI_HOME}
 
 COPY target/kafka-bridge-${strimzi_kafka_bridge_version}/kafka-bridge-${strimzi_kafka_bridge_version} ./
 
+#####
+# Add Tini
+#####
+ENV TINI_VERSION v0.18.0
+ENV TINI_SHA256=12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN echo "${TINI_SHA256} */usr/bin/tini" | sha256sum -c \
+    && chmod +x /usr/bin/tini
+
 USER 1001
 
 CMD ["/opt/strimzi/bin/kafka_bridge_run.sh"]

--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -56,4 +56,4 @@ function get_gc_opts {
 export JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
 # starting Kafka Bridge with final configuration
-${MYPATH}/../kafka_bridge_run.sh --config-file=/tmp/kafka-bridge.properties "$@"
+${MYPATH}/../kafka_bridge_run.sh --config-file=/tmp/kafka-bridge.properties --docker "$@"

--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -56,4 +56,4 @@ function get_gc_opts {
 export JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
 # starting Kafka Bridge with final configuration
-${MYPATH}/../kafka_bridge_run.sh --config-file=/tmp/kafka-bridge.properties --docker "$@"
+exec /usr/bin/tini -s -w -e 143 -- ${MYPATH}/../kafka_bridge_run.sh --config-file=/tmp/kafka-bridge.properties "$@"

--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -11,7 +11,7 @@ mkdir -p /tmp/strimzi
 
 # Import certificates into keystore and truststore
 # $1 = trusted certs, $2 = TLS auth cert, $3 = TLS auth key, $4 = truststore path, $5 = keystore path, $6 = certs and key path
-${MYPATH}/kafka_bridge_tls_prepare_certificates.sh \
+"${MYPATH}"/kafka_bridge_tls_prepare_certificates.sh \
     "$KAFKA_BRIDGE_TRUSTED_CERTS" \
     "$KAFKA_BRIDGE_TLS_AUTH_CERT" \
     "$KAFKA_BRIDGE_TLS_AUTH_KEY" \
@@ -21,16 +21,16 @@ ${MYPATH}/kafka_bridge_tls_prepare_certificates.sh \
 
 # Generate and print the consumer config file
 echo "Kafka Bridge configuration:"
-${MYPATH}/kafka_bridge_config_generator.sh | tee /tmp/kafka-bridge.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
+"${MYPATH}"/kafka_bridge_config_generator.sh | tee /tmp/kafka-bridge.properties | sed 's/sasl.jaas.config=.*/sasl.jaas.config=[hidden]/g' | sed 's/password=.*/password=[hidden]/g'
 echo ""
 
 # Configure logging for Kubernetes deployments
 export KAFKA_BRIDGE_LOG4J_OPTS="-Dlog4j2.configurationFile=file:$STRIMZI_HOME/custom-config/log4j2.properties"
 
 # Configure Memory
-. ${MYPATH}/dynamic_resources.sh
+. "${MYPATH}"/dynamic_resources.sh
 
-MAX_HEAP=`get_heap_size`
+MAX_HEAP=$(get_heap_size)
 if [ -n "$MAX_HEAP" ]; then
   export JAVA_OPTS="-Xms${MAX_HEAP}m -Xmx${MAX_HEAP}m $JAVA_OPTS"
 fi
@@ -56,4 +56,4 @@ function get_gc_opts {
 export JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
 # starting Kafka Bridge with final configuration
-exec /usr/bin/tini -s -w -e 143 -- ${MYPATH}/../kafka_bridge_run.sh --config-file=/tmp/kafka-bridge.properties "$@"
+exec /usr/bin/tini -s -w -e 143 -- "${MYPATH}"/../kafka_bridge_run.sh --config-file=/tmp/kafka-bridge.properties "$@"

--- a/bin/kafka_bridge_run.sh
+++ b/bin/kafka_bridge_run.sh
@@ -12,4 +12,9 @@ fi
 # Make sure that we use /dev/urandom
 JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
 
-exec java $JAVA_OPTS $KAFKA_BRIDGE_LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"
+if [[ "$@ " =~ "--docker " ]]; then
+    echo "Running with tini"
+    exec /usr/bin/tini -s -w -e 143 -- java $JAVA_OPTS $KAFKA_BRIDGE_LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"
+else
+    java $JAVA_OPTS $KAFKA_BRIDGE_LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"
+fi

--- a/bin/kafka_bridge_run.sh
+++ b/bin/kafka_bridge_run.sh
@@ -12,9 +12,4 @@ fi
 # Make sure that we use /dev/urandom
 JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
 
-if [[ "$@ " =~ "--docker " ]]; then
-    echo "Running with tini"
-    exec /usr/bin/tini -s -w -e 143 -- java $JAVA_OPTS $KAFKA_BRIDGE_LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"
-else
-    java $JAVA_OPTS $KAFKA_BRIDGE_LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"
-fi
+exec java $JAVA_OPTS $KAFKA_BRIDGE_LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Run docker image of bridge with `tini`.

Fixes https://github.com/strimzi/strimzi-kafka-bridge/issues/411