### PR TITLE
Fixed not working logging level for bridge related stuff

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -9,14 +9,15 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
 
 rootLogger.level = INFO
-rootLogger.appenderRefs = stdout
+rootLogger.appenderRefs = console
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
-io.strimzi.kafka.bridge.level = INFO
-io.strimzi.kafka.bridge.appenderRefs = stdout
-io.strimzi.kafka.bridge.appenderRef.console.ref = STDOUT
-io.strimzi.kafka.bridge.appenderRef.additivity = false
+logger.bridge.name = io.strimzi.kafka.bridge
+logger.bridge.level = INFO
+logger.bridge.appenderRefs = console
+logger.bridge.appenderRef.console.ref = STDOUT
+logger.bridge.additivity = false
 
 # HTTP OpenAPI specific logging levels (default is INFO)
 # Logging healthy and ready endpoints is very verbose because of Kubernetes health checking.

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -9,14 +9,15 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
 
 rootLogger.level = INFO
-rootLogger.appenderRefs = stdout
+rootLogger.appenderRefs = console
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
 
-io.strimzi.kafka.bridge.level = INFO
-io.strimzi.kafka.bridge.appenderRefs = stdout
-io.strimzi.kafka.bridge.appenderRef.console.ref = STDOUT
-io.strimzi.kafka.bridge.appenderRef.additivity = false
+logger.bridge.name = io.strimzi.kafka.bridge
+logger.bridge.level = INFO
+logger.bridge.appenderRefs = console
+logger.bridge.appenderRef.console.ref = STDOUT
+logger.bridge.additivity = false
 
 # HTTP OpenAPI specific logging levels (default is INFO)
 # Logging healthy and ready endpoints is very verbose because of Kubernetes health checking.


### PR DESCRIPTION
After moving to log4j2, the configuration file is not working for the `io.strimzi.kafka.bridge` anymore.
This PR fixes this.
This PR is also needed to fix https://github.com/strimzi/strimzi-kafka-operator/issues/3232