### PR TITLE
Add topic-partition retrieval operations

### DIFF
--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -148,7 +148,7 @@ Deletes a specified consumer instance. The request for this operation MUST use t
 |**Path**|**groupid** +
 __required__|ID of the consumer group to which the consumer belongs.|string
 |**Path**|**name** +
-__required__|Name of the consumer that you want to delete.|string
+__required__|Name of the consumer to delete.|string
 |===
 
 
@@ -206,7 +206,7 @@ Assigns one or more topic partitions to a consumer.
 |**Path**|**groupid** +
 __required__|ID of the consumer group to which the consumer belongs.|string
 |**Path**|**name** +
-__required__|Name of the consumer to which you want to assign topic partitions.|string
+__required__|Name of the consumer to assign topic partitions to.|string
 |**Body**|**body** +
 __required__|List of topic partitions to assign to the consumer.|<<_partitions,Partitions>>
 |===
@@ -611,7 +611,7 @@ Retrieves records for a subscribed consumer, including message values, topics, a
 |**Path**|**groupid** +
 __required__|ID of the consumer group to which the subscribed consumer belongs.|string
 |**Path**|**name** +
-__required__|Name of the subscribed consumer for which you want to retrieve records.|string
+__required__|Name of the subscribed consumer to retrieve records from.|string
 |**Query**|**max_bytes** +
 __optional__|The maximum size, in bytes, of unencoded keys and values that can be included in the response. Otherwise, an error response with code 422 is returned.|integer
 |**Query**|**timeout** +
@@ -720,7 +720,7 @@ Subscribes a consumer to one or more topics. You can describe the topics to whic
 |**Path**|**groupid** +
 __required__|ID of the consumer group to which the subscribed consumer belongs.|string
 |**Path**|**name** +
-__required__|Name of the consumer that you want to unsubscribe from topics.|string
+__required__|Name of the consumer to unsubscribe from topics.|string
 |**Body**|**body** +
 __required__|List of topics to which the consumer will subscribe.|<<_topics,Topics>>
 |===
@@ -817,7 +817,7 @@ Retrieves a list of the topics to which the consumer is subscribed.
 |**Path**|**groupid** +
 __required__|ID of the consumer group to which the subscribed consumer belongs.|string
 |**Path**|**name** +
-__required__|Name of the consumer that you want to unsubscribe from topics.|string
+__required__|Name of the consumer to unsubscribe from topics.|string
 |===
 
 
@@ -884,7 +884,7 @@ Unsubscribes a consumer from all topics.
 |**Path**|**groupid** +
 __required__|ID of the consumer group to which the subscribed consumer belongs.|string
 |**Path**|**name** +
-__required__|Name of the consumer that you want to unsubscribe from topics.|string
+__required__|Name of the consumer to unsubscribe from topics.|string
 |===
 
 
@@ -1018,7 +1018,7 @@ Sends one or more records to a given topic, optionally specifying a partition, k
 |===
 |Type|Name|Description|Schema
 |**Path**|**topicname** +
-__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
+__required__|Name of the topic to send records to or retrieve metadata from.|string
 |**Body**|**body** +
 __required__||<<_producerrecordlist,ProducerRecordList>>
 |===
@@ -1130,7 +1130,7 @@ Retrieves the metadata about a given topic.
 |===
 |Type|Name|Description|Schema
 |**Path**|**topicname** +
-__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
+__required__|Name of the topic to send records to or retrieve metadata from.|string
 |===
 
 
@@ -1208,7 +1208,7 @@ Retrieves a list of partitions for the topic.
 |===
 |Type|Name|Description|Schema
 |**Path**|**topicname** +
-__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
+__required__|Name of the topic to send records to or retrieve metadata from.|string
 |===
 
 
@@ -1292,9 +1292,9 @@ Sends one or more records to a given topic partition, optionally specifying a ke
 |===
 |Type|Name|Description|Schema
 |**Path**|**partitionid** +
