### PR TITLE
Completed rate-limiting and content-based routing extensions

### DIFF
--- a/ADDED_README.md
+++ b/ADDED_README.md
@@ -1,0 +1,212 @@
+
+# 1 CONTENT-BASED ROUTING
+
+### 1.1 Purpose and overview
+The purpose of content-based routing is to dynamically determine to which topic do the messages, issued to the bridge in order to be written to the Kafka cluster, belong to. This functionality can be accessed by making POST requests to the `/topics` route. In other words, this is an alternative to making POST requests to the `/topics/{foo}` route in which the topic (`foo` in this case) is not determined by the client but by the bridge itself.
+
+The routing adheres to the rules that the user specifies in a JSON configuration file, which is passed to the bridge in the `.spec.cbrConfigMap` field of the YAML file that generates the bridge. More precisely, in this field the user needs to specify the name of the Kubernetes ConfigMap that contains the JSON configuration - see section 1.4. If the `.spec.cbrConfigMap` field is omitted or some error occurs while fetching the content of the ConfigMap (e.g. a ConfigMap with the provided name does not exist, the JSON configuration does not have the required format, etc.), the functionality is disabled and attempts to make POST requests to the `/topics` route will result in a `400: BAD REQUEST` error.
+
+### 1.2 Writing content based routing configuration files
+There are two possibilities for the routing configuration file:
+
+* The first option is for the JSON file to only contain the name of the class, that alone takes care of routing. In such a case, the configuration must contain the following fields:
+    1. `custom-class` (required): the name of the class that contains the `getTopic(...)` method that is invoked in order to determine the topic, to which the messages belong to - see section 1.3;
+    2. `url` (required): URL with the format `{IP_ADDRESS}:{PORT}/{ROUTE}`, on which the ZIP file that contains all the necessary classes, including the `custom-class` class, can be downloaded.
+
+    An example of such a configuration is the following:
+	```
+	{
+		"custom-class": "com.boris.test.Router",
+		"url": "http://192.168.1.14:9090/topRouter.zip"
+   	}
+	```
+
+	Explanation of the example: the bridge downloads the `topRouter.zip` file, which is available on `http://192.168.1.14:9090/topRouter.zip`, and extracts it. After that, each time the bridge receives a `POST` request issued to the `/topics` route, the `getTopic(...)` method of the `com.boris.test.Router` class is invoked. The method returns a String that determines to which topic should the messages be written to. For example if the method returns `foo`, the messages are written to the `foo` topic (see section 1.4). Note that all the topics should manually be created beforehand;
+	
+* Alternatively, the JSON file contains (optionally) a set of custom rules (`custom-rules`) and (required) a default topic (`default-topic`). Each custom rule contains, apart from a (required) `topic` field, also (required) a non-empty array of conditions (`conditions`), and in order for the custom rule to be applied, all the condition specified inside of it must be satisfied. A condition has one of the following formats:
+  
+	1. Contains (required) `header-name`, (optionally) `header-value` and (optionally) `exists`. The first determines the HTTP header, that is going to be considered by the condition, while the second determines the value, expressed as a regular expression, that the value of the header needs to match; `exists` is by default `true`, and should be set to `false` when the condition requires that the `header-name` header should not be present. If `exists` is set to `false`, the `header-value` field **must** be omitted. **BEWARE**: headers without a value are removed by the parser, so if the request contains the header `foo: `, the header is completely ignored;
+	2. Contains `custom-class` and `url` - the purpose of these two is identical as above: `url` is the URL with the format `{IP_ADDRESS}:{PORT}/{ROUTE}`, on which the ZIP file that contains all the necessary classes, including the `custom-class` class, can be downloaded. `custom-class` identifies the name of the class, that contains the `isSatisfied(...)` method. This method is invoked each time a request is received and should return `true` if the condition is satisfied and `false` otherwise - see section 1.3.
+
+	In other words, when we wish to consider only the HTTP headers for routing, there is just the need to specify the name and the value of the considered HTTP headers, while if we wish to carry out any other type of routing, we need to provide custom classes.
+	Apart from the list of routing rules, the configuration must also contain a `default-topic`, which represents the topic, to which messages should be written to if none of the rules can be applied. The default topic, as well as the topic fields contained in the custom rules, can contain the following properties:
+ 
+	1. `topic-name` (required): name of the topic, to which messages should be routed. The topic is automatically created (if it does not exist already); 
+	3. `replicationFactor` (optional): replication factor of the topic. This parameter is going to be considered only if the `topic-name` topic does not exist prior to the launch of the bridge;
+	4. `replicationFactor` (optional): number of partitions of the topic. This parameter is going to be considered only if the `topic-name` topic does not exist prior to the launch of the bridge;
+
+	An example of a possible configuration is the following:
+	```
+	{
+		"custom-rules": [{
+				"conditions": [
+					{
+					  "header-name": "X-Custom-Header",
+					  "value": ".*(sun|fog|cloud|wind|rain).*"
+					}
+				],
+				"topic": {
+					"topic-name": "weather_discussion",
+					"replicationFactor": 1,
+					"partitionNumber": 1
+				}
+			}
+		],
+		"default-topic": {
+			"topic-name": "random_discussion",
+		  	"replicationFactor": 1,
+		  	"partitionNumber": 1
+		}
+	}
+	```
+
+	Explanation of the example: if the HTTP request issued to the `/topics` route contains the `X-Custom-Header` header **and** if the value of this header contains inside of it either of the following words (`sun`, `fog`, `cloud`, `wind`, or `rain`), the message is written to the `weather_discussion` topic. If this topic still needs to be created, it is created with replication factor of one and only one partition. All the other messages, i.e. those without the `X-Custom-Header` header and those whose value of the `X-Custom-Header` header does not contain the above mentioned words, are going to be written to the `random_discussion` topic.
+
+The schema to which the content-based routing configuration file needs to apply is shown in `config/cbr_schema_validation.json`.
+	
+### 1.3 Custom routing
+In the case you specified to use custom classes, you are required to group all the classes, that are necessary for the routing process, inside of a ZIP file and make it available over the network. The Bridge Pods will automatically download the ZIP file, extract its content and use it for routing. Depending on which type of routing you wish to use (see above), you need to specify a class that contains one of the following methods:
+* `public boolean isSatisfied(Map<String, String> headers, String body)`: the parameter `body` contains the body of the HTTP message, encoded with the UTF8 encoding. The method must return `true` if the condition is satisfied and `false` otherwise;
+* `public String getTopic(Map<String, String> headers, String body)`: the parameter `body` contains the body of the HTTP message, encoded with the UTF8 encoding. The method must return a String representing the name of the topic the message belong to. Note that all topics should be created beforehand. 
+
+### 1.4 Deployment on kubernetes
+The following procedure is valid for minikube, but a similar procedure has been tested also on GKE.
+
+1. Start minikube;
+2. Follow the steps as in https://strimzi.io/docs/operators/latest/quickstart.html to set up the Strimzi operators, the Kafka cluster, zookeeper (use the YAML files available in `/install/cluster-operator`). **Bewere**: you must deploy the extended version of the cluster controller, available now on GitHub (https://github.com/BorisRado/strimzi-kafka-operator) and DockerHub (borisrado/operator:latest);
+3. Create the ConfigMap that contains the JSON configuration. For convenience, the JSON configuration should be the only entry of the ConfigMap. For example you can write the JSON configuration in the `schema_example.json` file and later on create the ConfigMap with the command `kubectl create configmap myCbrConfigMap --from-file schema_example.json -n kafka`. **Beware**: the ConfigMap must be in the same namespace as the Bridge Pods;
+4. Deploy the Bridge with two additions: use the `borisrado/kafka-bridge` as the image (`.spec.image`), and set the `.spec.cbrConfigMap` field to contain the name of the ConfigMap that contains the configuration. In the case you created the ConfigMap with the command described in point 3., the YAML file should resemble something like this: ```
+	apiVersion: kafka.strimzi.io/v1alpha1
+	kind: KafkaBridge
+	metadata:
+		name: strimzi
+		labels:
+			app: my-bridge
+	spec:
+		replicas: 2
+		image: borisrado/kafka-bridge
+		cbrConfigMap: myCbrConfigMap
+		bootstrapServers: my-cluster-kafka-bootstrap:9092
+  	http:
+		port: 8080
+   ```
+5. You can now issue requests to the `/topics` route. The topic will be determined by the bridge itself. Other routes are in no way influenced (e.g. sending messages to `/topics/foo` route will still write the messages to the `foo` topic).
+When you update the configuration file or change the name of the `.spec.cbrConfigMap` field, the cluster controller will take over and perform a rolling release, so that the existing Pods will be shut down and a set of new ones with the new configuration will be launched.
+
+### 1.5 Possible responses
+* `400: BAD REQUEST`: is returned when the client tries to access to the `/topics` route when such option is not enabled (either on purpose or because some error occurred while fetching the ConfigMap);
+* All the other responses returned when issuing requests to the `/topics/{foo}` route. Note only that `200: OK` responses contain also the name of the topic, to which the messages have been written to, see the example below:
+  ```
+	{
+		"offsets": [
+			{
+				"partition":0,
+				"offset":2
+			},
+			{
+				"partition":0,
+				"offset":3
+			}
+		],
+		"topic": "random_discussion"
+	}
+  ```
+  
+
+# 2 RATE LIMITING
+### 2.1 Purpose and overview
+The general aim of rate limiting is to prevent the Kafka cluster from being overwhelmed by a large amount of messages, fact that might cause disruptions. The rate limiting check is limited to the process of writing messages to the brokers (i.e. no limits are in place when it comes to reading messages from the Kafka cluster).
+
+The rate limiting adheres to the rules that the user specifies in a JSON configuration file, which is passed to the bridge in the `.spec.rlConfigMap` field of the YAML file that generates the bridge. More precisely, in this field the user needs to specify the name of the Kubernetes ConfigMap that contains the JSON configuration - see section 2.3. If the `.spec.rlConfigMap` field is omitted or some error occurs while fetching the content of the ConfigMap (e.g. a ConfigMap with the provided name does not exist, the JSON configuration does not have the required format, etc.), the functionality is disabled and no limits are in place.
+
+When the limit has not been exceeded by the client, the responses of the bridge contain some of the following headers:
+1. `X-Limit-Seconds`: the number of records a client is allowed to write within a second. This header is present only if the number of requests a client is allowed to perform is limited on a seconds basis (e.g. a client is allowed to write maximum 10 messages per second);
+2. `X-Limit-Minutes`: the number of records a client is allowed to write within a minute. This header is present only if the number of requests a client is allowed to perform is limited on a minutes basis (e.g. a client is allowed to write maximum 10 messages per minute);
+3. `X-Limit-Hours`: the number of records a client is allowed to write within an hour. This header is present only if the number of requests a client is allowed to perform is limited on an hour basis (e.g. a client is allowed to write maximum 10 messages per hour);
+4. `X-Limit-Remaining`: the number of records a client is still allowed to write to the topic until the limit is renowned.
+When rate limiting is in place, at least one among `X-Limit-Seconds`, `X-Limit-Minutes` and `X-Limit-Hours` is present, while `X-Limit-Remaining` is always present.
+
+Once the limit is reached, `429: TOO MANY REQUESTS` response is returned and the messages have no follow-ups. The responses contain in such cases the `X-Millis-Until-Refill` header, which informs the client about the time, expressed in milliseconds, until when the limit is renowned (until that time, the client is not allowed to write messages to that topic).
+
+The token bucket algorithm is used.
+
+### 2.2 Writing rate-limiting configuration files
+The rate-limiting configuration file contains an array of topic-limits. Each topic-limit contains:
+* `topic` (optional): name of the topic, to which the limit is being applied. In the case this parameter is missing, the limit is applied to all the topics but the ones with their own limits;
+* `strategy` (optional): which strategy to use, either `local` (pods keep private to themselves the data concerning rate limiting, so the outcome of the rate-limiting process varies depending on which pod does handle the request) or `global` (pods share data concerning rate-limiting through a hazelcast cluster). The strategy should be set to `global` when there is the need for the rate limiting check to be precise. By default, this parameter is set to `local`;
+* `limits` (required): non-empty array of limits. Each limit can contain the following parameters: 
+	* `seconds` (optional): number of messages the client is allowed to write within a second;
+	* `minutes`(optional): number of messages the client is allowed to write within a minute;
+	* `hours` (optional): number of messages the client is allowed to write within an hour;
+	* `group-by-header` (optional): the name of the header whose value uniquely identifies the client. If this parameter is missing, clients are identified by their IP address;
+	* `header-name` (optional): name of the header, that contains additional information about the client. For example it might state to which tier does the user belong to. This allows us for example to differentiate between clients in the free and in the premium tier;
+	* `header-value` (optional): the value that the `header-name` header needs to match in order for the limit to be applied. This parameter cannot be set if the `header-name` parameter is missing;
+	Note that at least one of the `seconds`, `minutes` and `hours` parameters must be present.
+
+A limit is applied to the request if both these conditions are satisfied:
+1. the request contains the `header-name` header and its value matches the `header-value` **OR** the limit does not contain the `header-name` parameter;
+2. the request contains the `group-by-header` header **OR** if the limit does not contain the `group-by-header` parameter.
+
+The schema to which the rate-limiting rules need to apply is shown in `config/rl_schema_validation.json`.
+
+Here is an example of a possible configuration:
+```
+[
+	{
+		"topic": "weather_discussion",
+		"limits": [
+			{
+				"minutes": 3,
+				"group-by-header": "X-Consumer-Username",
+				"header-name": "X-Consumer-Groups",
+				"header-value": "free-acl-tier"
+			},
+			{
+				"minutes": 6,
+				"group-by-header": "X-Consumer-Username",
+				"header-name": "X-Consumer-Groups",
+				"header-value": "premium-acl-tier"
+			},
+			{
+				"minutes": 1
+			}
+		]
+	},
+	{
+		"strategy": "global",
+		"limits": [
+			{
+				"minutes": 5,
+				"group-by-header": "X-Consumer-Username"
+			},
+			{
+				"minutes": 2
+			}
+		]
+	}
+]
+```
+**Explanation of the example**: users that attach the `X-Consumer-Username` header to their request are the authenticated users. If the requests of the authenticated users contains the `X-Consumer-Groups` header and if the value of this header has the value `free-acl-tier`, the client is allowed to write up to 3 records per minute to the `weather_discussion` topic. If the value of the `X-Consumer-Groups` header is `premium-acl-tier`, clients are given a 6 records per minute quota. All the other clients (i.e. the not authenticated ones, the ones that do not attach the `X-Consumer-Groups` header to the request and the ones whose value of the `X-Consumer-Groups` header does not match the two values mentioned above), are given a default, 1 record per minute quota. The local strategy is used. On the other hand, when writing messages to any other topic but the `weather_discussion` one, the global strategy is used; authenticated users are allowed to write up to 5 messages per minute, while all the others are given a default, 2 requests per minute quota.
+
+**Bewere**: the order in which the limits are listed does matter. The most specific limit must be the first, the least specific must be the last. 
+
+### 2.3 Deployment on minikube
+The following procedure is valid for minikube, but a similar procedure has been tested also on GKE.
+
+1. Start minikube;
+2. Follow the steps as in https://strimzi.io/docs/operators/latest/quickstart.html to set up the Strimzi operators, the Kafka cluster, zookeeper (use the YAML files available in `/install/cluster-operator`). **Bewere**: you must deploy the extended version of the cluster controller, available now on GitHub (https://github.com/BorisRado/strimzi-kafka-operator) and DockerHub (borisrado/operator:latest);
+3. Create the ConfigMap that contains the JSON configuration. For convenience, the JSON configuration should be the only entry of the ConfigMap. For example you can write the JSON configuration in the `rl_example.json` file and later on create the ConfigMap with the command `kubectl create configmap myRlConfigMap --from-file rl_example.json -n kafka`. Of course, the ConfigMap must be in the same namespace as the bridge pods;
+4. Deploy the Bridge with two additions: use the `borisrado/kafka-bridge` as the image (`.spec.image`), and set the `.spec.rlConfigMap` field to contain the name of the ConfigMap that contains the rate limiting configuration. In the case you created the ConfigMap with the command described in point 3, you should write `rlConfigMap: myRlConfigMap`;
+5. Rate limiting should be now in place.
+
+When you update the configuration file or change the name of the `.spec.rlConfigMap` field, the cluster controller will take over and perform a rolling release, so that the existing pods will be shut down and a set of new ones with the new configuration will be launched.
+
+### 2.4 Possible responses
+* `429: TOO MANY REQUESTS`: is returned when the client has reached the maximum number of requests. The response contains the `X-Millis-Until-Refill` header, that informs the client about the time, expressed in milliseconds, it needs to wait until the limit is renowned;
+* `403: FORBIDDEN`: is returned when the number of messages inside of the same HTTP requests exceeds the maximum number of allowed messages, which happens for example when a client tries to write a batch of 10 messages to the `foo` topic, but it is allowed to write only 5 requests per second to this topic;
+* All the other responses returned when issuing requests to the `/topics/{foo}` and `/topics` route. Note only responses are going to contain the headers as explained in section 2.1.
+
+### Limitations
+Current limitations:
+* The Hazelcast cluster needs some time to spin up;
+* Limited to token bucker algorithm.

