### PR TITLE
Add / endpoint

### DIFF
--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -7,6 +7,19 @@
 __Type__ : < string, < integer (int32) > array > map
 
 
+[[_bridgeinfo]]
+=== BridgeInfo
+Information about Kafka Bridge instance.
+
+
+[options="header", cols=".^3a,.^4a"]
+|===
+|Name|Schema
+|**bridge_version** +
+__optional__|string
+|===
+
+
 [[_consumer]]
 === Consumer
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -14,13 +14,24 @@ Retrieves information about the Kafka Bridge instance, in JSON format.
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|Information about Kafka Bridge instance.|string
+|**200**|Information about Kafka Bridge instance.|<<_bridgeinfo,BridgeInfo>>
 |===
 
 
 ==== Produces
 
 * `application/json`
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+{
+  "bridge_version" : "0.16.0"
+}
+----
 
 
 [[_createconsumer]]

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -1274,4 +1274,25 @@ __required__|List of records to send to a given topic partition, including a val
 ----
 
 
+[[_version]]
+=== GET /version
+
+==== Description
+Retrieves the Kafka Bridge instance version in JSON format.
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|Info about Kafka Bridge instance version.|string
+|===
+
+
+==== Produces
+
+* `application/json`
+
+
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -2,6 +2,27 @@
 [[_paths]]
 == Paths
 
+[[_configuration]]
+=== GET /
+
+==== Description
+Retrieves the Kafka Bridge instance version in JSON format.
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|Info about Kafka Bridge instance configuration.|string
+|===
+
+
+==== Produces
+
+* `application/json`
+
+
 [[_createconsumer]]
 === POST /consumers/{groupid}
 
@@ -1272,27 +1293,6 @@ __required__|List of records to send to a given topic partition, including a val
   }
 }
 ----
-
-
-[[_version]]
-=== GET /version
-
-==== Description
-Retrieves the Kafka Bridge instance version in JSON format.
-
-
-==== Responses
-
-[options="header", cols=".^2a,.^14a,.^4a"]
-|===
-|HTTP Code|Description|Schema
-|**200**|Info about Kafka Bridge instance version.|string
-|===
-
-
-==== Produces
-
-* `application/json`
 
 
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -2,11 +2,11 @@
 [[_paths]]
 == Paths
 
-[[_configuration]]
+[[_info]]
 === GET /
 
 ==== Description
-Retrieves the Kafka Bridge instance version in JSON format.
+Retrieves the Kafka Bridge instance info in JSON format.
 
 
 ==== Responses
@@ -14,7 +14,7 @@ Retrieves the Kafka Bridge instance version in JSON format.
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|Info about Kafka Bridge instance configuration.|string
+|**200**|Info about Kafka Bridge instance.|string
 |===
 
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -6,7 +6,7 @@
 === GET /
 
 ==== Description
-Retrieves the Kafka Bridge instance info in JSON format.
+Retrieves information about the Kafka Bridge instance, in JSON format.
 
 
 ==== Responses
@@ -14,7 +14,7 @@ Retrieves the Kafka Bridge instance info in JSON format.
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|Info about Kafka Bridge instance.|string
+|**200**|Information about Kafka Bridge instance.|string
 |===
 
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -161,7 +161,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
                 routerFactory.addHandlerByOperationId(this.HEALTHY.getOperationId().toString(), this.HEALTHY);
                 routerFactory.addHandlerByOperationId(this.READY.getOperationId().toString(), this.READY);
                 routerFactory.addHandlerByOperationId(this.OPENAPI.getOperationId().toString(), this.OPENAPI);
-                routerFactory.addHandlerByOperationId(this.VERSION.getOperationId().toString(), this.VERSION);
+                routerFactory.addHandlerByOperationId(this.CONFIGURATION.getOperationId().toString(), this.CONFIGURATION);
 
                 this.router = routerFactory.getRouter();
 
@@ -721,7 +721,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         }
     };
 
