### PR TITLE
Allow s390x build to fail but fast finish the overall builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 sudo: required
 language: java
-matrix:
+jobs:
   fast_finish: true
   allow_failures:
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
     jdk: openjdk8
   - os: linux
     jdk: openjdk11
-  - bridge: s390xbuild
+  - build: s390x # custom job identifier to be referenced in the allow_failures section
     os: linux
     arch: s390x
     jdk: openjdk11
@@ -17,7 +17,7 @@ jobs:
         packages:
           - maven
   allow_failures:
-  - bridge: s390xbuild
+  - build: s390x
 services:
 - docker
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ dist: xenial
 sudo: required
 language: java
 jobs:
-  include:
+  fast_finish: true
+  allow_failures:
   - os: linux
-    dist: bionic
     arch: s390x
     jdk: openjdk11
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: required
 language: java
 jobs:
   fast_finish: true
+  include:
+  - os: linux
+    jdk: openjdk8
+  - os: linux
+    jdk: openjdk11
   allow_failures:
   - os: linux
     arch: s390x
@@ -11,9 +16,6 @@ jobs:
       apt:
         packages:
           - maven
-jdk:
-- openjdk8
-- openjdk11
 services:
 - docker
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 sudo: required
 language: java
-jobs:
+matrix:
   fast_finish: true
   allow_failures:
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,16 @@ jobs:
     jdk: openjdk8
   - os: linux
     jdk: openjdk11
-  allow_failures:
-  - os: linux
+  - bridge: s390xbuild
+    os: linux
     arch: s390x
     jdk: openjdk11
     addons:
       apt:
         packages:
           - maven
+  allow_failures:
+  - bridge: s390xbuild
 services:
 - docker
 before_install:


### PR DESCRIPTION
In order to handle the Travis build for s390x, which is quite unreliable and fails due to infrastructure problem, and in order to avoid blocking development for that, I had a chat with @nirmannarang who suggested to use "allow failures" and "fast finish" Travis features so that even if s390x fails, the overall build is considered to be ok.