### PR TITLE
Check on CPU architecture for main build to push to Docker

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -7,7 +7,7 @@ if [ ${JAVA_MAJOR_VERSION} -gt 1 ] ; then
   export JAVA_VERSION=${JAVA_MAJOR_VERSION}
 fi
 
-if [ ${JAVA_MAJOR_VERSION} -eq 11 ] ; then
+if [ ${JAVA_MAJOR_VERSION} -eq 11 ] && [ ${TRAVIS_CPU_ARCH} = "amd64" ] ; then
   # some parts of the workflow should be done only on the main build which is currently Java 11
   export MAIN_BUILD="TRUE"
 fi


### PR DESCRIPTION
Currently, the s390x build is failing because it's considered as the "main build" after the latest check based on Java 11 and it tries to build and push to Docker with this error.

```
Step 1/17 : FROM centos:7
7: Pulling from library/centos
no matching manifest for linux/s390x in the manifest list entries
```

of course build and push to Docker has to be done only for amd64 build. This PR should fix the problem.