-    HttpOpenApiOperation VERSION = new HttpOpenApiOperation(HttpOpenApiOperations.VERSION) {
+    HttpOpenApiOperation CONFIGURATION = new HttpOpenApiOperation(HttpOpenApiOperations.CONFIGURATION) {
 
         @Override
         public void process(RoutingContext routingContext) {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -161,7 +161,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
                 routerFactory.addHandlerByOperationId(this.HEALTHY.getOperationId().toString(), this.HEALTHY);
                 routerFactory.addHandlerByOperationId(this.READY.getOperationId().toString(), this.READY);
                 routerFactory.addHandlerByOperationId(this.OPENAPI.getOperationId().toString(), this.OPENAPI);
-                routerFactory.addHandlerByOperationId(this.CONFIGURATION.getOperationId().toString(), this.CONFIGURATION);
+                routerFactory.addHandlerByOperationId(this.INFO.getOperationId().toString(), this.INFO);
 
                 this.router = routerFactory.getRouter();
 
@@ -721,7 +721,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         }
     };
 
-    HttpOpenApiOperation CONFIGURATION = new HttpOpenApiOperation(HttpOpenApiOperations.CONFIGURATION) {
+    HttpOpenApiOperation INFO = new HttpOpenApiOperation(HttpOpenApiOperations.INFO) {
 
         @Override
         public void process(RoutingContext routingContext) {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -478,7 +478,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         });
     }
 
-    private void version(RoutingContext routingContext) {
+    private void information(RoutingContext routingContext) {
         // Only maven built binary has this value set.
         String version = Application.class.getPackage().getImplementationVersion();
         JsonObject versionJson = new JsonObject();
@@ -725,7 +725,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
 
         @Override
         public void process(RoutingContext routingContext) {
-            version(routingContext);
+            information(routingContext);
         }
     };
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -10,6 +10,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.AdminClientEndpoint;
+import io.strimzi.kafka.bridge.Application;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.EmbeddedFormat;
 import io.strimzi.kafka.bridge.HealthCheckable;
@@ -160,6 +161,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
                 routerFactory.addHandlerByOperationId(this.HEALTHY.getOperationId().toString(), this.HEALTHY);
                 routerFactory.addHandlerByOperationId(this.READY.getOperationId().toString(), this.READY);
                 routerFactory.addHandlerByOperationId(this.OPENAPI.getOperationId().toString(), this.OPENAPI);
+                routerFactory.addHandlerByOperationId(this.VERSION.getOperationId().toString(), this.VERSION);
 
                 this.router = routerFactory.getRouter();
 
@@ -476,6 +478,15 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         });
     }
 
+    private void version(RoutingContext routingContext) {
+        // Only maven built binary has this value set.
+        String version = Application.class.getPackage().getImplementationVersion();
+        JsonObject versionJson = new JsonObject();
+        versionJson.put("bridge_version", version == null ? "null" : version);
+        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(),
+                BridgeContentType.JSON, versionJson.toBuffer());
+    }
+
     @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
     private void errorHandler(RoutingContext routingContext) {
         int requestId = System.identityHashCode(routingContext.request());
@@ -707,6 +718,14 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         @Override
         public void process(RoutingContext routingContext) {
             openapi(routingContext);
+        }
+    };
+
+    HttpOpenApiOperation VERSION = new HttpOpenApiOperation(HttpOpenApiOperations.VERSION) {
+
+        @Override
+        public void process(RoutingContext routingContext) {
+            version(routingContext);
         }
     };
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -28,7 +28,7 @@ public enum HttpOpenApiOperations {
     HEALTHY("healthy"),
     READY("ready"),
     OPENAPI("openapi"),
-    CONFIGURATION("configuration");
+    INFO("info");
 
     private final String text;
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -27,7 +27,8 @@ public enum HttpOpenApiOperations {
     SEEK_TO_END("seekToEnd"),
     HEALTHY("healthy"),
     READY("ready"),
-    OPENAPI("openapi");
+    OPENAPI("openapi"),
+    VERSION("version");
 
     private final String text;
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -28,7 +28,7 @@ public enum HttpOpenApiOperations {
     HEALTHY("healthy"),
     READY("ready"),
     OPENAPI("openapi"),
-    VERSION("version");
+    CONFIGURATION("configuration");
 
     private final String text;
 

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1170,7 +1170,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "string"
+                                    "$ref": "#/components/schemas/BridgeInfo"
                                 }
                             }
                         }