-__required__|ID of the partition to which you want to either retrieve metadata for, or send records.|integer
+__required__|ID of the partition to send records to or retrieve metadata from.|integer
 |**Path**|**topicname** +
-__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
+__required__|Name of the topic to send records to or retrieve metadata from.|string
 |**Body**|**body** +
 __required__|List of records to send to a given topic partition, including a value (required) and a key (optional).|<<_producerrecordtopartitionlist,ProducerRecordToPartitionList>>
 |===
@@ -1394,7 +1394,7 @@ __required__|List of records to send to a given topic partition, including a val
 === GET /topics/{topicname}/partitions/{partitionid}
 
 ==== Description
-Retrieves a partition metadata for the topic partition.
+Retrieves partition metadata for the topic partition.
 
 
 ==== Parameters
@@ -1403,9 +1403,9 @@ Retrieves a partition metadata for the topic partition.
 |===
 |Type|Name|Description|Schema
 |**Path**|**partitionid** +
-__required__|ID of the partition to which you want to either retrieve metadata for, or send records.|integer
+__required__|ID of the partition to send records to or retrieve metadata from.|integer
 |**Path**|**topicname** +
-__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
+__required__|Name of the topic to send records to or retrieve metadata from.|string
 |===
 
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -1018,7 +1018,7 @@ Sends one or more records to a given topic, optionally specifying a partition, k
 |===
 |Type|Name|Description|Schema
 |**Path**|**topicname** +
-__required__|Name of the topic which you want to either retrieve metadata for, or to send records to.|string
+__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
 |**Body**|**body** +
 __required__||<<_producerrecordlist,ProducerRecordList>>
 |===
@@ -1130,7 +1130,7 @@ Retrieves the metadata about a given topic.
 |===
 |Type|Name|Description|Schema
 |**Path**|**topicname** +
-__required__|Name of the topic which you want to either retrieve metadata for, or to send records to.|string
+__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
 |===
 
 
@@ -1195,6 +1195,90 @@ __required__|Name of the topic which you want to either retrieve metadata for, o
 ----
 
 
+[[_listpartitions]]
+=== GET /topics/{topicname}/partitions
+
+==== Description
+Retrieves a list of partitions for the topic.
+
+
+==== Parameters
+
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|**Path**|**topicname** +
+__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|List of partitions|< <<_partitionmetadata,PartitionMetadata>> > array
+|**404**|The specified topic was not found.|<<_error,Error>>
+|===
+
+
+==== Produces
+
+* `application/vnd.kafka.v2+json`
+
+
+==== Tags
+
+* Topics
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+{
+  "application/vnd.kafka.v2+json" : [ {
+    "partition" : 1,
+    "leader" : 1,
+    "replicas" : [ {
+      "broker" : 1,
+      "leader" : true,
+      "in_sync" : true
+    }, {
+      "broker" : 2,
+      "leader" : false,
+      "in_sync" : true
+    } ]
+  }, {
+    "partition" : 2,
+    "leader" : 2,
+    "replicas" : [ {
+      "broker" : 1,
+      "leader" : false,
+      "in_sync" : true
+    }, {
+      "broker" : 2,
+      "leader" : true,
+      "in_sync" : true
+    } ]
+  } ]
+}
+----
+
+
+===== Response 404
+[source,json]
+----
+{
+  "application/vnd.kafka.v2+json" : {
+    "error_code" : 404,
+    "message" : "The specified topic was not found."
+  }
+}
+----
+
+
 [[_sendtopartition]]
 === POST /topics/{topicname}/partitions/{partitionid}
 
@@ -1208,9 +1292,9 @@ Sends one or more records to a given topic partition, optionally specifying a ke
 |===
 |Type|Name|Description|Schema
 |**Path**|**partitionid** +
-__required__|ID of the partition to which you want to send records.|integer
+__required__|ID of the partition to which you want to either retrieve metadata for, or send records.|integer
 |**Path**|**topicname** +
