### PR TITLE
add getOffsets operation using adminConsumer

### DIFF
--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -143,6 +143,19 @@ __optional__|< <<_offsetrecordsent,OffsetRecordSent>> > array
 |===
 
 
+[[_offsetssummary]]
+=== OffsetsSummary
+
+[options="header", cols=".^3a,.^4a"]
+|===
+|Name|Schema
+|**beginning_offset** +
+__optional__|integer (int64)
+|**end_offset** +
+__optional__|integer (int64)
+|===
+
+
 [[_partition]]
 === Partition
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -1464,4 +1464,69 @@ __required__|Name of the topic to send records to or retrieve metadata from.|str
 ----
 
 
+[[_getoffsets]]
+=== GET /topics/{topicname}/partitions/{partitionid}/offsets
+
+==== Description
+Retrieves a summary of the offsets for the topic partition.
+
+
+==== Parameters
+
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|**Path**|**partitionid** +
+__required__|ID of the partition.|integer
+|**Path**|**topicname** +
+__required__|Name of the topic containing the partition.|string
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|a summary of the offsets|<<_offsetssummary,OffsetsSummary>>
+|**404**|The specified topic partition was not found.|<<_error,Error>>
+|===
+
+
+==== Produces
+
+* `application/vnd.kafka.v2+json`
+
+
+==== Tags
+
+* Topics
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+{
+  "application/vnd.kafka.v2+json" : {
+    "beginning_offset" : 10,
+    "end_offset" : 50
+  }
+}
+----
+
+
+===== Response 404
+[source,json]
+----
+{
+  "application/vnd.kafka.v2+json" : {
+    "error_code" : 404,
+    "message" : "The specified topic partition was not found."
+  }
+}
+----
+
+
 

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -726,4 +726,20 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
             }
         });
     }
+
+    /**
+     * Returns the first offset for the given partition.
+     */
+    protected void getBeginningOffset(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler) {
+        log.info("Get the first offset for partition {}", topicPartition);
+        this.consumer.beginningOffsets(topicPartition, handler);
+    }
+
+    /**
+     * Returns the last offset for the given partition.
+     */
+    protected void getEndOffset(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler) {
+        log.info("Get the last offset for partition {}", topicPartition);
+        this.consumer.endOffsets(topicPartition, handler);
+    }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -27,6 +27,7 @@ public enum HttpOpenApiOperations {
     SEEK("seek"),
     SEEK_TO_BEGINNING("seekToBeginning"),
     SEEK_TO_END("seekToEnd"),
+    GET_OFFSETS("getOffsets"),
     HEALTHY("healthy"),
     READY("ready"),
     OPENAPI("openapi"),

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1098,6 +1098,66 @@
                 }
             ]
         },
+        "/topics/{topicname}/partitions/{partitionid}/offsets": {
+            "get": {
+                "tags": [
+                    "Topics"
+                ],
+                "description": "Retrieves a summary of the offsets for the topic partition.",
+                "operationId": "getOffsets",
+                "responses": {
+                    "200": {
+                        "description": "a summary of the offsets",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OffsetsSummary"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The specified topic partition was not found.",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "response": {
+                                        "value": {
+                                            "error_code": 404,
+                                            "message": "The specified topic partition was not found."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "topicname",
+                    "in": "path",
+                    "description": "Name of the topic containing the partition.",
+
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "partitionid",
+                    "in": "path",
+                    "description": "ID of the partition.",
+                    "required": true,
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ]
+        },
         "/consumers/{groupid}/instances/{name}": {
             "delete": {
                 "tags": [
@@ -1384,6 +1444,24 @@
                             "offset": 91
                         }
                     ]
+                }
+            },
+            "OffsetsSummary": {
+                "title": "OffsetsSummary",
+                "type": "object",
+                "properties": {
+                    "beginning_offset": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "end_offset": {
+                        "format": "int64",
+                        "type": "integer"
+                    }
+                },
+                "example": {
+                    "beginning_offset": 10,
+                    "end_offset": 50
                 }
             },
             "Error": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -996,6 +996,60 @@
         }
       ]
     },
+    "/topics/{topicname}/partitions/{partitionid}/offsets": {
+      "get": {
+        "tags": [
+          "Topics"
+        ],
+        "description": "Retrieves a summary of the offsets for the topic partition.",
+        "operationId": "getOffsets",
+        "produces": [
+          "application/vnd.kafka.v2+json"
+        ],
+        "responses": {
+          "200": {
+            "description": "a summary of the offsets",
+            "schema": {
+              "$ref": "#/definitions/OffsetsSummary"
+            },
+            "examples": {
+              "application/vnd.kafka.v2+json": {
+                "beginning_offset": 10,
+                "end_offset": 50
+              }
+            }
+          },
+          "404": {
+            "description": "The specified topic partition was not found.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/vnd.kafka.v2+json": {
+                "error_code": 404,
+                "message": "The specified topic partition was not found."
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "topicname",
+          "in": "path",
+          "description": "Name of the topic containing the partition.",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "partitionid",
+          "in": "path",
+          "description": "ID of the partition.",
+          "required": true,
+          "type": "integer"
+        }
+      ]
+    },
     "/consumers/{groupid}/instances/{name}": {
       "delete": {
         "tags": [
@@ -1272,6 +1326,24 @@
             "offset": 91
           }
         ]
+      }
+    },
+    "OffsetsSummary": {
+      "title": "OffsetsSummary",
+      "type": "object",
+      "properties": {
+        "beginning_offset": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "end_offset": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "example": {
+        "beginning_offset": 10,
+        "end_offset": 50
       }
     },
     "Error": {

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -114,7 +114,7 @@ public class OtherServicesTest extends HttpBridgeTestBase {
                         assertThat(paths.containsKey("/"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.INFO.toString()));
                         assertThat(paths.containsKey("/karel"), is(false));
-                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(22));
+                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(23));
                         assertThat(bridgeResponse.getJsonArray("tags").size(), is(4));
                     });
                     context.completeNow();


### PR DESCRIPTION
Signed-off-by: Aki Yoshida <elakito@gmail.com>

I would like to add the getOffsets operation to retrieve the offsets pair (i.e., first and last) of a specific partition. This needs a consumer instance that acts more like the admin consumer than a normal consumer. I created this consumer instance using a dedicated consumer ID and have it managed within the sinked endpoints with the other consumers. There may be several alternatives in how to manage this consumer instance and I am not sure if the approach taken is the best one.

Could you look at this PR and give me a feedback?
Thanks.

aki