### PR TITLE
Fix cors

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -48,9 +48,10 @@ import java.util.Iterator;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderNames.ORIGIN;
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
 import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN;
 import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS;
 
@@ -193,10 +194,13 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         Set<String> allowedHeaders = new HashSet<>();
         //set predefined headers
         allowedHeaders.add("x-requested-with");
+        allowedHeaders.add("x-forwarded-proto");
+        allowedHeaders.add("x-forwarded-host");
         allowedHeaders.add(ACCESS_CONTROL_ALLOW_ORIGIN.toString());
         allowedHeaders.add(ACCESS_CONTROL_ALLOW_METHODS.toString());
         allowedHeaders.add(ORIGIN.toString());
         allowedHeaders.add(CONTENT_TYPE.toString());
+        allowedHeaders.add(CONTENT_LENGTH.toString());
         allowedHeaders.add(ACCEPT.toString());
 
         //set allowed methods from property http.cors.allowedMethods

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeTestBase.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeTestBase.java
@@ -57,7 +57,7 @@ public abstract class HttpBridgeTestBase {
     protected static final int PERIODIC_MAX_MESSAGE = 10;
     protected static final int PERIODIC_DELAY = 1000;
     protected static final int MULTIPLE_MAX_MESSAGE = 10;
-    protected static  final int TEST_TIMEOUT = 60;
+    protected static final int TEST_TIMEOUT = 60;
     protected int count;
 
     public static StrimziKafkaContainer kafkaContainer = null;


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Because we use `routerFacotry`, we need to use CORS handler a little bit differently.
I have no idea how the tests passed before.

Fixes https://github.com/strimzi/strimzi-kafka-bridge/issues/465