### PR TITLE
Bump Strimzi Test Container to 0.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<micrometer.version>1.3.9</micrometer.version>
 		<jmx-prometheus-collector.version>0.12.0</jmx-prometheus-collector.version>
 		<commons-cli.version>1.4</commons-cli.version>
-		<test-container.version>0.19.0</test-container.version>
+		<test-container.version>0.20.0</test-container.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
After Strimzi 0.20.0 release, we can bump the test container dependency to the newer version where Kafka 2.6.0 is available.