### PR TITLE
Assignment test + NPE fix

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -198,7 +198,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     }
 
     /**
-     * Unubscribe all the topics which the consumer currently subscribes
+     * Unsubscribe all the topics which the consumer currently subscribes
      */
     protected void unsubscribe() {
         log.info("Unsubscribe from topics {}", this.topicSubscriptions);
@@ -360,6 +360,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
             Optional<PartitionInfo> requestedPartitionInfo =
                     availablePartitions.stream()
                             .filter(p -> p.getTopic().equals(topicSubscription.getTopic()) &&
+                                    topicSubscription.getPartition() != null &&
                                     p.getPartition() == topicSubscription.getPartition())
                             .findFirst();
 

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -69,6 +69,10 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     protected List<SinkTopicSubscription> topicSubscriptions;
     protected Pattern topicSubscriptionsPattern;
 
+    protected boolean subscribed;
+    protected boolean assigned;
+
+
     private int recordIndex;
     private int batchSize;
 
@@ -115,6 +119,8 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.format = format;
         this.keyDeserializer = keyDeserializer;
         this.valueDeserializer = valueDeserializer;
+        this.subscribed = false;
+        this.assigned = false;
     }
 
     @Override
@@ -191,6 +197,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.shouldAttachSubscriberHandler = shouldAttachHandler;
 
         log.info("Subscribe to topics {}", this.topicSubscriptions);
+        this.subscribed = true;
         this.setPartitionsAssignmentHandlers();
 
         Set<String> topics = this.topicSubscriptions.stream().map(ts -> ts.getTopic()).collect(Collectors.toSet());
@@ -204,6 +211,8 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         log.info("Unsubscribe from topics {}", this.topicSubscriptions);
         topicSubscriptions.clear();
         topicSubscriptionsPattern = null;
+        this.subscribed = false;
+        this.assigned = false;
         this.consumer.unsubscribe(this::unsubscribeHandler);
     }
 
@@ -228,6 +237,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
 
         log.info("Subscribe to topics with pattern {}", pattern);
         this.setPartitionsAssignmentHandlers();
+        this.subscribed = true;
         this.consumer.subscribe(pattern, this::subscribeHandler);
     }
 
@@ -276,6 +286,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.shouldAttachSubscriberHandler = shouldAttachHandler;
 
         log.info("Assigning to topics partitions {}", this.topicSubscriptions);
+        this.assigned = true;
         this.partitionsAssignmentAndSeek();
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -367,7 +367,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
             if (assignResult.succeeded()) {
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.NO_CONTENT.code(), null, null);
             } else {
-                if (assignResult.cause().getMessage().equals("Subscription to topics, partitions and pattern are mutually exclusive")) {
+                if (assignResult.cause() instanceof IllegalStateException) {
                     HttpBridgeError error = new HttpBridgeError(
                             HttpResponseStatus.CONFLICT.code(),
                             assignResult.cause().getMessage()

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -367,12 +367,14 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
             if (assignResult.succeeded()) {
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.NO_CONTENT.code(), null, null);
             } else {
-                HttpBridgeError error = new HttpBridgeError(
-                        HttpResponseStatus.CONFLICT.code(),
-                        assignResult.cause().getMessage()
-                );
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.CONFLICT.code(),
-                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                if (assignResult.cause().getMessage().equals("Subscription to topics, partitions and pattern are mutually exclusive")) {
+                    HttpBridgeError error = new HttpBridgeError(
+                            HttpResponseStatus.CONFLICT.code(),
+                            assignResult.cause().getMessage()
+                    );
+                    HttpUtils.sendResponse(routingContext, HttpResponseStatus.CONFLICT.code(),
+                            BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                }
             }
         });
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -366,6 +366,13 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         this.setAssignHandler(assignResult -> {
             if (assignResult.succeeded()) {
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.NO_CONTENT.code(), null, null);
+            } else {
+                HttpBridgeError error = new HttpBridgeError(
+                        HttpResponseStatus.CONFLICT.code(),
+                        assignResult.cause().getMessage()
+                );
+                HttpUtils.sendResponse(routingContext, HttpResponseStatus.CONFLICT.code(),
+                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
             }
         });
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -361,6 +361,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.CONFLICT.code(),
                     BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+            return;
         }
         JsonArray partitionsList = bodyAsJson.getJsonArray("partitions");
         this.topicSubscriptions.addAll(

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -299,9 +299,9 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
 
     @Test
     void assignTest(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        String topicToSub = "subscribe-topic";
+        String topic = "subscribe-and-assign-topic";
 
-        adminClientFacade.createTopic(topicToSub, 4, 1);
+        adminClientFacade.createTopic(topic, 4, 1);
 
         assertThat(adminClientFacade.listTopic().size(), is(1));
 
@@ -314,11 +314,11 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         JsonObject partitionsRoot = new JsonObject();
         JsonArray partitions = new JsonArray();
         JsonObject part0 = new JsonObject();
-        part0.put("topic", topicToSub);
+        part0.put("topic", topic);
         part0.put("partition", 0);
 
         JsonObject part1 = new JsonObject();
-        part1.put("topic", topicToSub);
+        part1.put("topic", topic);
         part1.put("partition", 1);
         partitions.add(part0);
         partitions.add(part1);
@@ -327,7 +327,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
 
         consumerService()
                 .createConsumer(context, groupId, json)
-                .subscribeConsumer(context, groupId, name, topicToSub);
+                .subscribeConsumer(context, groupId, name, topic);
 
         CompletableFuture<Boolean> assignCF = new CompletableFuture<>();
         consumerService()

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -298,7 +298,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
     }
 
     @Test
-    void assignTest(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    void assignAfterSubscriptionTest(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         String topic = "subscribe-and-assign-topic";
 
         adminClientFacade.createTopic(topic, 4, 1);

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -339,7 +339,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
                         HttpBridgeError error = HttpBridgeError.fromJson(response.body());
                         assertThat(response.statusCode(), is(HttpResponseStatus.CONFLICT.code()));
                         assertThat(error.getCode(), is(HttpResponseStatus.CONFLICT.code()));
-                        assertThat(error.getMessage(), is("Subscription to topics, partitions and pattern are mutually exclusive"));
+                        assertThat(error.getMessage(), is("Subscriptions to topics, partitions, and patterns are mutually exclusive."));
                     });
                     assignCF.complete(true);
                 });

--- a/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
@@ -93,6 +93,13 @@ public class ConsumerService extends BaseService {
                 .as(BodyCodec.jsonObject());
     }
 
+    public HttpRequest<JsonObject> assignRequest(String groupId, String name, JsonObject json) {
+        return postRequest(Urls.consumerInstanceAssignments(groupId, name))
+                .putHeader(CONTENT_LENGTH.toString(), String.valueOf(json.toBuffer().length()))
+                .putHeader(CONTENT_TYPE.toString(), BridgeContentType.KAFKA_JSON)
+                .as(BodyCodec.jsonObject());
+    }
+
     public HttpRequest<JsonObject> offsetsRequest(String groupId, String name) {
         return postRequest(Urls.consumerInstanceOffsets(groupId, name));
     }


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Assigment endpoint does not have any tests. 
Trying to access `subscribe` and `assign` endpoints ends up with NPE. After fix of NPE, it does not return 409 (Conflict).

Fixes https://github.com/strimzi/strimzi-kafka-bridge/issues/489