--- a/config/cbr_schema_validation.json
+++ b/config/cbr_schema_validation.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/product.schema.json",
+  "title": "RoutingRules",
+  "oneOf": [
+    {
+      "description": "Set of routing rules",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "custom-rules": {
+          "description": "Set of rules, with which the request is matched.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "conditions": {
+                "description": "All the conditions need to match in order for the rule to be applied",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "header-name": {
+                          "type": "string",
+                          "minLength": 2
+                        },
+                        "exists": {
+                          "type": "boolean",
+                          "description": "If set to false, the condition is fulfilled if the header is missing.",
+                          "default": "true"
+                        },
+                        "header-value": {
+                          "type": "string",
+                          "minLength": 2,
+                          "description": "regex to which the header must match in order for the condition to be fulfilled"
+                        }
+                      },
+                      "required": [
+                        "header-name"
+                      ],
+                      "if": {
+                        "properties": {
+                          "exists": {
+                            "const": false
+                          }
+                        },
+                        "required": [
+                          "exists"
+                        ]
+                      },
+                      "then": {
+                        "not": {
+                          "required": [
+                            "header-value"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "custom-class": {
+                          "type": "string",
+                          "description": "Name of the class, that implements the RoutingConditionInterface interface.",
+                          "minLength": 3
+                        },
+                        "url": {
+                          "type": "string",
+                          "minLength": 3,
+                          "description": "URL from which it is possible to downlaod a .zip file that contains all the jars required for your content routing"
+                        }
+                      },
+                      "required": [
+                        "custom-class",
+                        "url"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "topic": {
+                "description": "Topic to which messages will be written to if the rule is triggered",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "topic-name"
+                ],
+                "properties": {
+                  "topic-name": {
+                    "minLength": 3,
+                    "maxLength": 20,
+                    "type": "string"
+                  },
+                  "replicationFactor": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10
+                  },
+                  "partitionNumber": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 7
+                  }
+                }
+              }
+            },
+            "required": [
+              "topic",
+              "conditions"
+            ]
+          }
+        },
+        "default-topic": {
+          "description": "Topic to which messages will be written to if none of the rules can be applied",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "topic-name": {
+              "minLength": 3,
+              "maxLength": 20,
+              "type": "string"
+            },
+            "replicationFactor": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10
+            },
+            "partitionNumber": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 7
+            }
+          },
+          "required": [
+            "topic-name"
+          ]
+        }
+      },
+      "required": [
+        "default-topic"
+      ]
+    },
+    {
+      "description": "Custom class that returns the topic name",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "minLength": 3
+        },
+        "custom-class": {
+          "type": "string",
+          "minLength": 3
+        }
+      },
+      "required": [
+        "url",
+        "custom-class"
+      ]
+    }
+  ]
+}

