### PR TITLE
move statictests to integration-test phase

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -20,8 +20,8 @@ fi
 echo "Run docu check ..."
 make docu_check
 
-echo "Packaging ..."
-make java_package
+echo "Verifying ..."
+make java_verify
 
 echo "PULL_REQUEST=$PULL_REQUEST"
 echo "TAG=$TAG"

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,28 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
+				<configuration>
+					<excludes>
+						<exclude>**/*StaticTests.java</exclude>
+					</excludes>
+				</configuration>
+				<executions>
+					<execution>
+						<id>integration-test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<phase>integration-test</phase>
+						<configuration>
+							<excludes>
+								<exclude>none</exclude>
+							</excludes>
+							<includes>
+								<include>**/*StaticTests.java</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Signed-off-by: Aki Yoshida <elakito@gmail.com>

Moving StaticTests out of test phase and into integration-test phase.
As a result, mvn clean install will execute all tests except StaticTests and create the package jar and then execute StaticTests.
This should fix https://github.com/strimzi/strimzi-kafka-bridge/issues/388.
 