### PR TITLE
add getOffsets using adminClient

### DIFF
--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -164,6 +164,19 @@ __optional__|< <<_offsetrecordsent,OffsetRecordSent>> > array
 |===
 
 
+[[_offsetssummary]]
+=== OffsetsSummary
+
+[options="header", cols=".^3a,.^4a"]
+|===
+|Name|Schema
+|**beginning_offset** +
+__optional__|integer (int64)
+|**end_offset** +
+__optional__|integer (int64)
+|===
+
+
 [[_partition]]
 === Partition
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -1464,4 +1464,69 @@ __required__|Name of the topic to send records to or retrieve metadata from.|str
 ----
 
 
+[[_getoffsets]]
+=== GET /topics/{topicname}/partitions/{partitionid}/offsets
+
+==== Description
+Retrieves a summary of the offsets for the topic partition.
+
+
+==== Parameters
+
+[options="header", cols=".^2a,.^3a,.^9a,.^4a"]
+|===
+|Type|Name|Description|Schema
+|**Path**|**partitionid** +
+__required__|ID of the partition.|integer
+|**Path**|**topicname** +
+__required__|Name of the topic containing the partition.|string
+|===
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|a summary of the offsets|<<_offsetssummary,OffsetsSummary>>
+|**404**|The specified topic partition was not found.|<<_error,Error>>
+|===
+
+
+==== Produces
+
+* `application/vnd.kafka.v2+json`
+
+
+==== Tags
+
+* Topics
+
+
+==== Example HTTP response
+
+===== Response 200
+[source,json]
+----
+{
+  "application/vnd.kafka.v2+json" : {
+    "beginning_offset" : 10,
+    "end_offset" : 50
+  }
+}
+----
+
+
+===== Response 404
+[source,json]
+----
+{
+  "application/vnd.kafka.v2+json" : {
+    "error_code" : 404,
+    "message" : "The specified topic partition was not found."
+  }
+}
+----
+
+
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -1488,7 +1488,7 @@ __required__|Name of the topic containing the partition.|string
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|a summary of the offsets|<<_offsetssummary,OffsetsSummary>>
+|**200**|A summary of the offsets for the topic partition.|<<_offsetssummary,OffsetsSummary>>
 |**404**|The specified topic partition was not found.|<<_error,Error>>
 |===
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.13.3</log4j.version>
-		<vertx.version>3.9.3</vertx.version>
+		<vertx.version>3.9.4</vertx.version>
 		<debezium.version>1.2.3.Final</debezium.version>
 		<maven.checkstyle.version>3.1.0</maven.checkstyle.version>
 		<junit.platform.version>1.5.2</junit.platform.version>

--- a/src/main/java/io/strimzi/kafka/bridge/AdminClientEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/AdminClientEndpoint.java
@@ -12,8 +12,11 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.kafka.admin.Config;
 import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.kafka.admin.ListOffsetsResultInfo;
+import io.vertx.kafka.admin.OffsetSpec;
 import io.vertx.kafka.admin.TopicDescription;
 import io.vertx.kafka.client.common.ConfigResource;
+import io.vertx.kafka.client.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,6 +103,14 @@ public abstract class AdminClientEndpoint implements BridgeEndpoint {
     protected void describeConfigs(List<ConfigResource> configResources, Handler<AsyncResult<Map<ConfigResource, Config>>> handler) {
         log.info("Describe configs {}", configResources);
         this.adminClient.describeConfigs(configResources, handler);
+    }
+
+    /**
+     * Returns the offset spec for the given partition.
+     */
+    protected void listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets, Handler<AsyncResult<Map<TopicPartition, ListOffsetsResultInfo>>> handler) {
+        log.info("Get the offset spec for partition {}", topicPartitionOffsets);
+        this.adminClient.listOffsets(topicPartitionOffsets, handler);
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -161,6 +161,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
                 routerFactory.addHandlerByOperationId(this.GET_TOPIC.getOperationId().toString(), this.GET_TOPIC);
                 routerFactory.addHandlerByOperationId(this.LIST_PARTITIONS.getOperationId().toString(), this.LIST_PARTITIONS);
                 routerFactory.addHandlerByOperationId(this.GET_PARTITION.getOperationId().toString(), this.GET_PARTITION);
+                routerFactory.addHandlerByOperationId(this.GET_OFFSETS.getOperationId().toString(), this.GET_OFFSETS);
                 routerFactory.addHandlerByOperationId(this.HEALTHY.getOperationId().toString(), this.HEALTHY);
                 routerFactory.addHandlerByOperationId(this.READY.getOperationId().toString(), this.READY);
                 routerFactory.addHandlerByOperationId(this.OPENAPI.getOperationId().toString(), this.OPENAPI);
@@ -365,6 +366,11 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
 
     private void getPartition(RoutingContext routingContext) {
         this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.GET_PARTITION);
+        processAdminClient(routingContext);
+    }
+
+    private void getOffsets(RoutingContext routingContext) {
+        this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.GET_OFFSETS);
         processAdminClient(routingContext);
     }
 