-__required__|Name of the topic containing the partition to which you want to send records.|string
+__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
 |**Body**|**body** +
 __required__|List of records to send to a given topic partition, including a value (required) and a key (optional).|<<_producerrecordtopartitionlist,ProducerRecordToPartitionList>>
 |===
@@ -1301,6 +1385,80 @@ __required__|List of records to send to a given topic partition, including a val
   "application/vnd.kafka.v2+json" : {
     "error_code" : 422,
     "message" : "The record is not valid."
+  }
+}
+----
+
+
+[[_getpartition]]
+=== GET /topics/{topicname}/partitions/{partitionid}
+
+==== Description
+Retrieves a partition metadata for the topic partition.
+
+
+==== Parameters
+
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|**Path**|**partitionid** +
+__required__|ID of the partition to which you want to either retrieve metadata for, or send records.|integer
+|**Path**|**topicname** +
+__required__|Name of the topic which you want to either retrieve metadata for, or send records to.|string
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|Partition metadata|<<_partitionmetadata,PartitionMetadata>>
+|**404**|The specified topic partition was not found.|<<_error,Error>>
+|===
+
+
+==== Produces
+
+* `application/vnd.kafka.v2+json`
+
+
+==== Tags
+
+* Topics
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+{
+  "application/vnd.kafka.v2+json" : {
+    "partition" : 1,
+    "leader" : 1,
+    "replicas" : [ {
+      "broker" : 1,
+      "leader" : true,
+      "in_sync" : true
+    }, {
+      "broker" : 2,
+      "leader" : false,
+      "in_sync" : true
+    } ]
+  }
+}
+----
+
+
+===== Response 404
+[source,json]
+----
+{
+  "application/vnd.kafka.v2+json" : {
+    "error_code" : 404,
+    "message" : "The specified topic partition was not found."
   }
 }
 ----

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -158,6 +158,8 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
                 routerFactory.addHandlerByOperationId(this.SEEK_TO_END.getOperationId().toString(), this.SEEK_TO_END);
                 routerFactory.addHandlerByOperationId(this.LIST_TOPICS.getOperationId().toString(), this.LIST_TOPICS);
                 routerFactory.addHandlerByOperationId(this.GET_TOPIC.getOperationId().toString(), this.GET_TOPIC);
+                routerFactory.addHandlerByOperationId(this.LIST_PARTITIONS.getOperationId().toString(), this.LIST_PARTITIONS);
+                routerFactory.addHandlerByOperationId(this.GET_PARTITION.getOperationId().toString(), this.GET_PARTITION);
                 routerFactory.addHandlerByOperationId(this.HEALTHY.getOperationId().toString(), this.HEALTHY);
                 routerFactory.addHandlerByOperationId(this.READY.getOperationId().toString(), this.READY);
                 routerFactory.addHandlerByOperationId(this.OPENAPI.getOperationId().toString(), this.OPENAPI);
@@ -345,6 +347,16 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
 
     private void getTopic(RoutingContext routingContext) {
         this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.GET_TOPIC);
+        processAdminClient(routingContext);
+    }
+
+    private void listPartitions(RoutingContext routingContext) {
+        this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.LIST_PARTITIONS);
+        processAdminClient(routingContext);
+    }
+
+    private void getPartition(RoutingContext routingContext) {
+        this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.GET_PARTITION);
         processAdminClient(routingContext);
     }
 
