### PR TITLE
Update the OAuth library to 0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<swagger2markup.version>1.3.7</swagger2markup.version>
 		<jackson-core.version>2.10.2</jackson-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
-		<strimzi-oauth.version>0.5.0</strimzi-oauth.version>
+		<strimzi-oauth.version>0.6.1</strimzi-oauth.version>
 		<jaeger.version>1.1.0</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.12</opentracing-kafka-client.version>
@@ -38,6 +38,10 @@
 			<name>Strimzi Kafka Container repository</name>
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
 		</repository>
+        <repository>
+            <id>staging</id>
+            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1078</url>
+        </repository>
 	</repositories>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,6 @@
 			<name>Strimzi Kafka Container repository</name>
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
 		</repository>
-        <repository>
-            <id>staging</id>
-            <url>https://oss.sonatype.org/content/repositories/iostrimzi-1078</url>
-        </repository>
 	</repositories>
 
 	<dependencies>


### PR DESCRIPTION
This PR updates the Strimzi OAuth library to 0.6.1 which contains some updated dependencies to address CVEs.