### PR TITLE
Fixed way to track consumers with groupid-instanceid key

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/ConsumerInstanceId.java
+++ b/src/main/java/io/strimzi/kafka/bridge/ConsumerInstanceId.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge;
+
+/**
+ * Represents a unique consumer instance made by consumer group and instance name
+ */
+public class ConsumerInstanceId {
+
+    private final String groupId;
+    private final String instanceId;
+
+    /**
+     * Consumer
+     *
+     * @param groupId the consumer group the Kafka consumer belongs to
+     * @param instanceId the instance Id of the Kafka consumer
+     */
+    public ConsumerInstanceId(String groupId, String instanceId) {
+        this.groupId = groupId;
+        this.instanceId = instanceId;
+    }
+
+    /**
+     * @return the consumer group the Kafka consumer belongs to
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @return the instance Id of the Kafka consumer
+     */
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof ConsumerInstanceId)) {
+            return false;
+        }
+
+        ConsumerInstanceId other = (ConsumerInstanceId) obj;
+
+        if (groupId != null && !groupId.equals(other.groupId)) {
+            return false;
+        }
+
+        if (instanceId != null && !instanceId.equals(other.instanceId)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = 31 * result + (groupId != null ? groupId.hashCode() : 0);
+        result = 31 * result + (instanceId != null ? instanceId.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ConsumerInstanceId(" +
+                "groupId=" + this.groupId +
+                ", instanceId=" + this.instanceId +
+                ")";
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -62,6 +62,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     protected OffsetTracker offsetTracker;
 
     private KafkaConsumer<K, V> consumer;
+    protected ConsumerInstanceId consumerInstanceId;
 
     protected String groupId;
     protected List<SinkTopicSubscription> topicSubscriptions;
@@ -130,6 +131,10 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
             this.consumer.close();
         }
         this.handleClose();
+    }
+
+    public ConsumerInstanceId consumerInstanceId() {
+        return this.consumerInstanceId;
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
@@ -6,6 +6,7 @@
 package io.strimzi.kafka.bridge.http;
 
 import io.strimzi.kafka.bridge.AdminClientEndpoint;
+import io.strimzi.kafka.bridge.ConsumerInstanceId;
 import io.strimzi.kafka.bridge.SinkBridgeEndpoint;
 import io.strimzi.kafka.bridge.SourceBridgeEndpoint;
 import io.vertx.core.http.HttpConnection;
@@ -22,7 +23,7 @@ import java.util.Map;
  */
 public class HttpBridgeContext<K, V> {
 
-    private Map<String, SinkBridgeEndpoint<K, V>> httpSinkEndpoints = new HashMap<>();
+    private Map<ConsumerInstanceId, SinkBridgeEndpoint<K, V>> httpSinkEndpoints = new HashMap<>();
     private Map<HttpConnection, SourceBridgeEndpoint<K, V>> httpSourceEndpoints = new HashMap<>();
     private AdminClientEndpoint adminClientEndpoint;
 
@@ -31,7 +32,7 @@ public class HttpBridgeContext<K, V> {
     /**
      * @return map of sink endpoints
      */
-    public Map<String, SinkBridgeEndpoint<K, V>> getHttpSinkEndpoints() {
+    public Map<ConsumerInstanceId, SinkBridgeEndpoint<K, V>> getHttpSinkEndpoints() {
         return this.httpSinkEndpoints;
     }
 
@@ -75,7 +76,7 @@ public class HttpBridgeContext<K, V> {
     }
 
     public void closeAllSinkBridgeEndpoints() {
-        for (Map.Entry<String, SinkBridgeEndpoint<K, V>> sink: getHttpSinkEndpoints().entrySet()) {
+        for (Map.Entry<ConsumerInstanceId, SinkBridgeEndpoint<K, V>> sink: getHttpSinkEndpoints().entrySet()) {
             if (sink.getValue() != null)
                 sink.getValue().close();
         }


### PR DESCRIPTION
This PR fixes #424. 

The current bridge is wrongly tracking the created consumer using just the `instanceId` (provided or auto-generated) but not using the `groupid`. The PR fixes this.