### PR TITLE
Fixed test-container using its own version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<micrometer.version>1.3.9</micrometer.version>
 		<jmx-prometheus-collector.version>0.12.0</jmx-prometheus-collector.version>
 		<commons-cli.version>1.4</commons-cli.version>
+		<test-container.version>0.20.0-SNAPSHOT</test-container.version>
 	</properties>
 
 	<repositories>
@@ -181,6 +182,12 @@
 			<version>2.6.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.strimzi</groupId>
+			<artifactId>test-container</artifactId>
+			<version>${test-container.version}</version>
+			<scope>test</scope>
+		</dependency>
 		<!-- for AMQP test only	-->
 		<dependency>
 			<groupId>io.debezium</groupId>
@@ -194,11 +201,6 @@
 			<version>${debezium.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.strimzi</groupId>
-			<artifactId>test-container</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 
 		<!-- Transitive dependency version overrides for Vulnerabilities: -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,8 @@
 		<micrometer.version>1.3.9</micrometer.version>
 		<jmx-prometheus-collector.version>0.12.0</jmx-prometheus-collector.version>
 		<commons-cli.version>1.4</commons-cli.version>
-		<test-container.version>0.20.0-SNAPSHOT</test-container.version>
+		<test-container.version>0.19.0</test-container.version>
 	</properties>
-
-	<repositories>
-		<repository>
-			<id>test-container</id>
-			<name>Strimzi Kafka Container repository</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</repository>
-	</repositories>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Currently, the `test-container` version is tight to the bridge version which is wrong because this component is released within the Strimzi operator so it has to use the operator version.
This PR fixes this, using its own versioning for the `test-container`.
As raised offline by @scholzj we can use 0.20.0-SNAPSHOT version and it means using Kafka 2.6.0 or using the latest released 0.19.0 version but testing using Kafka 2.5.0. I went on the first way first but then decided to use the latest stable release because having a SNAPSHOT dependency is not so great.