@@ -646,6 +658,22 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         @Override
         public void process(RoutingContext routingContext) {
             getTopic(routingContext);
+        }
+    };
+
+    HttpOpenApiOperation LIST_PARTITIONS = new HttpOpenApiOperation(HttpOpenApiOperations.LIST_PARTITIONS) {
+
+        @Override
+        public void process(RoutingContext routingContext) {
+            listPartitions(routingContext);
+        }
+    };
+
+    HttpOpenApiOperation GET_PARTITION = new HttpOpenApiOperation(HttpOpenApiOperations.GET_PARTITION) {
+
+        @Override
+        public void process(RoutingContext routingContext) {
+            getPartition(routingContext);
         }
     };
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -19,6 +19,8 @@ public enum HttpOpenApiOperations {
     LIST_SUBSCRIPTIONS("listSubscriptions"),
     LIST_TOPICS("listTopics"),
     GET_TOPIC("getTopic"),
+    LIST_PARTITIONS("listPartitions"),
+    GET_PARTITION("getPartition"),
     ASSIGN("assign"),
     POLL("poll"),
     COMMIT("commit"),

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -393,7 +393,7 @@
                 {
                     "name": "name",
                     "in": "path",
-                    "description": "Name of the consumer that you want to unsubscribe from topics.",
+                    "description": "Name of the consumer to unsubscribe from topics.",
                     "required": true,
                     "schema": {
                         "type": "string"
@@ -538,7 +538,7 @@
                 {
                     "name": "name",
                     "in": "path",
-                    "description": "Name of the consumer to which you want to assign topic partitions.",
+                    "description": "Name of the consumer to assign topic partitions to.",
                     "required": true,
                     "schema": {
                         "type": "string"
@@ -703,7 +703,7 @@
                 {
                     "name": "topicname",
                     "in": "path",
-                    "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
+                    "description": "Name of the topic to send records to or retrieve metadata from.",
                     "required": true,
                     "schema": {
                         "type": "string"
@@ -868,7 +868,7 @@
                 {
                     "name": "name",
                     "in": "path",
-                    "description": "Name of the subscribed consumer for which you want to retrieve records.",
+                    "description": "Name of the subscribed consumer to retrieve records from.",
                     "required": true,
                     "schema": {
                         "type": "string"
@@ -939,7 +939,7 @@
                 {
                     "name": "topicname",
                     "in": "path",
-                    "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
+                    "description": "Name of the topic to send records to or retrieve metadata from.",
                     "required": true,
                     "schema": {
                         "type": "string"
@@ -952,7 +952,7 @@
                 "tags": [
                     "Topics"
                 ],
-                "description": "Retrieves a partition metadata for the topic partition.",
+                "description": "Retrieves partition metadata for the topic partition.",
                 "operationId": "getPartition",
                 "responses": {
                     "200": {
@@ -1081,7 +1081,7 @@
                 {
                     "name": "topicname",
                     "in": "path",
-                    "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
+                    "description": "Name of the topic to send records to or retrieve metadata from.",
                     "required": true,
                     "schema": {
                         "type": "string"
@@ -1090,7 +1090,7 @@
                 {
                     "name": "partitionid",
                     "in": "path",
-                    "description": "ID of the partition to which you want to either retrieve metadata for, or send records.",
+                    "description": "ID of the partition to send records to or retrieve metadata from.",
                     "required": true,
                     "schema": {
                         "type": "integer"
@@ -1142,7 +1142,7 @@
                 {
                     "name": "name",
                     "in": "path",
-                    "description": "Name of the consumer that you want to delete.",
+                    "description": "Name of the consumer to delete.",
                     "required": true,
                     "schema": {
                         "type": "string"

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -703,7 +703,7 @@
                 {
                     "name": "topicname",
                     "in": "path",
-                    "description": "Name of the topic which you want to either retrieve metadata for, or to send records to.",
+                    "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
                     "required": true,
                     "schema": {
                         "type": "string"
@@ -894,7 +894,97 @@
                 }
             ]
         },
+        "/topics/{topicname}/partitions": {
+            "get": {
+                "tags": [
+                    "Topics"
+                ],
+                "description": "Retrieves a list of partitions for the topic.",
+                "operationId": "listPartitions",
+                "responses": {
+                    "200": {
+                        "description": "List of partitions.",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/PartitionMetadata"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The specified topic was not found.",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "response": {
+                                        "value": {
+                                            "error_code": 404,
+                                            "message": "The specified topic was not found."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "topicname",
+                    "in": "path",
+                    "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ]
+        },
         "/topics/{topicname}/partitions/{partitionid}": {
+            "get": {
+                "tags": [
+                    "Topics"
+                ],
+                "description": "Retrieves a partition metadata for the topic partition.",
+                "operationId": "getPartition",
+                "responses": {
+                    "200": {
+                        "description": "Partition metadata",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PartitionMetadata"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The specified partition was not found.",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "response": {
+                                        "value": {
+                                            "error_code": 404,
+                                            "message": "The specified partition was not found."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "post": {
                 "tags": [
                     "Topics",
@@ -991,7 +1081,7 @@
                 {
                     "name": "topicname",
                     "in": "path",
-                    "description": "Name of the topic containing the partition to which you want to send records.",
+                    "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
                     "required": true,
                     "schema": {
                         "type": "string"
@@ -1000,7 +1090,7 @@
                 {
                     "name": "partitionid",
                     "in": "path",
-                    "description": "ID of the partition to which you want to send records.",
+                    "description": "ID of the partition to which you want to either retrieve metadata for, or send records.",
                     "required": true,
                     "schema": {
                         "type": "integer"

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -350,7 +350,7 @@
         {
           "name": "name",
           "in": "path",
-          "description": "Name of the consumer that you want to unsubscribe from topics.",
+          "description": "Name of the consumer to unsubscribe from topics.",
           "required": true,
           "type": "string"
         }
@@ -481,7 +481,7 @@
         {
           "name": "name",
           "in": "path",
-          "description": "Name of the consumer to which you want to assign topic partitions.",
+          "description": "Name of the consumer to assign topic partitions to.",
           "required": true,
           "type": "string"
         }
@@ -656,7 +656,7 @@
         {
           "name": "topicname",
           "in": "path",
-          "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
+          "description": "Name of the topic to send records to or retrieve metadata from.",
           "required": true,
           "type": "string"
         }
@@ -754,7 +754,7 @@
         {
           "name": "name",
           "in": "path",
-          "description": "Name of the subscribed consumer for which you want to retrieve records.",
+          "description": "Name of the subscribed consumer to retrieve records from.",
           "required": true,
           "type": "string"
         },
@@ -848,7 +848,7 @@
         {
           "name": "topicname",
           "in": "path",
-          "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
+          "description": "Name of the topic to send records to or retrieve metadata from.",
           "required": true,
           "type": "string"
         }
@@ -859,7 +859,7 @@
         "tags": [
           "Topics"
         ],
-        "description": "Retrieves a partition metadata for the topic partition.",
+        "description": "Retrieves partition metadata for the topic partition.",
         "operationId": "getPartition",
         "produces": [
           "application/vnd.kafka.v2+json"
@@ -983,14 +983,14 @@
         {
           "name": "topicname",
           "in": "path",
-          "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
+          "description": "Name of the topic to send records to or retrieve metadata from.",
           "required": true,
           "type": "string"
         },
         {
           "name": "partitionid",
           "in": "path",
-          "description": "ID of the partition to which you want to either retrieve metadata for, or send records.",
+          "description": "ID of the partition to send records to or retrieve metadata from.",
           "required": true,
           "type": "integer"
         }
@@ -1038,7 +1038,7 @@
         {
           "name": "name",
           "in": "path",
-          "description": "Name of the consumer that you want to delete.",
+          "description": "Name of the consumer to delete.",
           "required": true,
           "type": "string"
         }

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -656,7 +656,7 @@
         {
           "name": "topicname",
           "in": "path",
-          "description": "Name of the topic which you want to either retrieve metadata for, or to send records to.",
+          "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
           "required": true,
           "type": "string"
         }
@@ -774,7 +774,135 @@
         }
       ]
     },
+    "/topics/{topicname}/partitions": {
+      "get": {
+        "tags": [
+          "Topics"
+        ],
+        "description": "Retrieves a list of partitions for the topic.",
+        "operationId": "listPartitions",
+        "produces": [
+          "application/vnd.kafka.v2+json"
+        ],
+        "responses": {
+          "200": {
+            "description": "List of partitions",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PartitionMetadata"
+              }
+            },
+            "examples": {
+              "application/vnd.kafka.v2+json": [
+                {
+                  "partition": 1,
+                  "leader": 1,
+                  "replicas": [
+                    {
+                      "broker": 1,
+                      "leader": true,
+                      "in_sync": true
+                    },
+                    {
+                      "broker": 2,
+                      "leader": false,
+                      "in_sync": true
+                    }
+                  ]
+                },
+                {
+                  "partition": 2,
+                  "leader": 2,
+                  "replicas": [
+                    {
+                      "broker": 1,
+                      "leader": false,
+                      "in_sync": true
+                    },
+                    {
+                      "broker": 2,
+                      "leader": true,
+                      "in_sync": true
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "404": {
+            "description": "The specified topic was not found.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/vnd.kafka.v2+json": {
+                "error_code": 404,
+                "message": "The specified topic was not found."
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "topicname",
+          "in": "path",
+          "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
+          "required": true,
+          "type": "string"
+        }
+      ]
+    },
     "/topics/{topicname}/partitions/{partitionid}": {
+      "get": {
+        "tags": [
+          "Topics"
+        ],
+        "description": "Retrieves a partition metadata for the topic partition.",
+        "operationId": "getPartition",
+        "produces": [
+          "application/vnd.kafka.v2+json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Partition metadata",
+            "schema": {
+              "$ref": "#/definitions/PartitionMetadata"
+            },
+            "examples": {
+              "application/vnd.kafka.v2+json": {
+                "partition": 1,
+                "leader": 1,
+                "replicas": [
+                  {
+                    "broker": 1,
+                    "leader": true,
+                    "in_sync": true
+                  },
+                  {
+                    "broker": 2,
+                    "leader": false,
+                    "in_sync": true
+                  }
+                ]
+              }
+            }
+          },
+          "404": {
+            "description": "The specified topic partition was not found.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/vnd.kafka.v2+json": {
+                "error_code": 404,
+                "message": "The specified topic partition was not found."
+              }
+            }
+          }
+        }
+      },
       "post": {
         "tags": [
           "Topics",
@@ -855,14 +983,14 @@
         {
           "name": "topicname",
           "in": "path",
-          "description": "Name of the topic containing the partition to which you want to send records.",
+          "description": "Name of the topic which you want to either retrieve metadata for, or send records to.",
           "required": true,
           "type": "string"
         },
         {
           "name": "partitionid",
           "in": "path",
-          "description": "ID of the partition to which you want to send records.",
+          "description": "ID of the partition to which you want to either retrieve metadata for, or send records.",
           "required": true,
           "type": "integer"
         }

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -78,7 +78,8 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         Map<String, Object> paths = bridgeResponse.getJsonObject("paths").getMap();
                         // subscribe, list subscriptions and unsubscribe are using the same endpoint but different methods (-2)
                         // getTopic and send are using the same endpoint but different methods (-1)
-                        int pathsSize = HttpOpenApiOperations.values().length - 3;
+                        // getPartition and sendToPartition are using the same endpoint but different methods (-1)
+                        int pathsSize = HttpOpenApiOperations.values().length - 4;
                         assertThat(paths.size(), is(pathsSize));
                         assertThat(paths.containsKey("/consumers/{groupid}"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.CREATE_CONSUMER.toString()));
@@ -102,6 +103,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertThat(paths.containsKey("/topics/{topicname}"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/topics/{topicname}").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SEND.toString()));
                         assertThat(paths.containsKey("/topics/{topicname}/partitions/{partitionid}"), is(true));
+                        assertThat(paths.containsKey("/topics/{topicname}/partitions"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/topics/{topicname}/partitions/{partitionid}").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SEND_TO_PARTITION.toString()));
                         assertThat(paths.containsKey("/healthy"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/healthy").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.HEALTHY.toString()));


### PR DESCRIPTION
Signed-off-by: Aki Yoshida <elakito@gmail.com>

adding the following partition retrieval operations to adminClient
- listPartitions: GET /topics/{topicname}/partitions)
- getPartition:  GET /topics/{topicname}/partitions/{partitionid}

Could you review it?
Thanks.