### PR TITLE
Added JMX metrics collection for exposing in Prometheus format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.12</opentracing-kafka-client.version>
 		<micrometer.version>1.3.1</micrometer.version>
+		<jmx-prometheus-collector.version>0.12.0</jmx-prometheus-collector.version>
+		<commons-cli.version>1.4</commons-cli.version>
 	</properties>
 
 	<dependencies>
@@ -115,6 +117,16 @@
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>
 			<version>${micrometer.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.prometheus.jmx</groupId>
+			<artifactId>collector</artifactId>
+			<version>${jmx-prometheus-collector.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>${commons-cli.version}</version>
 		</dependency>
 
 		<!-- Testing -->

--- a/src/main/java/io/strimzi/kafka/bridge/EmbeddedHttpServer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/EmbeddedHttpServer.java
@@ -5,8 +5,6 @@
 
 package io.strimzi.kafka.bridge;
 
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Vertx;
 import org.slf4j.Logger;
@@ -20,8 +18,7 @@ public class EmbeddedHttpServer {
     private static final Logger log = LoggerFactory.getLogger(EmbeddedHttpServer.class);
 
     private final HealthChecker healthChecker;
-    private final MeterRegistry meterRegistry;
-    private final JmxCollectorRegistry jmxCollectorRegistry;
+    private final MetricsReporter metricsReporter;
     private final Vertx vertx;
     private final int port;
 
@@ -30,15 +27,13 @@ public class EmbeddedHttpServer {
      *
      * @param vertx Vert.x instance
      * @param healthChecker HealthChecker instance for checking health of enabled bridges
-     * @param meterRegistry registry for scraping metrics
-     * @param jmxCollectorRegistry registry for scraping JMX metrics
+     * @param metricsReporter MetricsReporter instance for scraping metrics from different registries
      * @param port port on which listening requests
      */
-    public EmbeddedHttpServer(Vertx vertx, HealthChecker healthChecker, MeterRegistry meterRegistry, JmxCollectorRegistry jmxCollectorRegistry, int port) {
+    public EmbeddedHttpServer(Vertx vertx, HealthChecker healthChecker, MetricsReporter metricsReporter, int port) {
         this.vertx = vertx;
         this.healthChecker = healthChecker;
-        this.meterRegistry = meterRegistry;
-        this.jmxCollectorRegistry = jmxCollectorRegistry;
+        this.metricsReporter = metricsReporter;
         this.port = port;
     }
 
@@ -56,13 +51,7 @@ public class EmbeddedHttpServer {
                         httpResponseStatus = healthChecker.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
                         request.response().setStatusCode(httpResponseStatus.code()).end();
                     } else if (request.path().equals("/metrics")) {
-                        PrometheusMeterRegistry prometheusMeterRegistry = (PrometheusMeterRegistry) meterRegistry;
-
-                        StringBuilder sb = new StringBuilder();
-                        sb.append(jmxCollectorRegistry.scrape());
-                        sb.append(prometheusMeterRegistry.scrape());
-
-                        request.response().setStatusCode(HttpResponseStatus.OK.code()).end(sb.toString());
+                        request.response().setStatusCode(HttpResponseStatus.OK.code()).end(metricsReporter.scrape());
                     } else {
                         request.response().setStatusCode(HttpResponseStatus.NOT_FOUND.code()).end();
                     }

--- a/src/main/java/io/strimzi/kafka/bridge/JmxCollectorRegistry.java
+++ b/src/main/java/io/strimzi/kafka/bridge/JmxCollectorRegistry.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import io.prometheus.jmx.JmxCollector;
+
+import javax.management.MalformedObjectNameException;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+/**
+ * Allow to collect JMX metrics exposing them in the Prometheus format
+ */
+public class JmxCollectorRegistry {
+
+    private final CollectorRegistry collectorRegistry;
+
+    /**
+     * Constructor
+     *
+     * @param yamlConfig YAML configuration string with metrics filtering rules
+     * @throws MalformedObjectNameException
+     */
+    public JmxCollectorRegistry(String yamlConfig) throws MalformedObjectNameException {
+        new JmxCollector(yamlConfig).register();
+        collectorRegistry = CollectorRegistry.defaultRegistry;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param yamlFileConfig file containing the YAML configuration with metrics filtering rules
+     * @throws MalformedObjectNameException
+     * @throws IOException
+     */
+    public JmxCollectorRegistry(File yamlFileConfig) throws MalformedObjectNameException, IOException {
+        new JmxCollector(yamlFileConfig).register();
+        collectorRegistry = CollectorRegistry.defaultRegistry;
+    }
+
+    /**
+     * @return Content that should be included in the response body for an endpoint designated for
+     * Prometheus to scrape from.
+     */
+    public String scrape() {
+        Writer writer = new StringWriter();
+        try {
+            TextFormat.write004(writer, collectorRegistry.metricFamilySamples());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return writer.toString();
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/MetricsReporter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/MetricsReporter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+
+/**
+ * Used for scraping and reporting metrics in Prometheus format
+ */
+public class MetricsReporter {
+
+    private final JmxCollectorRegistry jmxCollectorRegistry;
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * Constructor
+     *
+     * @param jmxCollectorRegistry JmxCollectorRegistry instance for scraping metrics from JMX endpoints
+     * @param meterRegistry MeterRegistry instance for scraping metrics exposed through Vert.x
+     */
+    public MetricsReporter(JmxCollectorRegistry jmxCollectorRegistry, MeterRegistry meterRegistry) {
+        this.jmxCollectorRegistry = jmxCollectorRegistry;
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * @return JmxCollectorRegistry instance for scraping metrics from JMX endpoints
+     */
+    public JmxCollectorRegistry getJmxCollectorRegistry() {
+        return jmxCollectorRegistry;
+    }
+
+    /**
+     * @return MeterRegistry instance for scraping metrics exposed through Vert.x
+     */
+    public MeterRegistry getMeterRegistry() {
+        return meterRegistry;
+    }
+
+    /**
+     * Scrape metrics on the provided registries returning them in the Prometheus format
+     *
+     * @return metrics in Prometheus format as String
+     */
+    public String scrape() {
+        StringBuilder sb = new StringBuilder();
+        if (jmxCollectorRegistry != null) {
+            sb.append(jmxCollectorRegistry.scrape());
+        }
+        if (meterRegistry instanceof PrometheusMeterRegistry) {
+            sb.append(((PrometheusMeterRegistry) meterRegistry).scrape());
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
@@ -97,7 +97,7 @@ public class AmqpBridge extends AbstractVerticle implements HealthCheckable {
      * Constructor
      *
      * @param bridgeConfig bridge configuration
-     * @@param metricsReporter MetricsReporter instance for scraping metrics from different registries
+     * @param metricsReporter MetricsReporter instance for scraping metrics from different registries
      */
     public AmqpBridge(BridgeConfig bridgeConfig, MetricsReporter metricsReporter) {
         this.bridgeConfig = bridgeConfig;

--- a/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/amqp/AmqpBridge.java
@@ -5,10 +5,10 @@
 
 package io.strimzi.kafka.bridge.amqp;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.ConnectionEndpoint;
 import io.strimzi.kafka.bridge.EmbeddedFormat;
 import io.strimzi.kafka.bridge.HealthCheckable;
+import io.strimzi.kafka.bridge.MetricsReporter;
 import io.strimzi.kafka.bridge.SinkBridgeEndpoint;
 import io.strimzi.kafka.bridge.SourceBridgeEndpoint;
 import io.strimzi.kafka.bridge.amqp.converter.AmqpDefaultMessageConverter;
@@ -91,17 +91,17 @@ public class AmqpBridge extends AbstractVerticle implements HealthCheckable {
     // if the bridge is ready to handle requests
     private boolean isReady = false;
 
-    private MeterRegistry meterRegistry;
+    private MetricsReporter metricsReporter;
 
     /**
      * Constructor
      *
      * @param bridgeConfig bridge configuration
-     * @param meterRegistry registry for scraping metrics
+     * @@param metricsReporter MetricsReporter instance for scraping metrics from different registries
      */
-    public AmqpBridge(BridgeConfig bridgeConfig, MeterRegistry meterRegistry) {
+    public AmqpBridge(BridgeConfig bridgeConfig, MetricsReporter metricsReporter) {
         this.bridgeConfig = bridgeConfig;
-        this.meterRegistry = meterRegistry;
+        this.metricsReporter = metricsReporter;
     }
 
     /**

--- a/src/test/java/io/strimzi/kafka/bridge/amqp/AmqpBridgeTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/amqp/AmqpBridgeTest.java
@@ -6,6 +6,7 @@
 package io.strimzi.kafka.bridge.amqp;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.strimzi.kafka.bridge.MetricsReporter;
 import io.strimzi.kafka.bridge.amqp.converter.AmqpDefaultMessageConverter;
 import io.strimzi.kafka.bridge.amqp.converter.AmqpJsonMessageConverter;
 import io.strimzi.kafka.bridge.amqp.converter.AmqpRawMessageConverter;
@@ -113,7 +114,7 @@ class AmqpBridgeTest {
         this.vertx = Vertx.vertx();
 
         this.bridgeConfig = BridgeConfig.fromMap(config);
-        this.bridge = new AmqpBridge(this.bridgeConfig, meterRegistry);
+        this.bridge = new AmqpBridge(this.bridgeConfig, new MetricsReporter(null, meterRegistry));
 
         vertx.deployVerticle(this.bridge, context.succeeding(id -> context.completeNow()));
     }

--- a/src/test/java/io/strimzi/kafka/bridge/example/AmqpBridgeServer.java
+++ b/src/test/java/io/strimzi/kafka/bridge/example/AmqpBridgeServer.java
@@ -6,6 +6,7 @@
 package io.strimzi.kafka.bridge.example;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.strimzi.kafka.bridge.MetricsReporter;
 import io.strimzi.kafka.bridge.amqp.AmqpBridge;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.vertx.core.Vertx;
@@ -28,7 +29,7 @@ public class AmqpBridgeServer {
         BridgeConfig bridgeConfig = BridgeConfig.fromMap(config);
         MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
         
-        AmqpBridge bridge = new AmqpBridge(bridgeConfig, meterRegistry);
+        AmqpBridge bridge = new AmqpBridge(bridgeConfig, new MetricsReporter(null, meterRegistry));
 
         vertx.deployVerticle(bridge);
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameTest.java
@@ -7,6 +7,7 @@ package io.strimzi.kafka.bridge.http;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.HealthChecker;
+import io.strimzi.kafka.bridge.JmxCollectorRegistry;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
 import io.strimzi.kafka.bridge.config.KafkaConsumerConfig;
@@ -66,6 +67,16 @@ public class ConsumerGeneratedNameTest {
     static MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
     static final String BRIDGE_EXTERNAL_ENV = System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE");
 
+    static JmxCollectorRegistry jmxCollectorRegistry;
+
+    static {
+        try {
+            jmxCollectorRegistry = new JmxCollectorRegistry("");
+        } catch (Exception ex) {
+
+        }
+    }
+
     ConsumerService consumerService() {
         return ConsumerService.getInstance(client);
     }
@@ -82,7 +93,7 @@ public class ConsumerGeneratedNameTest {
 
         if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
             bridgeConfig = BridgeConfig.fromMap(config);
-            httpBridge = new HttpBridge(bridgeConfig, meterRegistry);
+            httpBridge = new HttpBridge(bridgeConfig, meterRegistry, jmxCollectorRegistry);
             httpBridge.setHealthChecker(new HealthChecker());
 
             LOGGER.info("Deploying in-memory bridge");

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTestBase.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTestBase.java
@@ -7,6 +7,7 @@ package io.strimzi.kafka.bridge.http;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.HealthChecker;
+import io.strimzi.kafka.bridge.JmxCollectorRegistry;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
 import io.strimzi.kafka.bridge.config.KafkaConsumerConfig;
@@ -63,6 +64,15 @@ class HttpBridgeTestBase {
     static BridgeConfig bridgeConfig;
     static KafkaFacade kafkaCluster = new KafkaFacade();
     static MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
+    static JmxCollectorRegistry jmxCollectorRegistry;
+
+    static {
+        try {
+            jmxCollectorRegistry = new JmxCollectorRegistry("");
+        } catch (Exception ex) {
+
+        }
+    }
 
     static final String BRIDGE_EXTERNAL_ENV = System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE");
 
@@ -91,7 +101,7 @@ class HttpBridgeTestBase {
 
         if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
             bridgeConfig = BridgeConfig.fromMap(config);
-            httpBridge = new HttpBridge(bridgeConfig, meterRegistry);
+            httpBridge = new HttpBridge(bridgeConfig, meterRegistry, jmxCollectorRegistry);
             httpBridge.setHealthChecker(new HealthChecker());
 
             LOGGER.info("Deploying in-memory bridge");

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTestBase.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpBridgeTestBase.java
@@ -8,6 +8,7 @@ package io.strimzi.kafka.bridge.http;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.HealthChecker;
 import io.strimzi.kafka.bridge.JmxCollectorRegistry;
+import io.strimzi.kafka.bridge.MetricsReporter;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
 import io.strimzi.kafka.bridge.config.KafkaConsumerConfig;
@@ -23,7 +24,6 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import io.vertx.micrometer.backends.BackendRegistries;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.logging.log4j.LogManager;
@@ -63,16 +63,8 @@ class HttpBridgeTestBase {
 
     static BridgeConfig bridgeConfig;
     static KafkaFacade kafkaCluster = new KafkaFacade();
-    static MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
-    static JmxCollectorRegistry jmxCollectorRegistry;
-
-    static {
-        try {
-            jmxCollectorRegistry = new JmxCollectorRegistry("");
-        } catch (Exception ex) {
-
-        }
-    }
+    static MeterRegistry meterRegistry = null;
+    static JmxCollectorRegistry jmxCollectorRegistry = null;
 
     static final String BRIDGE_EXTERNAL_ENV = System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE");
 
@@ -101,7 +93,7 @@ class HttpBridgeTestBase {
 
         if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
             bridgeConfig = BridgeConfig.fromMap(config);
-            httpBridge = new HttpBridge(bridgeConfig, meterRegistry, jmxCollectorRegistry);
+            httpBridge = new HttpBridge(bridgeConfig, new MetricsReporter(jmxCollectorRegistry, meterRegistry));
             httpBridge.setHealthChecker(new HealthChecker());
 
             LOGGER.info("Deploying in-memory bridge");

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsTests.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsTests.java
@@ -8,6 +8,7 @@ package io.strimzi.kafka.bridge.http;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.HealthChecker;
 import io.strimzi.kafka.bridge.JmxCollectorRegistry;
+import io.strimzi.kafka.bridge.MetricsReporter;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
 import io.strimzi.kafka.bridge.facades.KafkaFacade;
@@ -20,7 +21,6 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import io.vertx.micrometer.backends.BackendRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
@@ -60,17 +60,8 @@ public class HttpCorsTests {
 
     static BridgeConfig bridgeConfig;
     static KafkaFacade kafkaCluster = new KafkaFacade();
-    static MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
-
-    static JmxCollectorRegistry jmxCollectorRegistry;
-
-    static {
-        try {
-            jmxCollectorRegistry = new JmxCollectorRegistry("");
-        } catch (Exception ex) {
-
-        }
-    }
+    static MeterRegistry meterRegistry = null;
+    static JmxCollectorRegistry jmxCollectorRegistry = null;
 
     @BeforeAll
     static void beforeAll() {
@@ -227,7 +218,7 @@ public class HttpCorsTests {
             config.put(HttpConfig.HTTP_CORS_ALLOWED_METHODS, methodsAllowed != null ? methodsAllowed : "GET,POST,PUT,DELETE,OPTIONS,PATCH");
 
             bridgeConfig = BridgeConfig.fromMap(config);
-            httpBridge = new HttpBridge(bridgeConfig, meterRegistry, jmxCollectorRegistry);
+            httpBridge = new HttpBridge(bridgeConfig, new MetricsReporter(jmxCollectorRegistry, meterRegistry));
             httpBridge.setHealthChecker(new HealthChecker());
         }
     }

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsTests.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsTests.java
@@ -7,6 +7,7 @@ package io.strimzi.kafka.bridge.http;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.strimzi.kafka.bridge.HealthChecker;
+import io.strimzi.kafka.bridge.JmxCollectorRegistry;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
 import io.strimzi.kafka.bridge.facades.KafkaFacade;
@@ -60,6 +61,16 @@ public class HttpCorsTests {
     static BridgeConfig bridgeConfig;
     static KafkaFacade kafkaCluster = new KafkaFacade();
     static MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
+
+    static JmxCollectorRegistry jmxCollectorRegistry;
+
+    static {
+        try {
+            jmxCollectorRegistry = new JmxCollectorRegistry("");
+        } catch (Exception ex) {
+
+        }
+    }
 
     @BeforeAll
     static void beforeAll() {
@@ -216,7 +227,7 @@ public class HttpCorsTests {
             config.put(HttpConfig.HTTP_CORS_ALLOWED_METHODS, methodsAllowed != null ? methodsAllowed : "GET,POST,PUT,DELETE,OPTIONS,PATCH");
 
             bridgeConfig = BridgeConfig.fromMap(config);
-            httpBridge = new HttpBridge(bridgeConfig, meterRegistry);
+            httpBridge = new HttpBridge(bridgeConfig, meterRegistry, jmxCollectorRegistry);
             httpBridge.setHealthChecker(new HealthChecker());
         }
     }


### PR DESCRIPTION
This PR adds a way for getting JMX metrics and exposing them in the Prometheus format through the HTTP server `/metrics` endpoint.
The metrics can be "filtered" providing a JMX configuration file follow the syntax provided by the JMX exporter.

Signed-off-by: Paolo Patierno <ppatierno@live.com>