--- a/config/rl_schema_validation.json
+++ b/config/rl_schema_validation.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/product.schema.json",
+  "title": "RateLimiting",
+  "description": "Rate limiting rules",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "limits"
+    ],
+    "properties": {
+      "topic": {
+        "type": "string",
+        "minLength": 2
+      },
+      "strategy": {
+        "type": "string",
+        "enum": [
+          "global",
+          "local"
+        ],
+        "default": "local"
+      },
+      "limits": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "anyOf": [
+            {
+              "required": [
+                "seconds"
+              ]
+            },
+            {
+              "required": [
+                "minutes"
+              ]
+            },
+            {
+              "required": [
+                "hours"
+              ]
+            }
+          ],
+          "dependencies": {
+            "header-value": [
+              "header-name"
+            ],
+            "header-name": [
+              "header-value"
+            ]
+          },
+          "properties": {
+            "seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Max number of allowed requests in a second."
+            },
+            "minutes": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Max number of allowed requests in a minute"
+            },
+            "hours": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Max number of allowed requests in an hour"
+            },
+            "header-name": {
+              "type": "string",
+              "minLength": 2,
+              "description": "header name, that is used to differentiate between different type of users (e.g. premium, free tier, etc.). If present, the header-value must be set too"
+            },
+            "header-value": {
+              "type": "string",
+              "minLength": 2,
+              "description": "regex to match to the actual header value. If this parameter is missing it is enough for the header-name to be present. If present, header-name must be set too"
+            },
+            "group-by-header": {
+              "type": "string",
+              "minLength": 2,
+              "description": "The value of this header will be used in order to aggregate clients. By default is ignored (only IP address is considered)"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<micrometer.version>1.3.1</micrometer.version>
 		<jmx-prometheus-collector.version>0.12.0</jmx-prometheus-collector.version>
 		<commons-cli.version>1.4</commons-cli.version>
+		<bucket4j.version>4.10.0</bucket4j.version>
 	</properties>
 
 	<repositories>
@@ -205,6 +206,43 @@
 			<artifactId>test-container</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		
+		<!-- Dependency for json validation -->
+        <dependency>
+            <groupId>org.everit.json</groupId>
+            <artifactId>org.everit.json.schema</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+        
+        <!-- Hazelcast dependencies -->
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-hazelcast</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-kubernetes</artifactId>
+            <version>1.5.4</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
+        <!-- bucket4j dependencies -->
+        <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>${bucket4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>bucket4j-hazelcast-3</artifactId>
+            <version>${bucket4j.version}</version>
+        </dependency>
+        
 	</dependencies>
 
 	<pluginRepositories>

--- a/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
@@ -9,7 +9,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import io.strimzi.kafka.bridge.amqp.AmqpConfig;
+import io.strimzi.kafka.bridge.contentRouting.RoutingPolicy;
 import io.strimzi.kafka.bridge.http.HttpConfig;
+import io.strimzi.kafka.bridge.rateLimiting.RateLimitingPolicy;
 
 /**
  * Bridge configuration properties
@@ -24,6 +26,8 @@ public class BridgeConfig extends AbstractConfig {
     private KafkaConfig kafkaConfig;
     private AmqpConfig amqpConfig;
     private HttpConfig httpConfig;
+    private RoutingPolicy routingPolicy;
+    private RateLimitingPolicy rateLimitingPolicy;
 
     /**
      * Constructor
@@ -85,6 +89,8 @@ public class BridgeConfig extends AbstractConfig {
                 ",kafkaConfig=" + this.kafkaConfig +
                 ",amqpConfig=" + this.amqpConfig +
                 ",httpConfig=" + this.httpConfig +
+                ",rlConfig=" + this.rateLimitingPolicy +
+                ",cbrConfig=" + this.routingPolicy +
                 ")";
     }
 
@@ -102,5 +108,21 @@ public class BridgeConfig extends AbstractConfig {
         } else {
             return config.get(BridgeConfig.TRACING_TYPE).toString();
         }
+    }
+    
+    public void setRoutingPolicy(RoutingPolicy routingPolicy) {
+        this.routingPolicy = routingPolicy;
+    }
+    
+    public RoutingPolicy getRoutingPolicy() {
+        return this.routingPolicy;
+    }
+    
+    public void setRateLimitingPolicy(RateLimitingPolicy rateLimitingPolicy) {
+        this.rateLimitingPolicy = rateLimitingPolicy;
+    }
+    
+    public RateLimitingPolicy getRateLimitingPolicy() {
+        return this.rateLimitingPolicy;
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/CheckConditionThread.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/CheckConditionThread.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+public class CheckConditionThread implements Runnable {
+
+    private boolean satisfaction = false;
+    private Object condition;
+    private Map<String, String> headers;
+    private String body;
+
+    public CheckConditionThread(CustomClassLoader cll, Object condition, Map<String, String> headers,
+            String body) throws InterruptedException {
+        try {
+            this.headers = headers;
+            this.body = body;
+            this.condition = condition;
+            Thread thread = new Thread(this, "CustomRuleCheckingThread");
+            thread.setContextClassLoader(cll);
+            thread.start();
+            thread.join();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    @Override
+    public void run() {
+        try {
+            Method method = condition.getClass().getMethod("isSatisfied", Map.class, String.class);
+            this.satisfaction = (boolean) method.invoke(condition, headers, body);
+        } catch (NoSuchMethodException | SecurityException e) {
+            // these exceptions should not happen for we already checked that everything is working fine
+            e.printStackTrace();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    
+    public boolean getSatisfaction() {
+        return this.satisfaction;
+    }
+
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/ContentRouter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/ContentRouter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import java.util.Map;
+
+import io.vertx.ext.web.RoutingContext;
+
+public class ContentRouter {
+        
+    public static String getTopic(Map<String, String> headers, RoutingContext routingContext, 
+            RoutingPolicy routingPolicy) {
+
+        if (routingPolicy.getCustomClassLoader() == null) {
+            
+            // use routing rules
+            RoutingRule[] routingRules = routingPolicy.getRoutingRules();
+            
+            if (routingRules == null) {
+                return routingPolicy.getDefaultTopic().getTopicName();
+            }
+            
+            for (int i = 0; i < routingRules.length; i++) {
+                if (routingRules[i].isSatisfied(headers, routingContext)) {
+                    return routingRules[i].getRuleTopic();
+                }
+            }
+            return routingPolicy.getDefaultTopic().getTopicName();            
+        } else {
+            // use custom class to determine topic
+            try {
+                GetTopicNameThread thread = new GetTopicNameThread(routingPolicy.getCustomClassLoader(), 
+                        routingPolicy.getCustomClassObject(), headers, routingContext.getBodyAsString());
+                return thread.getTopicName();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/CustomClassLoader.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/CustomClassLoader.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html). 
+ */
+
+/**
+ * Many thanks to Isuru Weerarathna for this terrific article:
+ * https://medium.com/@isuru89/java-a-child-first-class-loader-cbd9c3d0305
+ * Most of the code in this class is taken from his code.
+ */
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+public class CustomClassLoader extends URLClassLoader {
+    private final ClassLoader sysClzLoader;
+
+    public CustomClassLoader(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+        sysClzLoader = getSystemClassLoader();
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        
+        Class<?> loadedClass = findLoadedClass(name);
+        if (loadedClass == null) {
+            try {
+                loadedClass = findClass(name);
+            } catch (ClassNotFoundException e) {
+                loadedClass = super.loadClass(name, resolve);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        if (resolve) {
+            resolveClass(loadedClass);
+        }
+        return loadedClass;
+    }
+
+
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        List<URL> allRes = new LinkedList<URL>();
+
+        Enumeration<URL> sysResources = sysClzLoader.getResources(name);
+        if (sysResources != null) {
+            while (sysResources.hasMoreElements()) {
+                allRes.add(sysResources.nextElement());
+            }
+        }
+
+        Enumeration<URL> thisRes = findResources(name);
+        if (thisRes != null) {
+            while (thisRes.hasMoreElements()) {
+                allRes.add(thisRes.nextElement());
+            }
+        }
+        final List<URL> finalList = new LinkedList(allRes);
+
+        Enumeration<URL> parentRes = super.findResources(name);
+        if (parentRes != null) {
+            while (parentRes.hasMoreElements()) {
+                allRes.add(parentRes.nextElement());
+            }
+        }
+
+        return new Enumeration<URL>() {
+            Iterator<URL> it = finalList.iterator();
+
+            @Override
+            public boolean hasMoreElements() {
+                return it.hasNext();
+            }
+
+            @Override
+            public URL nextElement() {
+                return it.next();
+            }
+        };
+    }
+
+    @Override
+    public URL getResource(String name) {
+        URL res = null;
+        if (sysClzLoader != null) {
+            res = sysClzLoader.getResource(name);
+        }
+        if (res == null) {
+            res = findResource(name);
+        }
+        if (res == null) {
+            res = super.getResource(name);
+        }
+        return res;
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/DependencyLoader.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/DependencyLoader.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.strimzi.kafka.bridge.Application;
+
+public class DependencyLoader {
+
+    private static final String TEMP_ZIP_FILE = "/tmp/downloadingZip.zip";
+    private static final Logger log = LoggerFactory.getLogger(Application.class);
+    private static Map<String, CustomClassLoader> map = new HashMap<String, CustomClassLoader>();
+    private static final String JAR_EXTENSION = ".jar";
+
+    /**
+     * 
+     * @param sourceUrl the the URL at which the ZIP file can be downloaded
+     * @param customClass name of the custom class
+     * @param destDirString is the name of the folder to which the ZIP file is going to be extracted
+     * @param isCondition is set to true if the class only checks for a condition. If set to false, the class is meant to return the name of a topic
+     * @return instance of the custom class `customClass`
+     * @throws Exception
+     */
+    public static Object createObject(String sourceUrl, String customClass, String destDirString, boolean isCondition) 
+            throws Exception {
+
+        
+        // if a folder with the same name exists already, delete it (it might happen only if some error occurred when downloading other zip files)
+        File destDir = new File(destDirString);
+        deleteFolder(destDir);
+
+        try {
+            URL[] classUrls;
+            CustomClassLoader cll;
+
+            if (map.containsKey(sourceUrl)) {
+                
+                // the ZIP file has already been downloaded
+                cll = map.get(sourceUrl);
+                log.info(sourceUrl + " was already downlaoded");
+                
+            } else {
+            
+                // create the directory, in which the content of the ZIP file is going to be extracted
+                destDir.mkdir();
+                
+                //download zip archive from provided url
+                downloadFromUrl(new URL(sourceUrl));
+                
+                // zip archive is downloaded to TEMP_ZIP_FILE, we can unzip it
+                classUrls = unzipArchive(destDir);
+                cll = new CustomClassLoader(classUrls, null);
+                map.put(sourceUrl, cll);
+                
+                // delete the temp zip archive
+                new File(TEMP_ZIP_FILE).delete();
+                
+            }
+            
+            Class<?> clazz = cll.loadClass(customClass);
+            
+            if (isCondition) {
+                Object condition = clazz.newInstance();
+                
+                clazz.getMethod("isSatisfied", Map.class, String.class);
+                log.info("Class " + clazz.getCanonicalName() + " successfully instantiated");
+                
+                return condition;
+            } else {
+                Object router = clazz.newInstance();
+                clazz.getMethod("getTopic", Map.class, String.class);
+                log.info("Class " + clazz.getCanonicalName() + " successfully instantiated");
+                
+                return router;
+            }
+
+        } catch (Exception e) {
+            deleteFolder(destDir);
+            Files.deleteIfExists(new File(TEMP_ZIP_FILE).toPath());
+            throw e;
+        }
+    }
+
+    private static void downloadFromUrl(URL downloadUrl) throws Exception {
+
+        ReadableByteChannel readableByteChannel = Channels.newChannel(downloadUrl.openStream());
+        FileOutputStream fileOutputStream = new FileOutputStream(TEMP_ZIP_FILE);
+        FileChannel fileChannel = fileOutputStream.getChannel();
+        fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+
+        fileOutputStream.close();
+        fileChannel.close();
+
+    }
+
+    private static URL[] unzipArchive(File destDir) throws Exception {
+
+        ArrayList<URL> classUrls = new ArrayList<URL>();
+
+        byte[] buffer = new byte[1024];
+        ZipInputStream zis = new ZipInputStream(new FileInputStream(TEMP_ZIP_FILE));
+        ZipEntry zipEntry = zis.getNextEntry();
+        while (zipEntry != null) {
+            File newFile = newFile(destDir, zipEntry);
+            
+            if (getFileExtension(newFile.getName()).equals(JAR_EXTENSION)) {
+                classUrls.add(new URL("file:" + destDir + "/" + newFile.getName()));
+            }
+            FileOutputStream fos = new FileOutputStream(newFile);
+            int len;
+            while ((len = zis.read(buffer)) > 0) {
+                fos.write(buffer, 0, len);
+            }
+            fos.close();
+            zipEntry = zis.getNextEntry();
+        }
+        zis.closeEntry();
+        zis.close();
+        URL[] urlsArray = new URL[classUrls.size()];
+        urlsArray = classUrls.toArray(urlsArray);
+        return urlsArray;
+
+    }
+
+    private static File newFile(File destinationDir, ZipEntry zipEntry) throws Exception {
+        File destFile = new File(destinationDir, zipEntry.getName());
+
+        String destDirPath = destinationDir.getCanonicalPath();
+        String destFilePath = destFile.getCanonicalPath();
+
+        if (!destFilePath.startsWith(destDirPath + File.separator)) {
+            throw new Exception("Entry is outside of the target dir: " + zipEntry.getName());
+        }
+
+        return destFile;
+    }
+    
+    public static void deleteFolder(File destDir) {
+        if (destDir.exists()) {
+            String[] files = destDir.list();
+            for (String f : files) {
+                File currentFile = new File(destDir.getPath(), f);
+                currentFile.delete();
+            }
+            destDir.delete();                
+        }
+    }
+    
+    private static String getFileExtension(String name) {
+        return name.substring(name.length() - 4);
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/GetTopicNameThread.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/GetTopicNameThread.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+public class GetTopicNameThread implements Runnable {
+
+    private String topicName;
+    private Object customObject;
+    private Map<String, String> headers;
+    private String body;
+    
+    public GetTopicNameThread(CustomClassLoader cll, Object customObject, Map<String, String> headers,
+            String body) throws InterruptedException {
+        try {
+            this.headers = headers;
+            this.body = body;
+            this.customObject = customObject;
+            Thread thread = new Thread(this, "GetTopicNameThread");
+            thread.setContextClassLoader(cll);
+            thread.start();
+            thread.join();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    @Override
+    public void run() {
+        try {
+            Method method = customObject.getClass().getMethod("getTopic", Map.class, String.class);
+            this.topicName = (String) method.invoke(customObject, headers, body);
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.topicName = null;
+        }
+    }
+    
+    public String getTopicName() {
+        return this.topicName;
+    }
+
+
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/RoutingConditionInterface.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/RoutingConditionInterface.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import java.util.Map;
+
+public interface RoutingConditionInterface {
+
+    public boolean isSatisfied(Map<String, String> headers, String body);
+    
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/RoutingConfigurationParameters.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/RoutingConfigurationParameters.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+
+/**
+ * 
+ * @author BorisRado
+ *
+ *
+ * README: if the same topic is defined multiple times, the configuration that is going to be used for initialization is the following:
+ *  - the default topic always
+ *  - the first definition proposed inside the custom-rules
+ */
+@SuppressWarnings("checkstyle:MemberName")
+public class RoutingConfigurationParameters {
+    
+    public static final String CUSTOM_RULES_DEF = "custom-rules";
+    public static final String RULE_TOPIC_DEF = "topic";
+    public static final String DEFAULT_TOPIC_DEF = "default-topic";
+    public static final String TOPIC_REPLICATION_FACTOR_DEF = "replicationFactor";
+    public static final String TOPIC_NUM_OF_PARTITIONS_DEF = "partitionNumber";
+    public static final String TOPIC_NAME_DEF = "topic-name";
+    public static final String RULE_HEADER_NAME_DEF = "header-name";
+    public static final String RULE_HEADER_VALUE_DEF = "header-value";
+    public static final String RULE_CONDITIONS_DEF = "conditions";
+    public static final String RULE_HEADER_EXISTS_DEF = "exists";
+    public static final String RULE_CUSTOM_CLASS = "custom-class";
+    public static final String CUSTOM_CLASS_URL = "url";
+    
+    
+    public static final int DEFAULT_NUMBER_OF_PARTITIONS = 3;
+    public static final int DEFAULT_REPLICATION_FACTOR = 3;
+    
+    
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/RoutingPolicy.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/RoutingPolicy.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Properties;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.strimzi.kafka.bridge.Application;
+
+@SuppressWarnings("checkstyle:MemberName")
+public class RoutingPolicy {
+    
+    private static final Logger log = LoggerFactory.getLogger(Application.class);
+    
+    private Topic defaultTopic;
+    private RoutingRule[] routingRules;
+    
+    Object customClassObject;
+    CustomClassLoader customClassLoader;
+    
+    public RoutingPolicy(JSONObject policy, HashMap<String, Topic> allTopics) throws Exception {
+        
+        if (policy.has(RoutingConfigurationParameters.CUSTOM_CLASS_URL)) {
+            
+            // the user provided a class that alone takes care of routing
+            String targetFolder = new File(Application.class.getProtectionDomain()
+                    .getCodeSource()
+                    .getLocation()
+                    .toURI())
+                    .getParent() + "/custom_class/";
+            
+            this.customClassObject = DependencyLoader.createObject(policy.getString(RoutingConfigurationParameters.CUSTOM_CLASS_URL), 
+                    policy.getString(RoutingConfigurationParameters.RULE_CUSTOM_CLASS), 
+                    targetFolder,
+                    false);
+            this.customClassLoader = (CustomClassLoader) customClassObject.getClass().getClassLoader();
+            
+        } else {
+        
+            // the configuration is composed of routing rules and a default topic. The custom class only checks a condition
+            this.defaultTopic = new Topic(policy.getJSONObject(RoutingConfigurationParameters.DEFAULT_TOPIC_DEF));
+            allTopics.put(this.defaultTopic.getTopicName(), this.defaultTopic);
+            
+            if (policy.optJSONArray(RoutingConfigurationParameters.CUSTOM_RULES_DEF) != null) {
+                JSONArray rulesArray = policy.getJSONArray(RoutingConfigurationParameters.CUSTOM_RULES_DEF);
+                int numOfRules = rulesArray.length();
+                this.routingRules = new RoutingRule[numOfRules];
+                for (int i = 0; i < numOfRules; i++) {
+                    try {
+                        routingRules[i] = new RoutingRule(rulesArray.getJSONObject(i), allTopics);
+                    } catch (Exception e) {
+                        throw e;
+                    }
+                }
+            }
+        }
+    }
+    
+    public CustomClassLoader getCustomClassLoader() {
+        return this.customClassLoader;
+    }
+    
+    public Object getCustomClassObject() {
+        return this.customClassObject;
+    }
+    
+    public Topic getDefaultTopic() {
+        return this.defaultTopic;
+    }
+    
+    public RoutingRule[] getRoutingRules() {
+        return this.routingRules;
+    }
+    
+    public static void createTopics(HashMap<String, Topic> allTopics, String bootstrapServers) 
+            throws Exception {
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(AdminClientConfig.RETRIES_CONFIG, 5);
+        AdminClient adminClient = null;
+        
+        try {
+            adminClient = AdminClient.create(props);
+            
+            ArrayList<NewTopic> newTopicsList = new ArrayList<NewTopic>();
+            for (Topic t : allTopics.values()) {
+                newTopicsList.add(new NewTopic(t.getTopicName(), t.getNumOfPartitions(), (short) t.getReplicationFactor()));
+            }
+            CreateTopicsResult res = adminClient.createTopics(newTopicsList);
+            res.all().get();
+            log.info("Topics from the routing policy successfully created.");
+
+        } catch (Exception e) {
+            if (e.getCause() instanceof TopicExistsException) {
+                log.info("Some topics from the routing policy exist already");
+            } else {
+                throw e;
+            }
+        } finally {
+            if (adminClient != null) {
+                adminClient.close();
+            }
+        }
+        
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/RoutingRule.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/RoutingRule.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import io.strimzi.kafka.bridge.Application;
+import io.vertx.ext.web.RoutingContext;
+
+
+@SuppressWarnings("checkstyle:MemberName")
+public class RoutingRule {
+
+    private Object[] ruleConditionObjects;
+    private Topic topic;
+    private static int customClassId = 0;
+    private CustomClassLoader[] customClassLoaders;
+    
+    public RoutingRule(JSONObject ruleDefinitionObject, HashMap<String, Topic> allTopics) throws Exception {
+        
+        JSONObject topicDefinitionObject = ruleDefinitionObject.getJSONObject(RoutingConfigurationParameters.RULE_TOPIC_DEF);
+        String topicName = topicDefinitionObject.getString(RoutingConfigurationParameters.TOPIC_NAME_DEF);
+        addTopicToList(topicName, allTopics, topicDefinitionObject);
+
+        JSONArray conditionsDefinitionArray = ruleDefinitionObject.getJSONArray(RoutingConfigurationParameters.RULE_CONDITIONS_DEF);
+        this.ruleConditionObjects = new Object[conditionsDefinitionArray.length()];
+        this.customClassLoaders = new CustomClassLoader[conditionsDefinitionArray.length()];
+
+        for (int i = 0; i < ruleConditionObjects.length; i++) {
+            JSONObject currentObject = conditionsDefinitionArray.getJSONObject(i);
+            
+            if (currentObject.opt(RoutingConfigurationParameters.RULE_HEADER_NAME_DEF) != null) {
+                // provided only-header-looking strategy is used. The CustomClassLoader is set to null
+                ruleConditionObjects[i] = new RuleCondition(currentObject);
+                customClassLoaders[i] = null;
+                
+            } else {
+                
+                // a custom class checks whether the condition is satisfied or not
+                try {
+                    String targetFolder = new File(Application.class.getProtectionDomain()
+                            .getCodeSource()
+                            .getLocation()
+                            .toURI())
+                            .getParent() + "/" + Integer.toString(customClassId) + "/";
+                    
+                    ruleConditionObjects[i] = DependencyLoader.createObject(
+                            currentObject.getString(RoutingConfigurationParameters.CUSTOM_CLASS_URL), 
+                            currentObject.getString(RoutingConfigurationParameters.RULE_CUSTOM_CLASS), 
+                            targetFolder,
+                            true);
+                    customClassLoaders[i] = (CustomClassLoader) ruleConditionObjects[i].getClass().getClassLoader();                                        
+                    
+                    customClassId++;
+                } catch (Exception e) {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    private void addTopicToList(String topicName, HashMap<String, Topic> allTopics, JSONObject topicDefinitionObject) {
+        
+        // if a topic with this name has already been defined, don't add the topic to the HashMap
+        if (allTopics.containsKey(topicName)) {
+            this.topic = allTopics.get(topicName);
+        } else {
+            this.topic = new Topic(topicDefinitionObject);
+            allTopics.put(topicName, this.topic);
+        }
+        
+    }
+
+    public RuleCondition[] getRuleConditions() {
+        return this.getRuleConditions();
+    }
+
+    public String getRuleTopic() {
+        return this.topic.getTopicName();
+    }
+
+    public boolean isSatisfied(Map<String, String> headers, RoutingContext routingContext) {
+        for (int i = 0; i < this.ruleConditionObjects.length; i++) {
+            if (this.customClassLoaders[i] == null && !((RuleCondition) this.ruleConditionObjects[i]).isSatisfied(headers, routingContext.getBodyAsString())) {
+                return false;
+            } else if (this.customClassLoaders[i] != null) {
+                CheckConditionThread clt;
+                try {
+                    clt = new CheckConditionThread(this.customClassLoaders[i], this.ruleConditionObjects[i], headers, routingContext.getBodyAsString());
+                    if (!clt.getSatisfaction()) {
+                        return false;
+                    }
+                } catch (InterruptedException e) {
+                    // some error occurred. We decide a priori that the condition is not satisfied
+                    e.printStackTrace();
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/RuleCondition.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/RuleCondition.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.json.JSONObject;
+
+@SuppressWarnings("checkstyle:MemberName")
+public class RuleCondition implements RoutingConditionInterface {
+
+    private String conditionHeaderName, conditionHeaderValue;
+    private Boolean conditionHeaderExists;
+
+    public RuleCondition(JSONObject condition) {
+        this.conditionHeaderName = condition.getString(RoutingConfigurationParameters.RULE_HEADER_NAME_DEF);
+        
+        // set that by default the header existence is true
+        if (condition.has(RoutingConfigurationParameters.RULE_HEADER_EXISTS_DEF)) {
+            this.conditionHeaderExists = condition.getBoolean(RoutingConfigurationParameters.RULE_HEADER_EXISTS_DEF);            
+        } else {
+            this.conditionHeaderExists = true;
+        }
+        
+        this.conditionHeaderValue = condition.optString(RoutingConfigurationParameters.RULE_HEADER_VALUE_DEF);
+    }
+
+    @Override
+    public boolean isSatisfied(Map<String, String> headers, String body) {
+        
+        if (this.conditionHeaderExists) {
+            boolean containsHeader = headers.containsKey(this.conditionHeaderName);
+            String headerValue = headers.get(this.conditionHeaderName);
+            return containsHeader && Pattern.matches(this.conditionHeaderValue, headerValue);
+        } else {
+            return !headers.containsKey(this.conditionHeaderName);
+        }
+    }
+
+
+}

--- a/src/main/java/io/strimzi/kafka/bridge/contentRouting/Topic.java
+++ b/src/main/java/io/strimzi/kafka/bridge/contentRouting/Topic.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+
+package io.strimzi.kafka.bridge.contentRouting;
+
+import org.json.JSONObject;
+
+public class Topic {
+    
+    private String topicName;
+    private int numOfPartitions;
+    private int replicationFactor;
+    
+    public Topic(JSONObject userDefinedTopic) {
+        this.topicName = userDefinedTopic.getString(RoutingConfigurationParameters.TOPIC_NAME_DEF);
+        this.numOfPartitions = userDefinedTopic.optInt(RoutingConfigurationParameters.TOPIC_NUM_OF_PARTITIONS_DEF) == 0 ?
+                RoutingConfigurationParameters.DEFAULT_NUMBER_OF_PARTITIONS : userDefinedTopic.getInt(RoutingConfigurationParameters.TOPIC_NUM_OF_PARTITIONS_DEF);
+        this.replicationFactor = userDefinedTopic.optInt(RoutingConfigurationParameters.TOPIC_REPLICATION_FACTOR_DEF) == 0 ?
+                RoutingConfigurationParameters.DEFAULT_REPLICATION_FACTOR : userDefinedTopic.getInt(RoutingConfigurationParameters.TOPIC_REPLICATION_FACTOR_DEF);
+    }
+    
+    public String getTopicName() {
+        return this.topicName;
+    }
+    
+    public int getNumOfPartitions() {
+        return this.numOfPartitions;
+    }
+    
+    public int getReplicationFactor() {
+        return this.replicationFactor;
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
@@ -15,6 +15,9 @@ import java.util.stream.Collectors;
  */
 public class HttpConfig extends AbstractConfig {
 
+    private static final String ENV_ROUTING_CONFIG_MAP_NAME = "ROUTING_CONFIG_MAP";
+    private static final String ENV_RATE_LIMITING_CONFIG_MAP_NAME = "RATE_LIMITING_CONFIG_MAP";
+
     public static final String HTTP_CONFIG_PREFIX = "http.";
 
     public static final String HTTP_ENABLED = HTTP_CONFIG_PREFIX + "enabled";
@@ -29,6 +32,9 @@ public class HttpConfig extends AbstractConfig {
     public static final String DEFAULT_HOST = "0.0.0.0";
     public static final int DEFAULT_PORT = 8080;
     public static final long DEFAULT_CONSUMER_TIMEOUT = -1L;
+
+    private boolean errorWhileRateLimiting = false;
+    private boolean errorWhileContentRouting = false;
 
     /**
      * Constructor
@@ -87,6 +93,34 @@ public class HttpConfig extends AbstractConfig {
     public String getCorsAllowedMethods() {
         return (String) this.config.getOrDefault(HTTP_CORS_ALLOWED_METHODS, "GET,POST,PUT,DELETE,OPTIONS,PATCH");
     }
+    
+    /**
+     * @return if content based routing is enabled
+     */
+    public boolean isRoutingEnabled() {
+        if (System.getenv().containsKey(ENV_ROUTING_CONFIG_MAP_NAME) && !this.errorWhileContentRouting) {
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * @return if content rate  limiting is enabled
+     */
+    public boolean isRateLimitingEnabled() {
+        if (System.getenv().containsKey(ENV_RATE_LIMITING_CONFIG_MAP_NAME) && !this.errorWhileRateLimiting) {
+            return true;
+        }
+        return false;
+    }
+    
+    public String getEnvironmentRlConfigMapName() {
+        return ENV_RATE_LIMITING_CONFIG_MAP_NAME;
+    }
+    
+    public String getEnvironmentCbrConfigMapName() {
+        return ENV_ROUTING_CONFIG_MAP_NAME;
+    }
 
     /**
      * Loads HTTP related configuration parameters from a related map
@@ -106,5 +140,13 @@ public class HttpConfig extends AbstractConfig {
         return "HttpConfig(" +
                 "config=" + this.config +
                 ")";
+    }
+    
+    public void setErrorWhileRateLimiting() {
+        this.errorWhileRateLimiting = true;
+    }
+    
+    public void setErrorWhileContentRouting() {
+        this.errorWhileContentRouting = true;
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -11,6 +11,7 @@ package io.strimzi.kafka.bridge.http;
 public enum HttpOpenApiOperations {
 
     SEND("send"),
+    SEND_WITH_CBR_RULES("sendWithCbrRules"),
     SEND_TO_PARTITION("sendToPartition"),
     CREATE_CONSUMER("createConsumer"),
     DELETE_CONSUMER("deleteConsumer"),

--- a/src/main/java/io/strimzi/kafka/bridge/rateLimiting/BucketDate.java
+++ b/src/main/java/io/strimzi/kafka/bridge/rateLimiting/BucketDate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+
+package io.strimzi.kafka.bridge.rateLimiting;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import io.github.bucket4j.Bucket;
+
+public class BucketDate {
+    
+    Optional<Bucket> bucket;
+    LocalDateTime lastAccessTime;
+    
+    public BucketDate(Optional<Bucket> bucket) {
+        this.bucket = bucket;
+        this.lastAccessTime = null;
+    }
+    
+    public LocalDateTime getLastAccessTime() {
+        return this.lastAccessTime;
+    }
+    
+    public void setLocalDate() {
+        this.lastAccessTime = LocalDateTime.now();
+    }
+    
+    public Optional<Bucket> getOptionalBucket() {
+        return this.bucket;
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/rateLimiting/CleanLocalMapThread.java
+++ b/src/main/java/io/strimzi/kafka/bridge/rateLimiting/CleanLocalMapThread.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.rateLimiting;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CleanLocalMapThread implements Runnable {
+
+    private Map<String, BucketDate> locaBuckets;
+    private int evictionTime;
+    
+    private static final Logger log = LoggerFactory.getLogger(CleanLocalMapThread.class);
+
+    
+    public CleanLocalMapThread(Map<String, BucketDate> localBuckets, int evictionTime) {
+        this.locaBuckets = localBuckets;
+        this.evictionTime = evictionTime;
+
+        LoggerFactory.getLogger(CleanLocalMapThread.class).info("Eviction time for Map (LOCAL RL): " + evictionTime);
+        Thread thread = new Thread(this, "LocalBucketMapCleanerDaemon");
+        thread.start();
+        
+    }
+    
+    @Override
+    public void run() {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                Thread.sleep(Duration.ofSeconds(40).toMillis());
+                synchronized (locaBuckets) {
+                    log.info("Cleaning local buckets map...");
+                    for (Map.Entry<String, BucketDate> bucketDate : locaBuckets.entrySet()) {
+                        
+                        Duration difference = Duration.between(bucketDate.getValue().getLastAccessTime(), LocalDateTime.now());
+                        if (difference.getSeconds() > evictionTime) {
+                            locaBuckets.remove(bucketDate.getKey());
+                        }
+                    }
+                    log.info("Local map cleaned");
+                    locaBuckets.notifyAll();
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RateLimitSingleLimit.java
+++ b/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RateLimitSingleLimit.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.rateLimiting;
+
+import org.json.JSONObject;
+
+public class RateLimitSingleLimit {
+    
+    private int limitSeconds;
+    private int limitMinutes;
+    private int limitHours;
+    private String headerName;
+    private String headerValue;
+    private boolean ignoreIp;
+    private String groupByHeaderName;
+    
+    public RateLimitSingleLimit(JSONObject jsonLimit) {
+        this.limitSeconds = jsonLimit.optInt(RateLimitingParameters.RL_SECOND_LIMIT) > 0 ?
+                jsonLimit.getInt(RateLimitingParameters.RL_SECOND_LIMIT) : -1;
+        this.limitMinutes = jsonLimit.optInt(RateLimitingParameters.RL_MINUTE_LIMIT) > 0 ?
+                jsonLimit.getInt(RateLimitingParameters.RL_MINUTE_LIMIT) : -1;
+        this.limitHours = jsonLimit.optInt(RateLimitingParameters.RL_HOUR_LIMIT) > 0 ?
+                jsonLimit.getInt(RateLimitingParameters.RL_HOUR_LIMIT) : -1;
+                
+        this.headerName = jsonLimit.optString(RateLimitingParameters.RL_HEADER_NAME);
+        this.headerValue = jsonLimit.optString(RateLimitingParameters.RL_HEADER_VALUE);
+        
+        if (jsonLimit.has(RateLimitingParameters.RL_HEADER_AGGREGATION)) {
+            ignoreIp = true;
+            this.groupByHeaderName = jsonLimit.optString(RateLimitingParameters.RL_HEADER_AGGREGATION);            
+        } else {
+            this.groupByHeaderName = "";
+            ignoreIp = false;
+        }
+    }
+    
+    public String getHeaderName() {
+        return this.headerName;
+    }
+    
+    public String getHeaderPattern() {
+        return this.headerValue;
+    }
+    
+    public int getLimitSeconds() {
+        return this.limitSeconds;
+    }
+
+    public int getLimitMinutes() {
+        return this.limitMinutes;
+    }
+    
+    public int getLimitHours() {
+        return this.limitHours;
+    }
+    
+    public boolean getIgnoreIp() {
+        return this.ignoreIp;
+    }
+    
+    public String getHeaderAggregation() {
+        return this.groupByHeaderName;
+    }
+    
+}

--- a/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RateLimiting.java
+++ b/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RateLimiting.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.rateLimiting;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.strimzi.kafka.bridge.BridgeContentType;
+import io.strimzi.kafka.bridge.converter.MessageConverter;
+import io.strimzi.kafka.bridge.http.HttpSourceBridgeEndpoint;
+import io.strimzi.kafka.bridge.http.HttpUtils;
+import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Bucket4j;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.ConfigurationBuilder;
+import io.github.bucket4j.ConsumptionProbe;
+import io.github.bucket4j.Refill;
+import io.github.bucket4j.local.LocalBucket;
+import io.github.bucket4j.local.LocalBucketBuilder;
+
+@SuppressWarnings("checkstyle:ParameterNumber")
+public class RateLimiting {
+
+    private static final int TOPIC_GLOBAL = 0;
+    private static final int TOPIC_LOCAL = 1;
+    private static final int DEFAULT_GLOABAL = 2;
+    private static final int DEFAULT_LOCAL = 3;
+
+    private static final String IGNORE_IP = "_ignore_ip_";
+    private static final String IGNORE_HEADER = "_ignore_header_";
+
+    public static void allowRequest(HttpSourceBridgeEndpoint<?, ?> bridge, RoutingContext routingContext, String topic) {
+
+        Optional<RateLimitSingleLimit> singleLimit;
+        String ipAddress = routingContext.request().remoteAddress().host();
+        Map<String, String> headers = bridge.getHeaders();
+
+        long numOfTokens = getNumberOfTokens(routingContext, bridge, topic);
+        if (numOfTokens == -1) {
+            return;
+        }
+
+        RateLimitingPolicy rateLimitingPolicy = bridge.getRateLimitingPolicy();
+
+        switch (getRateLimitingStrategy(rateLimitingPolicy, topic)) {
+            case TOPIC_GLOBAL:
+                singleLimit = getSingleLimit(rateLimitingPolicy.getLimits().get(topic), headers);
+                allowRequestGlobalStrategy(routingContext, topic, ipAddress, bridge, numOfTokens, singleLimit, true, headers);
+                break;
+            case TOPIC_LOCAL:
+                singleLimit = getSingleLimit(rateLimitingPolicy.getLimits().get(topic), headers);
+                allowRequestLocalStrategy(routingContext, topic, ipAddress, bridge, numOfTokens, singleLimit, true, headers);
+                break;
+            case DEFAULT_GLOABAL:
+                singleLimit = getSingleLimit(rateLimitingPolicy.getDefaultLimitInstance(), bridge.getHeaders());
+                allowRequestGlobalStrategy(routingContext, topic, ipAddress, bridge, numOfTokens, singleLimit, false, headers);
+                break;
+            case DEFAULT_LOCAL:
+                singleLimit = getSingleLimit(rateLimitingPolicy.getDefaultLimitInstance(), bridge.getHeaders());
+                allowRequestLocalStrategy(routingContext, topic, ipAddress, bridge, numOfTokens, singleLimit, false, headers);
+                break;
+            default:
+                bridge.sendMessagesToTopic(routingContext, topic);
+                break;
+        }
+    }
+
+    private static void allowRequestGlobalStrategy(RoutingContext routingContext, String topic, String ipAddress, 
+            HttpSourceBridgeEndpoint<?, ?> bridge, long numOfTokens, Optional<RateLimitSingleLimit> limit, 
+            boolean includeTopicInBucketName, Map<String, String> headers) {
+
+        if (limit.isPresent()) {
+            // the request should be rate limited, we can give for granted that some limit (sec/min) exists
+            String bucketName = getBucketName(limit.get(), topic, headers, ipAddress, includeTopicInBucketName);
+
+            Supplier<BucketConfiguration> supplier = getSupplier(limit.get(), headers);
+            Bucket requestBucket = bridge.getGlobalBuckets().getProxy(bucketName, supplier);
+            Bandwidth[] bandwidths = supplier.get().getBandwidths();
+            long bucketCapacity = getBucketCapacity(bandwidths, routingContext);
+            if (bucketCapacity < numOfTokens) {
+                HttpUtils.sendResponse(routingContext, HttpResponseStatus.FORBIDDEN.code(), 
+                        BridgeContentType.JSON, getTooManyTokensErrorMessage(topic, bucketCapacity));
+            } else {
+                CompletableFuture.supplyAsync(() -> requestBucket.asAsync().tryConsumeAndReturnRemaining(numOfTokens))
+                    .thenAccept(result -> {
+                        try {
+                            processRateLimitingResults(result.get(), routingContext, topic, bridge);
+                        } catch (InterruptedException | ExecutionException e) {
+                            e.printStackTrace();
+                            HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(), 
+                                    BridgeContentType.JSON, new JsonObject().toBuffer());
+                        }
+                    });        
+            }            
+        } else {
+            bridge.sendMessagesToTopic(routingContext, topic);
+        }
+    }
+    
+    private static void allowRequestLocalStrategy(RoutingContext routingContext, String topic, String ipAddress, 
+            HttpSourceBridgeEndpoint<?, ?> bridge, long numOfTokens, Optional<RateLimitSingleLimit> limit, 
+            boolean includeTopicInBucketName, Map<String, String> headers) {
+        if (limit.isPresent()) {
+            String bucketName = getBucketName(limit.get(), topic, headers, ipAddress, includeTopicInBucketName);
+            BucketDate bucketDate = bridge.getLocalBuckets().computeIfAbsent(bucketName, key -> buildNewBucket(limit.get(), headers));
+            bucketDate.setLocalDate();
+            LocalBucket requestBucket = (LocalBucket) bucketDate.getOptionalBucket().get();
+            Bandwidth[] bandwidths = requestBucket.getConfiguration().getBandwidths();
+            long bucketCapacity = getBucketCapacity(bandwidths, routingContext);
+            if (bucketCapacity < numOfTokens) {
+                HttpUtils.sendResponse(routingContext, HttpResponseStatus.FORBIDDEN.code(), BridgeContentType.JSON, 
+                        getTooManyTokensErrorMessage(topic, bucketCapacity));
+            } else {
+                ConsumptionProbe probe = requestBucket.tryConsumeAndReturnRemaining(numOfTokens);
+                processRateLimitingResults(probe, routingContext, topic, bridge);
+            }
+        } else {
+            bridge.sendMessagesToTopic(routingContext, topic);
+        }
+    }
+
+    public static void processRateLimitingResults(ConsumptionProbe probe, RoutingContext routingContext, String topic, 
+            HttpSourceBridgeEndpoint<?, ?> bridge) {
+        long nanosToWait = probe.getNanosToWaitForRefill();
+        if (nanosToWait > 0) {
+            routingContext.response().putHeader("X-Millis-Until-Refill", Integer.toString((int) Math.ceil(nanosToWait / 1_000_000)));
+        }
+        if (probe.isConsumed()) {
+            routingContext.response().putHeader("X-Limit-Remaining", Long.toString(probe.getRemainingTokens()));
+            bridge.sendMessagesToTopic(routingContext, topic);
+        } else {
+            HttpUtils.sendResponse(routingContext, HttpResponseStatus.TOO_MANY_REQUESTS.code(), 
+                    BridgeContentType.JSON, getTooManyRequestsErrorMessage(topic, probe.getNanosToWaitForRefill()));
+        }
+    }
+
+    private static BucketDate buildNewBucket(RateLimitSingleLimit singleLimit, Map<String, String> headers) {
+        LocalBucketBuilder builder = Bucket4j.builder();
+        addLimit(singleLimit.getLimitSeconds(), singleLimit.getLimitMinutes(), singleLimit.getLimitHours(), builder);
+        return new BucketDate(Optional.of(builder.build()));
+    }
+
+    private static Supplier<BucketConfiguration> getSupplier(RateLimitSingleLimit singleLimit, Map<String, String> headers) {
+        ConfigurationBuilder configurationBuilder = Bucket4j.configurationBuilder();
+        addLimit(singleLimit.getLimitSeconds(), singleLimit.getLimitMinutes(), singleLimit.getLimitHours(), configurationBuilder);
+        return () -> configurationBuilder.build();                
+    }
+
+    /**
+     * 
+     * @return the RateLimitSingleLimit that applies to the request or an empty Optional if no limit applies to it
+     */
+    private static Optional<RateLimitSingleLimit> getSingleLimit(TopicLimit limit, Map<String, String> headers) {
+        for (RateLimitSingleLimit currentLimit : limit.getLimits()) {
+            String header = currentLimit.getHeaderName();
+            String aggregationHeader = currentLimit.getHeaderAggregation();
+            if (header.length() == 0) {
+                if ((aggregationHeader.length() > 0 && headers.containsKey(aggregationHeader)) || aggregationHeader.length() == 0) {
+                    return Optional.of(currentLimit);
+                }
+            } else if (header.length() > 0 && headers.containsKey(header)) {
+                String pattern = currentLimit.getHeaderPattern();
+                Matcher matcher = Pattern.compile(pattern).matcher(headers.get(header));
+                if (matcher.find()) {
+                    if ((aggregationHeader.length() > 0 && headers.containsKey(aggregationHeader)) || aggregationHeader.length() == 0) {
+                        return Optional.of(currentLimit);
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static void addLimit(int limitSeconds, int limitMinutes, int limitHours, ConfigurationBuilder configurationBuilder) {
+        if (limitSeconds > 0) {
+            configurationBuilder.addLimit(Bandwidth.classic(limitSeconds, 
+                    Refill.intervally(limitSeconds, Duration.ofSeconds(1))).withInitialTokens(limitSeconds));
+        }
+        if (limitMinutes > 0) {
+            configurationBuilder.addLimit(Bandwidth.classic(limitMinutes, 
+                    Refill.intervally(limitMinutes, Duration.ofMinutes(1))).withInitialTokens(limitMinutes));
+        }
+        if (limitHours > 0) {
+            configurationBuilder.addLimit(Bandwidth.classic(limitHours, 
+                    Refill.intervally(limitHours, Duration.ofHours(1))).withInitialTokens(limitHours));
+        }
+    }
+
+    private static void addLimit(int limitSeconds, int limitMinutes, int limitHours, LocalBucketBuilder localBucketBuilder) {
+        if (limitSeconds > 0) {
+            localBucketBuilder.addLimit(Bandwidth.classic(limitSeconds, 
+                    Refill.intervally(limitSeconds, Duration.ofSeconds(1))).withInitialTokens(limitSeconds));
+        }
+        if (limitMinutes > 0) {
+            localBucketBuilder.addLimit(Bandwidth.classic(limitMinutes, 
+                    Refill.intervally(limitMinutes, Duration.ofMinutes(1))).withInitialTokens(limitMinutes));
+        }
+        if (limitHours > 0) {
+            localBucketBuilder.addLimit(Bandwidth.classic(limitHours, 
+                    Refill.intervally(limitHours, Duration.ofHours(1))).withInitialTokens(limitHours));
+        }
+        
+    }
+
+    private static Buffer getTooManyRequestsErrorMessage(String topic, long nanosToWait) {
+        return new JsonObject().put("error", "too many requests")
+                .put("X-Topic", topic)
+                .put("X-Millis-Until-Refill", (int) Math.ceil(nanosToWait / 1_000_000))
+                .toBuffer();
+    }
+
+    private static Buffer getTooManyTokensErrorMessage(String topic, long maximum) {
+        return new JsonObject()
+                .put("X-Error", "The number of messages you tried to write exceeds the bucket capacity")
+                .put("X-Topic", topic)
+                .put("X-BucketCapacity", maximum)
+                .toBuffer();
+    }
+
+    // returns the smallest capacity of the bucket
+    private static long getBucketCapacity(Bandwidth[] bandwidths, RoutingContext routingContext) {
+        long capacity = Long.MAX_VALUE;
+        for (Bandwidth bandwidth : bandwidths) {
+            long period = bandwidth.getRefillPeriodNanos();
+            if (period == TimeUnit.SECONDS.toNanos(1)) {
+                routingContext.response().putHeader("X-Limit-Seconds", Long.toString(bandwidth.getCapacity()));
+            } else if (period == TimeUnit.MINUTES.toNanos(1)) {
+                routingContext.response().putHeader("X-Limit-Minutes", Long.toString(bandwidth.getCapacity()));
+            } else if (period == TimeUnit.HOURS.toNanos(1)) {
+                routingContext.response().putHeader("X-Limit-Hours", Long.toString(bandwidth.getCapacity()));
+            }
+            capacity = Long.min(capacity, bandwidth.getCapacity());            
+        }
+        return capacity;
+    }
+    
+    private static String getBucketName(RateLimitSingleLimit limit, String topic, Map<String, String> headers, 
+            String ipAddress, boolean includeTopic) {
+        String aggregationHeaderName = limit.getHeaderAggregation();
+        ipAddress = limit.getIgnoreIp() ? IGNORE_IP : ipAddress;
+        String aggregationHeaderValue = aggregationHeaderName.length() == 0 ? IGNORE_HEADER : headers.get(aggregationHeaderName);
+        String temp = ipAddress + aggregationHeaderValue;
+        return includeTopic ? temp + "_" + topic : temp;
+    }
+
+    private static int getRateLimitingStrategy(RateLimitingPolicy rateLimitingPolicy, String topic) {
+        if (rateLimitingPolicy.getLimits().containsKey(topic) && rateLimitingPolicy.getLimits().get(topic).isGlobal()) {
+            return TOPIC_GLOBAL;
+        } else if (rateLimitingPolicy.getLimits().containsKey(topic)) {
+            return TOPIC_LOCAL;
+        } else if (rateLimitingPolicy.getDefaultLimitInstance() != null && rateLimitingPolicy.getDefaultLimitInstance().isGlobal()) {
+            return DEFAULT_GLOABAL;
+        } else if (rateLimitingPolicy.getDefaultLimitInstance() != null) {
+            return DEFAULT_LOCAL;
+        }
+        return -1;
+    }
+
+    private static long getNumberOfTokens(RoutingContext routingContext, HttpSourceBridgeEndpoint<?, ?> bridge, String topic) {
+        MessageConverter<?, ?, Buffer, Buffer> messageConverter = bridge.getMessageConverter();
+        if (messageConverter == null) {
+            HttpBridgeError error = new HttpBridgeError(
+                    HttpResponseStatus.INTERNAL_SERVER_ERROR.code(), HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
+            HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                    BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+            return -1;
+        }
+        return (long) bridge.getMessageConverter().toKafkaRecords(topic, null, routingContext.getBody()).size();
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RateLimitingParameters.java
+++ b/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RateLimitingParameters.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+
+package io.strimzi.kafka.bridge.rateLimiting;
+
+public class RateLimitingParameters {
+
+    public static final String RL_TOPIC_NAME = "topic";
+    public static final String RL_SECOND_LIMIT = "seconds";
+    public static final String RL_MINUTE_LIMIT = "minutes";
+    public static final String RL_HOUR_LIMIT = "hours";
+    public static final String RL_STRATEGY = "strategy";
+    public static final String RL_GLOBAL_STRATEGY = "global";
+    public static final String RL_HEADER_NAME = "header-name";
+    public static final String RL_HEADER_VALUE = "header-value";
+    public static final String RL_LIMITS_ARRAY = "limits";
+    public static final String RL_HEADER_AGGREGATION = "group-by-header";
+    
+    
+}

--- a/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RateLimitingPolicy.java
+++ b/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RateLimitingPolicy.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+
+package io.strimzi.kafka.bridge.rateLimiting;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class RateLimitingPolicy {
+
+    private Map<String, TopicLimit> limits;
+    private TopicLimit defaultLimitInstance = null;
+    private boolean usesGlobalRL = false;
+    private boolean usesLocalRL = false;
+    private boolean usesHourWindowsLocalRl = false;
+    private boolean usesHourWindowsGlobalRl = false;
+    
+    public RateLimitingPolicy(JSONArray arrayTopicLimits) {
+        
+        limits = new HashMap<String, TopicLimit>();
+        
+        for (int i = 0; i < arrayTopicLimits.length(); i++) {
+            JSONObject currentLimit = arrayTopicLimits.getJSONObject(i);
+            TopicLimit newTopicLimit = new TopicLimit(currentLimit);
+            String topicName = currentLimit.optString("topic");
+            if (topicName.length() > 0 && !limits.containsKey(topicName)) {
+                limits.put(topicName, newTopicLimit);
+            } else if (topicName.length() == 0 && defaultLimitInstance == null) {
+                defaultLimitInstance = newTopicLimit;
+            }
+            if (newTopicLimit.isGlobal()) {
+                this.usesGlobalRL = true;
+                if (newTopicLimit.usesHourWindows()) {
+                    usesHourWindowsGlobalRl = true;
+                }
+            } else {
+                this.usesLocalRL = true;
+                if (newTopicLimit.usesHourWindows()) {
+                    usesHourWindowsLocalRl = true;
+                }
+            }
+        }
+    }
+    
+    public Map<String, TopicLimit> getLimits() {
+        return this.limits;
+    }
+    
+    public TopicLimit getDefaultLimitInstance() {
+        return this.defaultLimitInstance;
+    }
+    
+    public boolean usesGlobalRL() {
+        return this.usesGlobalRL;
+    }
+    
+    public boolean usesLocalRL() {
+        return this.usesLocalRL;
+    }
+    
+    public int getWindowTimeGlobalRl() {
+        if (this.usesHourWindowsGlobalRl) {
+            return 3650;
+        } else {
+            return 70;
+        }
+    }
+    
+    public int getWindowTimeLocalRl() {
+        if (this.usesHourWindowsLocalRl) {
+            return 3650;
+        } else {
+            return 70;
+        }
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RlDeploymentOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/rateLimiting/RlDeploymentOperations.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.rateLimiting;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.LoggerFactory;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+
+import io.github.bucket4j.Bucket4j;
+import io.github.bucket4j.grid.GridBucketState;
+import io.github.bucket4j.grid.ProxyManager;
+import io.strimzi.kafka.bridge.config.BridgeConfig;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+public class RlDeploymentOperations {
+    
+    private static final String BUCKET_MAP = "bucket-map";
+    
+    
+    /*
+     * returns the namespace in which the bridge pods are in. The value is retrieved from the filesystem of the pods
+     */
+    private static String getPodNamespace() {
+        String namespace;
+        try {            
+            namespace = new String(Files.readAllBytes(Paths.get("/var/run/secrets/kubernetes.io/serviceaccount/namespace")));
+        } catch (Exception e) {
+            namespace = "";
+            e.printStackTrace();
+        }
+        return namespace;
+        
+    }
+    
+    
+    /*
+     * generate the configuration of the hazelcast cluster
+     */
+    private static Config getHazelcastConfig(int evictionTime) {
+        Config hazelcastConfig = new Config();
+        hazelcastConfig.getNetworkConfig().setPort(5701);
+        
+        hazelcastConfig.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        
+        hazelcastConfig.getNetworkConfig().getJoin().getKubernetesConfig().setEnabled(true)
+            .setProperty("namespace", getPodNamespace())
+            .setProperty("resolve-not-ready-addresses", "true")
+            .setProperty("service-name", "bridge-hazelcast-service")
+            .setProperty("service-port", "5701");
+        
+        LoggerFactory.getLogger(RlDeploymentOperations.class).info("Eviction time for Hazelcast (GLOBAL RL): " + evictionTime);
+        hazelcastConfig.getMapConfig(BUCKET_MAP)
+            .setTimeToLiveSeconds(evictionTime)
+            .setEvictionPolicy(EvictionPolicy.LRU);
+        
+        return hazelcastConfig;
+    }
+    
+    public static ProxyManager<String> startHazelcast(Handler<AsyncResult<Void>> resultHandler, int evictionTime) {
+        try {
+            Config hazelcastConfig = getHazelcastConfig(evictionTime);
+            
+            HazelcastInstance hazelcastCluster = Hazelcast.newHazelcastInstance(hazelcastConfig);
+            IMap<String, GridBucketState> map = hazelcastCluster.getMap(BUCKET_MAP);
+            ProxyManager<String> globalBuckets = Bucket4j.extension(io.github.bucket4j.grid.hazelcast.Hazelcast.class).proxyManagerForMap(map);
+            resultHandler.handle(Future.succeededFuture());            
+            return globalBuckets;
+        } catch (Exception e) {
+            resultHandler.handle(Future.failedFuture("Cannot deploy Hazelcast cluster"));
+        }
+        return null;
+    }
+    
+    public static Map<String, BucketDate> startLocalRlMap(BridgeConfig bridgeConfig) {
+        
+        Map<String, BucketDate> localBuckets = null;
+        if (bridgeConfig.getHttpConfig().isRateLimitingEnabled() && bridgeConfig.getRateLimitingPolicy().usesLocalRL()) {
+            // initialize a bucket for local use only
+            localBuckets = new ConcurrentHashMap<>();
+            new CleanLocalMapThread(localBuckets, bridgeConfig.getRateLimitingPolicy().getWindowTimeLocalRl());
+        }
+        return localBuckets;
+    }
+    
+    
+}

--- a/src/main/java/io/strimzi/kafka/bridge/rateLimiting/TopicLimit.java
+++ b/src/main/java/io/strimzi/kafka/bridge/rateLimiting/TopicLimit.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.rateLimiting;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class TopicLimit {
+
+    private String topicName;
+    private boolean global;
+    private List<RateLimitSingleLimit> limits;
+    private boolean usesHourWindows = false;
+    
+    public TopicLimit(JSONObject jsonObject) {
+        this.topicName = jsonObject.optString(RateLimitingParameters.RL_TOPIC_NAME);
+        
+        if (jsonObject.has(RateLimitingParameters.RL_STRATEGY)) {
+            this.global = RateLimitingParameters.RL_GLOBAL_STRATEGY.equals(jsonObject.optString(RateLimitingParameters.RL_STRATEGY));            
+        } else {
+            this.global = false;
+        }
+        
+        limits = new ArrayList<RateLimitSingleLimit>();
+        JSONArray jsonLimits = jsonObject.getJSONArray(RateLimitingParameters.RL_LIMITS_ARRAY);
+        for (int i = 0; i < jsonLimits.length(); i++) {
+            RateLimitSingleLimit newLimit = new RateLimitSingleLimit(jsonLimits.getJSONObject(i));
+            this.limits.add(newLimit);
+            if (newLimit.getLimitHours() != -1) {
+                usesHourWindows = true;
+            }
+        }
+    }
+    
+    public boolean isGlobal() {
+        return this.global;
+    }
+    
+    public String getTopicName() {
+        return this.topicName;
+    }
+    
+    public List<RateLimitSingleLimit> getLimits() {
+        return this.limits;
+    }
+    
+    public boolean usesHourWindows() {
+        return this.usesHourWindows;
+    }
+    
+}

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -568,6 +568,98 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "tags": [
+                    "Topics",
+                    "Producer"
+                ],
+                "description": "Sends one or more records to a topic, that is determined dynamically",
+                "operationId": "sendWithCbrRules",
+                "requestBody": {
+                    "content": {
+                        "application/vnd.kafka.json.v2+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProducerRecordList"
+                            }
+                        },
+                        "application/vnd.kafka.binary.v2+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProducerRecordList"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Records sent successfully.",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OffsetRecordSentList"
+                                },
+                                "examples": {
+                                    "response": {
+                                        "value": {
+                                            "offsets": [
+                                                {
+                                                    "partition": 2,
+                                                    "offset": 0
+                                                },
+                                                {
+                                                    "partition": 1,
+                                                    "offset": 1
+                                                },
+                                                {
+                                                    "partition": 2,
+                                                    "offset": 2
+                                                }
+                                            ],
+                                            "topic": "topic_to_which_the_messages_were_sent"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Content based routing is not enabled, so this route cannot be accessed",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "response": {
+                                        "value": {
+                                            "error_code": 400,
+                                            "message": "Cannot use content-routing if such option is disabled in the configuration file provided."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "The record list is not valid.",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "response": {
+                                        "value": {
+                                            "error_code": 422,
+                                            "message": "The record list contains invalid records."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/topics/{topicname}": {


### PR DESCRIPTION
Hi, this PR provides the bridge with rate limiting capabilities as well as with the possibility to dynamically determine the topic to which a bunch of messages should be directed to. 
You can read the extended description about how to manage these two functionalities in the `ADDED_README.md` file.
Implementational details about how did I implement the functionalities are discussed [in chapter 6 of my dissertation thesis, while in chapter 7](https://www.dropbox.com/s/5tnmdzd4eyr67i9/63170401_dopolnjena_diplomska.pdf?dl=0) it is presented a purely demonstrative use case for the two extensions.
Please let me know what do you think.
Cheers!