### PR TITLE
Fixed log4j2 logging configuration for specific OpenAPI operations

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -19,7 +19,7 @@ io.strimzi.kafka.bridge.appenderRef.console.ref = STDOUT
 io.strimzi.kafka.bridge.appenderRef.additivity = false
 
 # HTTP OpenAPI specific logging levels (default is INFO)
-http.openapi.operation.healthy.level=WARN
-http.openapi.operation.healthyadditivity=false
-http.openapi.operation.ready.level=WARN
-http.openapi.operation.ready.additivity=false
+logger.healthy.name = http.openapi.operation.healthy
+logger.healthy.level = WARN
+logger.ready.name = http.openapi.operation.ready
+logger.ready.level = WARN

--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -19,6 +19,7 @@ io.strimzi.kafka.bridge.appenderRef.console.ref = STDOUT
 io.strimzi.kafka.bridge.appenderRef.additivity = false
 
 # HTTP OpenAPI specific logging levels (default is INFO)
+# Logging healthy and ready endpoints is very verbose because of Kubernetes health checking.
 logger.healthy.name = http.openapi.operation.healthy
 logger.healthy.level = WARN
 logger.ready.name = http.openapi.operation.ready

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -19,7 +19,7 @@ io.strimzi.kafka.bridge.appenderRef.console.ref = STDOUT
 io.strimzi.kafka.bridge.appenderRef.additivity = false
 
 # HTTP OpenAPI specific logging levels (default is INFO)
-http.openapi.operation.healthy.level=WARN
-http.openapi.operation.healthyadditivity=false
-http.openapi.operation.ready.level=WARN
-http.openapi.operation.ready.additivity=false
+logger.healthy.name = http.openapi.operation.healthy
+logger.healthy.level = WARN
+logger.ready.name = http.openapi.operation.ready
+logger.ready.level = WARN

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -19,6 +19,7 @@ io.strimzi.kafka.bridge.appenderRef.console.ref = STDOUT
 io.strimzi.kafka.bridge.appenderRef.additivity = false
 
 # HTTP OpenAPI specific logging levels (default is INFO)
+# Logging healthy and ready endpoints is very verbose because of Kubernetes health checking.
 logger.healthy.name = http.openapi.operation.healthy
 logger.healthy.level = WARN
 logger.ready.name = http.openapi.operation.ready


### PR DESCRIPTION
This PR fixes #438 