@@ -684,6 +690,14 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         @Override
         public void process(RoutingContext routingContext) {
             getPartition(routingContext);
+        }
+    };
+
+    HttpOpenApiOperation GET_OFFSETS = new HttpOpenApiOperation(HttpOpenApiOperations.GET_OFFSETS) {
+
+        @Override
+        public void process(RoutingContext routingContext) {
+            getOffsets(routingContext);
         }
     };
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -21,6 +21,7 @@ public enum HttpOpenApiOperations {
     GET_TOPIC("getTopic"),
     LIST_PARTITIONS("listPartitions"),
     GET_PARTITION("getPartition"),
+    GET_OFFSETS("getOffsets"),
     ASSIGN("assign"),
     POLL("poll"),
     COMMIT("commit"),

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1107,7 +1107,7 @@
                 "operationId": "getOffsets",
                 "responses": {
                     "200": {
-                        "description": "a summary of the offsets",
+                        "description": "A summary of the offsets of the topic partition.",
                         "content": {
                             "application/vnd.kafka.v2+json": {
                                 "schema": {
@@ -1141,7 +1141,6 @@
                     "name": "topicname",
                     "in": "path",
                     "description": "Name of the topic containing the partition.",
-
                     "required": true,
                     "schema": {
                         "type": "string"

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1098,6 +1098,66 @@
                 }
             ]
         },
+        "/topics/{topicname}/partitions/{partitionid}/offsets": {
+            "get": {
+                "tags": [
+                    "Topics"
+                ],
+                "description": "Retrieves a summary of the offsets for the topic partition.",
+                "operationId": "getOffsets",
+                "responses": {
+                    "200": {
+                        "description": "a summary of the offsets",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OffsetsSummary"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The specified topic partition was not found.",
+                        "content": {
+                            "application/vnd.kafka.v2+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "response": {
+                                        "value": {
+                                            "error_code": 404,
+                                            "message": "The specified topic partition was not found."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "topicname",
+                    "in": "path",
+                    "description": "Name of the topic containing the partition.",
+
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "name": "partitionid",
+                    "in": "path",
+                    "description": "ID of the partition.",
+                    "required": true,
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ]
+        },
         "/consumers/{groupid}/instances/{name}": {
             "delete": {
                 "tags": [
@@ -1436,6 +1496,24 @@
                             "offset": 91
                         }
                     ]
+                }
+            },
+            "OffsetsSummary": {
+                "title": "OffsetsSummary",
+                "type": "object",
+                "properties": {
+                    "beginning_offset": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "end_offset": {
+                        "format": "int64",
+                        "type": "integer"
+                    }
+                },
+                "example": {
+                    "beginning_offset": 10,
+                    "end_offset": 50
                 }
             },
             "Error": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1008,7 +1008,7 @@
         ],
         "responses": {
           "200": {
-            "description": "a summary of the offsets",
+            "description": "A summary of the offsets for the topic partition.",
             "schema": {
               "$ref": "#/definitions/OffsetsSummary"
             },

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -996,6 +996,60 @@
         }
       ]
     },
+    "/topics/{topicname}/partitions/{partitionid}/offsets": {
+      "get": {
+        "tags": [
+          "Topics"
+        ],
+        "description": "Retrieves a summary of the offsets for the topic partition.",
+        "operationId": "getOffsets",
+        "produces": [
+          "application/vnd.kafka.v2+json"
+        ],
+        "responses": {
+          "200": {
+            "description": "a summary of the offsets",
+            "schema": {
+              "$ref": "#/definitions/OffsetsSummary"
+            },
+            "examples": {
+              "application/vnd.kafka.v2+json": {
+                "beginning_offset": 10,
+                "end_offset": 50
+              }
+            }
+          },
+          "404": {
+            "description": "The specified topic partition was not found.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "examples": {
+              "application/vnd.kafka.v2+json": {
+                "error_code": 404,
+                "message": "The specified topic partition was not found."
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "topicname",
+          "in": "path",
+          "description": "Name of the topic containing the partition.",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "partitionid",
+          "in": "path",
+          "description": "ID of the partition.",
+          "required": true,
+          "type": "integer"
+        }
+      ]
+    },
     "/consumers/{groupid}/instances/{name}": {
       "delete": {
         "tags": [
@@ -1324,6 +1378,24 @@
             "offset": 91
           }
         ]
+      }
+    },
+    "OffsetsSummary": {
+      "title": "OffsetsSummary",
+      "type": "object",
+      "properties": {
+        "beginning_offset": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "end_offset": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "example": {
+        "beginning_offset": 10,
+        "end_offset": 50
       }
     },
     "Error": {

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesTest.java
@@ -104,6 +104,7 @@ public class OtherServicesTest extends HttpBridgeTestAbstract {
                         assertThat(paths.containsKey("/topics/{topicname}"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/topics/{topicname}").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SEND.toString()));
                         assertThat(paths.containsKey("/topics/{topicname}/partitions/{partitionid}"), is(true));
+                        assertThat(paths.containsKey("/topics/{topicname}/partitions/{partitionid}/offsets"), is(true));
                         assertThat(paths.containsKey("/topics/{topicname}/partitions"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/topics/{topicname}/partitions/{partitionid}").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SEND_TO_PARTITION.toString()));
                         assertThat(paths.containsKey("/healthy"), is(true));
@@ -115,7 +116,7 @@ public class OtherServicesTest extends HttpBridgeTestAbstract {
                         assertThat(paths.containsKey("/"), is(true));
                         assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.INFO.toString()));
                         assertThat(paths.containsKey("/karel"), is(false));
-                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(24));
+                        assertThat(bridgeResponse.getJsonObject("definitions").getMap().size(), is(25));
                         assertThat(bridgeResponse.getJsonArray("tags").size(), is(4));
                     });
                     context.completeNow();


### PR DESCRIPTION
Signed-off-by: Aki Yoshida <elakito@gmail.com>

I created this PR to implement getOffsets using the new adminConsumer of vertx-3.9.4.
This PR should replace https://github.com/strimzi/strimzi-kafka-bridge/pull/455.

This PR contains a change in pom.xml to upgrade vertx to 3.9.4. Please let me know if this vertx upgrade should go into a separate PR or commit.