@@ -1767,7 +1767,21 @@
                     "leader": true,
                     "in_sync": true
                 }
-            }            
+            }
+            },
+            "BridgeInfo": {
+                "title": "BridgeInfo",
+                "description": "Information about Kafka Bridge instance.",
+                "type": "object",
+                "properties": {
+                    "bridge_version": {
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "bridge_version": "0.16.0"
+                }
+            }
         }
     },
     "tags": [

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1166,7 +1166,7 @@
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Info about Kafka Bridge instance configuration.",
+                        "description": "Info about Kafka Bridge instance.",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1176,8 +1176,8 @@
                         }
                     }
                 },
-                "operationId": "configuration",
-                "description": "Retrieves the Kafka Bridge instance version in JSON format."
+                "operationId": "info",
+                "description": "Retrieves the Kafka Bridge instance info in JSON format."
             }
         }
     },

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1162,11 +1162,11 @@
                 "description": "Retrieves the OpenAPI v2 specification in JSON format."
             }
         },
-        "/version": {
+        "/": {
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Info about Kafka Bridge instance version.",
+                        "description": "Info about Kafka Bridge instance configuration.",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1176,7 +1176,7 @@
                         }
                     }
                 },
-                "operationId": "version",
+                "operationId": "configuration",
                 "description": "Retrieves the Kafka Bridge instance version in JSON format."
             }
         }

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1166,7 +1166,7 @@
             "get": {
                 "responses": {
                     "200": {
-                        "description": "Info about Kafka Bridge instance.",
+                        "description": "Information about Kafka Bridge instance.",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1177,7 +1177,7 @@
                     }
                 },
                 "operationId": "info",
-                "description": "Retrieves the Kafka Bridge instance info in JSON format."
+                "description": "Retrieves information about the Kafka Bridge instance, in JSON format."
             }
         }
     },

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1161,6 +1161,24 @@
                 "operationId": "openapi",
                 "description": "Retrieves the OpenAPI v2 specification in JSON format."
             }
+        },
+        "/version": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Info about Kafka Bridge instance version.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "version",
+                "description": "Retrieves the Kafka Bridge instance version in JSON format."
+            }
         }
     },
     "components": {

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1767,7 +1767,6 @@
                     "leader": true,
                     "in_sync": true
                 }
-            }
             },
             "BridgeInfo": {
                 "title": "BridgeInfo",

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1023,7 +1023,7 @@
           "200": {
             "description": "Information about Kafka Bridge instance.",
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/BridgeInfo"
             }
           }
         },
@@ -1601,7 +1601,21 @@
         "leader": true,
         "in_sync": true
       }
-    }            
+    }
+    },
+    "BridgeInfo": {
+      "title": "BridgeInfo",
+      "description": "Information about Kafka Bridge instance.",
+      "type": "object",
+      "properties": {
+        "bridge_version": {
+          "type": "string"
+        }
+      },
+      "example": {
+        "bridge_version": "0.16.0"
+      }
+    }
   },
   "tags": [
     {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1014,20 +1014,20 @@
         "description": "Retrieves the OpenAPI v2 specification in JSON format."
       }
     },
-    "/version": {
+    "/": {
       "get": {
         "produces": [
           "application/json"
         ],
         "responses": {
           "200": {
-            "description": "Info about Kafka Bridge instance version.",
+            "description": "Info about Kafka Bridge instance configuration.",
             "schema": {
               "type": "string"
             }
           }
         },
-        "operationId": "version",
+        "operationId": "configuration",
         "description": "Retrieves the Kafka Bridge instance version in JSON format."
       }
     }

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1021,14 +1021,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Info about Kafka Bridge instance.",
+            "description": "Information about Kafka Bridge instance.",
             "schema": {
               "type": "string"
             }
           }
         },
         "operationId": "info",
-        "description": "Retrieves the Kafka Bridge instance info in JSON format."
+        "description": "Retrieves information about the Kafka Bridge instance, in JSON format."
       }
     }
   },

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1601,7 +1601,6 @@
         "leader": true,
         "in_sync": true
       }
