### PR TITLE
[test fixes] Add deletion of consumers to tests that miss it

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionTest.java
@@ -199,6 +199,10 @@ public class ConsumerSubscriptionTest extends HttpBridgeTestBase {
                     subscribe.complete(true);
                 });
         subscribe.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+
+        consumerService()
+            .deleteConsumer(context, groupId, name);
+
         context.completeNow();
     }
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekTest.java
@@ -87,6 +87,10 @@ public class SeekTest extends HttpBridgeTestBase {
                 });
             });
         assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+
+        // consumer deletion
+        consumerService()
+            .deleteConsumer(context, groupId, name);
     }
 
     @Test
@@ -118,6 +122,11 @@ public class SeekTest extends HttpBridgeTestBase {
                     });
                     consumerInstanceDontHaveTopic.complete(true);
                 });
+
+        // consumer deletion
+        consumerService()
+            .deleteConsumer(context, groupId, name);
+
         consumerInstanceDontHaveTopic.get(TEST_TIMEOUT, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This PR gonna add some deletions to the tests where we are creating consumers and didn't delete them. In some cases the tests failed because the consumer was already created, so the response from Bridge was different than expected.