### PR TITLE
Changed Linux distribution for s390x architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: java
 jobs:
   include:
   - os: linux
+    dist: bionic
     arch: s390x
     jdk: openjdk11
     addons:


### PR DESCRIPTION
This PR tries to run s390x build using a different Linux distribution.
It's always failing with error "An error occurred while generating the build script." using Xenial.