-    }
     },
     "BridgeInfo": {
       "title": "BridgeInfo",

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1021,14 +1021,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Info about Kafka Bridge instance configuration.",
+            "description": "Info about Kafka Bridge instance.",
             "schema": {
               "type": "string"
             }
           }
         },
-        "operationId": "configuration",
-        "description": "Retrieves the Kafka Bridge instance version in JSON format."
+        "operationId": "info",
+        "description": "Retrieves the Kafka Bridge instance info in JSON format."
       }
     }
   },

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1013,6 +1013,23 @@
         "operationId": "openapi",
         "description": "Retrieves the OpenAPI v2 specification in JSON format."
       }
+    },
+    "/version": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Info about Kafka Bridge instance version.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "operationId": "version",
+        "description": "Retrieves the Kafka Bridge instance version in JSON format."
+      }
     }
   },
   "definitions": {

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -113,6 +113,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.INFO.toString()));
                         assertThat(paths.containsKey("/karel"), is(false));
                         assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(21));
+                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(19));
                         assertThat(bridgeResponse.getJsonArray("tags").size(), is(4));
                     });
                     context.completeNow();

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -109,8 +109,8 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/ready").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.READY.toString()));
                         assertThat(paths.containsKey("/openapi"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/openapi").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.OPENAPI.toString()));
-                        assertThat(paths.containsKey("/version"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/version").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.VERSION.toString()));
+                        assertThat(paths.containsKey("/"), is(true));
+                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.CONFIGURATION.toString()));
                         assertThat(paths.containsKey("/karel"), is(false));
                         assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(21));
                         assertThat(bridgeResponse.getJsonArray("tags").size(), is(4));
@@ -139,7 +139,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
     @Test
     void getVersion(VertxTestContext context) {
         baseService()
-                .getRequest("/version")
+                .getRequest("/")
                 .as(BodyCodec.jsonObject())
                 .send(ar -> {
                     context.verify(() -> {

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class OtherServicesTest extends HttpBridgeTestBase {
 
@@ -108,6 +109,8 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/ready").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.READY.toString()));
                         assertThat(paths.containsKey("/openapi"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/openapi").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.OPENAPI.toString()));
+                        assertThat(paths.containsKey("/version"), is(true));
+                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/version").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.VERSION.toString()));
                         assertThat(paths.containsKey("/karel"), is(false));
                         assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(21));
                         assertThat(bridgeResponse.getJsonArray("tags").size(), is(4));
@@ -131,5 +134,20 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                 });
                 context.completeNow();
             });
+    }
+
+    @Test
+    void getVersion(VertxTestContext context) {
+        baseService()
+                .getRequest("/version")
+                .as(BodyCodec.jsonObject())
+                .send(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        assertThat(response.body().getString("bridge_version"), is(notNullValue()));
+                    });
+                    context.completeNow();
+                });
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -110,7 +110,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertThat(paths.containsKey("/openapi"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/openapi").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.OPENAPI.toString()));
                         assertThat(paths.containsKey("/"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.CONFIGURATION.toString()));
+                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.INFO.toString()));
                         assertThat(paths.containsKey("/karel"), is(false));
                         assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(21));
                         assertThat(bridgeResponse.getJsonArray("tags").size(), is(4));

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -112,8 +112,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertThat(paths.containsKey("/"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.INFO.toString()));
                         assertThat(paths.containsKey("/karel"), is(false));
-                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(21));
-                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(19));
+                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(22));
                         assertThat(bridgeResponse.getJsonArray("tags").size(), is(4));
                     });
                     context.completeNow();


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Fixes https://github.com/strimzi/strimzi-kafka-bridge/issues/375

This PR adds new endpoint (`/`) where the bridge instance info will be exposed. Currently, just the version of the bridge is there.

When the bridge is built with maven, `Class.class.getPackage().getImplementationVersion()` fetches a version from pom file. Unit test from IDE would fail (the null value would be there) so if the version is null, `"null"` string is returned.