### PR TITLE
Enabling metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 		<jaeger.version>1.1.0</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.12</opentracing-kafka-client.version>
+		<micrometer.version>1.3.1</micrometer.version>
 	</properties>
 
 	<dependencies>
@@ -53,6 +54,11 @@
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-config</artifactId>
+			<version>${vertx.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.vertx</groupId>
+			<artifactId>vertx-micrometer-metrics</artifactId>
 			<version>${vertx.version}</version>
 		</dependency>
 		<dependency>
@@ -104,6 +110,11 @@
 			<groupId>io.opentracing.contrib</groupId>
 			<artifactId>opentracing-kafka-client</artifactId>
 			<version>${opentracing-kafka-client.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<version>${micrometer.version}</version>
 		</dependency>
 
 		<!-- Testing -->

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -6,6 +6,7 @@
 package io.strimzi.kafka.bridge;
 
 import io.jaegertracing.Configuration;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 import io.strimzi.kafka.bridge.amqp.AmqpBridge;
@@ -18,12 +19,18 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.json.JsonObject;
+import io.vertx.micrometer.Label;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
@@ -34,14 +41,23 @@ public class Application {
 
     private static final Logger log = LoggerFactory.getLogger(Application.class);
 
-    private static final String HEALTH_SERVER_PORT = "HEALTH_SERVER_PORT";
+    private static final String EMBEDDED_HTTP_SERVER_PORT = "EMBEDDED_HTTP_SERVER_PORT";
 
-    private static final int DEFAULT_HEALTH_SERVER_PORT = 8080;
+    private static final int DEFAULT_EMBEDDED_HTTP_SERVER_PORT = 8080;
 
     @SuppressWarnings({"checkstyle:NPathComplexity"})
     public static void main(String[] args) {
         log.info("Strimzi Kafka Bridge {} is starting", Application.class.getPackage().getImplementationVersion());
-        Vertx vertx = Vertx.vertx();
+        // setup Micrometer metrics options
+        VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(
+                new MicrometerMetricsOptions()
+                        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                        .setLabels(EnumSet.of(Label.REMOTE, Label.LOCAL, Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE))
+                        .setJvmMetricsEnabled(true)
+                        .setEnabled(true));
+        Vertx vertx = Vertx.vertx(vertxOptions);
+
+        MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
 
         if (args.length == 0)   {
             log.error("Please specify a configuration file using the '--config-file` option. For example 'bin/kafka_bridge_run.sh --config-file config/application.properties'.");
@@ -72,16 +88,16 @@ public class Application {
                 Map<String, Object> config = ar.result().getMap();
                 BridgeConfig bridgeConfig = BridgeConfig.fromMap(config);
 
-                int healthServerPort = Integer.parseInt(config.getOrDefault(HEALTH_SERVER_PORT, DEFAULT_HEALTH_SERVER_PORT).toString());
+                int embeddedHttpServerPort = Integer.parseInt(config.getOrDefault(EMBEDDED_HTTP_SERVER_PORT, DEFAULT_EMBEDDED_HTTP_SERVER_PORT).toString());
 
-                if (bridgeConfig.getAmqpConfig().isEnabled() && bridgeConfig.getAmqpConfig().getPort() == healthServerPort) {
-                    log.error("Health server port {} conflicts with configured AMQP port", healthServerPort);
+                if (bridgeConfig.getAmqpConfig().isEnabled() && bridgeConfig.getAmqpConfig().getPort() == embeddedHttpServerPort) {
+                    log.error("Embedded HTTP server port {} conflicts with configured AMQP port", embeddedHttpServerPort);
                     System.exit(1);
                 }
 
                 List<Future> futures = new ArrayList<>();
-                futures.add(deployAmqpBridge(vertx, bridgeConfig));
-                futures.add(deployHttpBridge(vertx, bridgeConfig));
+                futures.add(deployAmqpBridge(vertx, bridgeConfig, meterRegistry));
+                futures.add(deployHttpBridge(vertx, bridgeConfig, meterRegistry));
 
                 CompositeFuture.join(futures).onComplete(done -> {
                     if (done.succeeded()) {
@@ -97,10 +113,12 @@ public class Application {
                             }
                         }                    
                         
-                        // when HTTP protocol is enabled, it handles healthy/ready endpoints as well,
-                        // so no need for a standalone HTTP health server
+                        // when HTTP protocol is enabled, it handles healthy/ready/metrics endpoints as well,
+                        // so no need for a standalone embedded HTTP server
                         if (!bridgeConfig.getHttpConfig().isEnabled()) {
-                            healthChecker.startHealthServer(vertx, healthServerPort);
+                            EmbeddedHttpServer embeddedHttpServer =
+                                    new EmbeddedHttpServer(vertx, healthChecker, meterRegistry, embeddedHttpServerPort);
+                            embeddedHttpServer.start();
                         }
 
                         // register OpenTracing Jaeger tracer
@@ -126,13 +144,14 @@ public class Application {
      *
      * @param vertx                 Vertx instance
      * @param bridgeConfig          Bridge configuration
+     * @param meterRegistry         Registry for scraping metrics
      * @return                      Future for the bridge startup
      */
-    private static Future<AmqpBridge> deployAmqpBridge(Vertx vertx, BridgeConfig bridgeConfig)  {
+    private static Future<AmqpBridge> deployAmqpBridge(Vertx vertx, BridgeConfig bridgeConfig, MeterRegistry meterRegistry)  {
         Promise<AmqpBridge> amqpPromise = Promise.promise();
 
         if (bridgeConfig.getAmqpConfig().isEnabled()) {
-            AmqpBridge amqpBridge = new AmqpBridge(bridgeConfig);
+            AmqpBridge amqpBridge = new AmqpBridge(bridgeConfig, meterRegistry);
 
             vertx.deployVerticle(amqpBridge, done -> {
                 if (done.succeeded()) {
@@ -155,13 +174,14 @@ public class Application {
      *
      * @param vertx                 Vertx instance
      * @param bridgeConfig          Bridge configuration
+     * @param meterRegistry         Registry for scraping metrics
      * @return                      Future for the bridge startup
      */
-    private static Future<HttpBridge> deployHttpBridge(Vertx vertx, BridgeConfig bridgeConfig)  {
+    private static Future<HttpBridge> deployHttpBridge(Vertx vertx, BridgeConfig bridgeConfig, MeterRegistry meterRegistry)  {
         Promise<HttpBridge> httpPromise = Promise.promise();
 
         if (bridgeConfig.getHttpConfig().isEnabled()) {
-            HttpBridge httpBridge = new HttpBridge(bridgeConfig);
+            HttpBridge httpBridge = new HttpBridge(bridgeConfig, meterRegistry);
             
             vertx.deployVerticle(httpBridge, done -> {
                 if (done.succeeded()) {

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -22,6 +22,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.micrometer.Label;
+import io.vertx.micrometer.MetricsDomain;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 import io.vertx.micrometer.VertxPrometheusOptions;
 import io.vertx.micrometer.backends.BackendRegistries;
@@ -52,7 +53,10 @@ public class Application {
         VertxOptions vertxOptions = new VertxOptions().setMetricsOptions(
                 new MicrometerMetricsOptions()
                         .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+                        // define the lables on the HTTP server related metrics
                         .setLabels(EnumSet.of(Label.REMOTE, Label.LOCAL, Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE))
+                        // disable metrics about pool and verticles
+                        .setDisabledMetricsCategories(EnumSet.of(MetricsDomain.NAMED_POOLS, MetricsDomain.VERTICLES))
                         .setJvmMetricsEnabled(true)
                         .setEnabled(true));
         Vertx vertx = Vertx.vertx(vertxOptions);

--- a/src/main/java/io/strimzi/kafka/bridge/EmbeddedHttpServer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/EmbeddedHttpServer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.Vertx;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An HTTP server exposing endpoints for health and metrics used when the HTTP bridge is not enabled
+ */
+public class EmbeddedHttpServer {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbeddedHttpServer.class);
+
+    private final HealthChecker healthChecker;
+    private final MeterRegistry meterRegistry;
+    private final Vertx vertx;
+    private final int port;
+
+    /**
+     * Constructor
+     *
+     * @param vertx Vert.x instance
+     * @param healthChecker HealthChecker instance for checking health of enabled bridges
+     * @param meterRegistry registry for scraping metrics
+     * @param port port on which listening requests
+     */
+    public EmbeddedHttpServer(Vertx vertx, HealthChecker healthChecker, MeterRegistry meterRegistry, int port) {
+        this.vertx = vertx;
+        this.healthChecker = healthChecker;
+        this.meterRegistry = meterRegistry;
+        this.port = port;
+    }
+
+    /**
+     * Create and start the HTTP server
+     */
+    public void start() {
+        vertx.createHttpServer()
+                .requestHandler(request -> {
+                    HttpResponseStatus httpResponseStatus;
+                    if (request.path().equals("/healthy")) {
+                        httpResponseStatus = healthChecker.isAlive() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
+                        request.response().setStatusCode(httpResponseStatus.code()).end();
+                    } else if (request.path().equals("/ready")) {
+                        httpResponseStatus = healthChecker.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
+                        request.response().setStatusCode(httpResponseStatus.code()).end();
+                    } else if (request.path().equals("/metrics")) {
+                        PrometheusMeterRegistry prometheusMeterRegistry = (PrometheusMeterRegistry) meterRegistry;
+                        request.response().setStatusCode(HttpResponseStatus.OK.code()).end(prometheusMeterRegistry.scrape());
+                    } else {
+                        request.response().setStatusCode(HttpResponseStatus.NOT_FOUND.code()).end();
+                    }
+                })
+                .listen(port, done -> {
+                    if (done.succeeded()) {
+                        log.info("Embedded HTTP server started, listening on port {}", port);
+                    } else {
+                        log.error("Failed to start the embedded HTTP server", done.cause());
+                    }
+                });
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
+++ b/src/main/java/io/strimzi/kafka/bridge/HealthChecker.java
@@ -11,9 +11,6 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.vertx.core.Vertx;
-
 /**
  * Check the healthiness and readiness of the registered services
  */
@@ -66,32 +63,5 @@ public class HealthChecker {
             }
         }
         return isReady;
-    }
-
-    /**
-     * Start an HTTP health server
-     */
-    public void startHealthServer(Vertx vertx, int port) {
-
-        vertx.createHttpServer()
-                .requestHandler(request -> {
-                    HttpResponseStatus httpResponseStatus = HttpResponseStatus.OK;
-                    if (request.path().equals("/healthy")) {
-                        httpResponseStatus = this.isAlive() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
-                        request.response().setStatusCode(httpResponseStatus.code()).end();
-                    } else if (request.path().equals("/ready")) {
-                        httpResponseStatus = this.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
-                        request.response().setStatusCode(httpResponseStatus.code()).end();
-                    } else {
-                        request.response().setStatusCode(HttpResponseStatus.NOT_FOUND.code()).end();
-                    }
-                })
-                .listen(port, done -> {
-                    if (done.succeeded()) {
-                        log.info("Health server started, listening on port {}", port);
-                    } else {
-                        log.error("Failed to start Health server", done.cause());
-                    }
-                });
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.bridge.amqp;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.ConnectionEndpoint;
 import io.strimzi.kafka.bridge.EmbeddedFormat;
 import io.strimzi.kafka.bridge.HealthCheckable;
@@ -90,13 +91,17 @@ public class AmqpBridge extends AbstractVerticle implements HealthCheckable {
     // if the bridge is ready to handle requests
     private boolean isReady = false;
 
+    private MeterRegistry meterRegistry;
+
     /**
      * Constructor
      *
      * @param bridgeConfig bridge configuration
+     * @param meterRegistry registry for scraping metrics
      */
-    public AmqpBridge(BridgeConfig bridgeConfig) {
+    public AmqpBridge(BridgeConfig bridgeConfig, MeterRegistry meterRegistry) {
         this.bridgeConfig = bridgeConfig;
+        this.meterRegistry = meterRegistry;
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -6,6 +6,8 @@
 package io.strimzi.kafka.bridge.http;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.EmbeddedFormat;
@@ -73,13 +75,17 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
 
     private Map<String, Long> timestampMap = new HashMap<>();
 
+    private MeterRegistry meterRegistry;
+
     /**
      * Constructor
      *
      * @param bridgeConfig bridge configuration
+     * @param meterRegistry registry for scraping metrics
      */
-    public HttpBridge(BridgeConfig bridgeConfig) {
+    public HttpBridge(BridgeConfig bridgeConfig, MeterRegistry meterRegistry) {
         this.bridgeConfig = bridgeConfig;
+        this.meterRegistry = meterRegistry;
     }
 
     private void bindHttpServer(Promise<Void> startPromise) {
@@ -157,6 +163,8 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
                 // handling validation errors and not existing endpoints
                 this.router.errorHandler(HttpResponseStatus.BAD_REQUEST.code(), this::errorHandler);
                 this.router.errorHandler(HttpResponseStatus.NOT_FOUND.code(), this::errorHandler);
+
+                this.router.route("/metrics").handler(this::metricsHandler);
 
                 //enable cors
                 if (this.bridgeConfig.getHttpConfig().isCorsEnabled()) {
@@ -471,6 +479,11 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
             requestId,
             routingContext.statusCode(),
             message);
+    }
+
+    private void metricsHandler(RoutingContext routingContext) {
+        PrometheusMeterRegistry prometheusMeterRegistry = (PrometheusMeterRegistry) meterRegistry;
+        routingContext.response().setStatusCode(HttpResponseStatus.OK.code()).end(prometheusMeterRegistry.scrape());
     }
 
     private void processConnection(HttpConnection httpConnection) {

--- a/src/test/java/io/strimzi/kafka/bridge/amqp/AmqpBridgeTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/amqp/AmqpBridgeTest.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.bridge.amqp;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.amqp.converter.AmqpDefaultMessageConverter;
 import io.strimzi.kafka.bridge.amqp.converter.AmqpJsonMessageConverter;
 import io.strimzi.kafka.bridge.amqp.converter.AmqpRawMessageConverter;
@@ -21,6 +22,7 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.impl.KafkaConsumerRecordImpl;
+import io.vertx.micrometer.backends.BackendRegistries;
 import io.vertx.proton.ProtonClient;
 import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.ProtonHelper;
@@ -92,6 +94,7 @@ class AmqpBridgeTest {
 
     private BridgeConfig bridgeConfig;
     static KafkaFacade kafkaCluster = new KafkaFacade();
+    static MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
 
 
     @BeforeAll
@@ -110,7 +113,7 @@ class AmqpBridgeTest {
         this.vertx = Vertx.vertx();
 
         this.bridgeConfig = BridgeConfig.fromMap(config);
-        this.bridge = new AmqpBridge(this.bridgeConfig);
+        this.bridge = new AmqpBridge(this.bridgeConfig, meterRegistry);
 
         vertx.deployVerticle(this.bridge, context.succeeding(id -> context.completeNow()));
     }

--- a/src/test/java/io/strimzi/kafka/bridge/example/AmqpBridgeServer.java
+++ b/src/test/java/io/strimzi/kafka/bridge/example/AmqpBridgeServer.java
@@ -5,9 +5,11 @@
 
 package io.strimzi.kafka.bridge.example;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.amqp.AmqpBridge;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.vertx.core.Vertx;
+import io.vertx.micrometer.backends.BackendRegistries;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -24,8 +26,9 @@ public class AmqpBridgeServer {
 
         Map<String, Object> config = new HashMap<>();
         BridgeConfig bridgeConfig = BridgeConfig.fromMap(config);
+        MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
         
-        AmqpBridge bridge = new AmqpBridge(bridgeConfig);
+        AmqpBridge bridge = new AmqpBridge(bridgeConfig, meterRegistry);
 
         vertx.deployVerticle(bridge);
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameTest.java
@@ -4,6 +4,7 @@
  */
 package io.strimzi.kafka.bridge.http;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.HealthChecker;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
@@ -21,6 +22,7 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.logging.log4j.LogManager;
@@ -61,6 +63,7 @@ public class ConsumerGeneratedNameTest {
     static HttpBridge httpBridge;
     static WebClient client;
     static BridgeConfig bridgeConfig;
+    static MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
     static final String BRIDGE_EXTERNAL_ENV = System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE");
 
     ConsumerService consumerService() {
@@ -79,7 +82,7 @@ public class ConsumerGeneratedNameTest {
 
         if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
             bridgeConfig = BridgeConfig.fromMap(config);
-            httpBridge = new HttpBridge(bridgeConfig);
+            httpBridge = new HttpBridge(bridgeConfig, meterRegistry);
             httpBridge.setHealthChecker(new HealthChecker());
 
             LOGGER.info("Deploying in-memory bridge");

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTestBase.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTestBase.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.bridge.http;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.HealthChecker;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
@@ -21,6 +22,7 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.logging.log4j.LogManager;
@@ -60,6 +62,7 @@ class HttpBridgeTestBase {
 
     static BridgeConfig bridgeConfig;
     static KafkaFacade kafkaCluster = new KafkaFacade();
+    static MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
 
     static final String BRIDGE_EXTERNAL_ENV = System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE");
 
@@ -88,7 +91,7 @@ class HttpBridgeTestBase {
 
         if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
             bridgeConfig = BridgeConfig.fromMap(config);
-            httpBridge = new HttpBridge(bridgeConfig);
+            httpBridge = new HttpBridge(bridgeConfig, meterRegistry);
             httpBridge.setHealthChecker(new HealthChecker());
 
             LOGGER.info("Deploying in-memory bridge");

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsTests.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsTests.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.bridge.http;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.HealthChecker;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.facades.KafkaFacade;
@@ -16,6 +17,7 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.micrometer.backends.BackendRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
@@ -54,6 +56,7 @@ public class HttpCorsTests {
 
     static BridgeConfig bridgeConfig;
     static KafkaFacade kafkaCluster = new KafkaFacade();
+    static MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
 
     @BeforeAll
     static void beforeAll() {
@@ -210,7 +213,7 @@ public class HttpCorsTests {
             config.put(HttpConfig.HTTP_CORS_ALLOWED_METHODS, methodsAllowed != null ? methodsAllowed : "GET,POST,PUT,DELETE,OPTIONS,PATCH");
 
             bridgeConfig = BridgeConfig.fromMap(config);
-            httpBridge = new HttpBridge(bridgeConfig);
+            httpBridge = new HttpBridge(bridgeConfig, meterRegistry);
             httpBridge.setHealthChecker(new HealthChecker());
         }
     }


### PR DESCRIPTION
This PR enables bridge metrics.
More specifically it enables the JVM and HTTP server ones provided by Vert.x out of the box.
The HTTP server ones already provide information like opened connections, bytes received, bytes sent, response time but most importantly requests count tagged with information like method and path so that it's possible to get, for example, insights on how many POSTs on the `/topics/<my-topic>` about producers and things like that.
I will think about more specific metrics that will come in a following PR.

Signed-off-by: Paolo Patierno <ppatierno@live.com>