### PR TITLE
Poll without subscribe should return reasonable message

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -67,7 +67,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
 
     protected String groupId;
     protected List<SinkTopicSubscription> topicSubscriptions;
-    protected boolean topicSubscriptionsPatternUsed;
+    protected Pattern topicSubscriptionsPattern;
 
     private int recordIndex;
     private int batchSize;
@@ -111,7 +111,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.vertx = vertx;
         this.bridgeConfig = bridgeConfig;
         this.topicSubscriptions = new ArrayList<>();
-        this.topicSubscriptionsPatternUsed = false;
+        this.topicSubscriptionsPattern = null;
         this.format = format;
         this.keyDeserializer = keyDeserializer;
         this.valueDeserializer = valueDeserializer;
@@ -203,7 +203,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     protected void unsubscribe() {
         log.info("Unsubscribe from topics {}", this.topicSubscriptions);
         topicSubscriptions.clear();
-        topicSubscriptionsPatternUsed = false;
+        topicSubscriptionsPattern = null;
         this.consumer.unsubscribe(this::unsubscribeHandler);
     }
 
@@ -223,7 +223,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
      */
     protected void subscribe(Pattern pattern, boolean shouldAttachHandler) {
 
-        topicSubscriptionsPatternUsed = true;
+        topicSubscriptionsPattern = pattern;
         this.shouldAttachSubscriberHandler = shouldAttachHandler;
 
         log.info("Subscribe to topics with pattern {}", pattern);

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -67,6 +67,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
 
     protected String groupId;
     protected List<SinkTopicSubscription> topicSubscriptions;
+    protected boolean topicSubscriptionsPatternUsed;
 
     private int recordIndex;
     private int batchSize;
@@ -110,6 +111,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.vertx = vertx;
         this.bridgeConfig = bridgeConfig;
         this.topicSubscriptions = new ArrayList<>();
+        this.topicSubscriptionsPatternUsed = false;
         this.format = format;
         this.keyDeserializer = keyDeserializer;
         this.valueDeserializer = valueDeserializer;
@@ -199,9 +201,9 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
      * Unubscribe all the topics which the consumer currently subscribes
      */
     protected void unsubscribe() {
-
         log.info("Unsubscribe from topics {}", this.topicSubscriptions);
         topicSubscriptions.clear();
+        topicSubscriptionsPatternUsed = false;
         this.consumer.unsubscribe(this::unsubscribeHandler);
     }
 
@@ -221,6 +223,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
      */
     protected void subscribe(Pattern pattern, boolean shouldAttachHandler) {
 
+        topicSubscriptionsPatternUsed = true;
         this.shouldAttachSubscriberHandler = shouldAttachHandler;
 
         log.info("Subscribe to topics with pattern {}", pattern);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -248,6 +248,16 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
     }
 
     private void doPoll(RoutingContext routingContext) {
+        if (!topicSubscriptionsPatternUsed && topicSubscriptions.isEmpty()) {
+            HttpBridgeError error = new HttpBridgeError(
+                    HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                    "Consumer is not subscribed to any topics or assigned any partitions"
+            );
+            HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                    BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+            return;
+        }
+
         String accept = routingContext.request().getHeader("Accept");
 
         // check that the accepted body by the client is the same as the format on creation

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -248,7 +248,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
     }
 
     private void doPoll(RoutingContext routingContext) {
-        if (!topicSubscriptionsPatternUsed && topicSubscriptions.isEmpty()) {
+        if (topicSubscriptionsPattern == null && topicSubscriptions.isEmpty()) {
             HttpBridgeError error = new HttpBridgeError(
                     HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                     "Consumer is not subscribed to any topics or assigned any partitions"


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

When the poll is requested, subscription list and the subsrciption patter is checked whether they are set up. If not, `Consumer is not subscribed to any topics or assigned any partitions` message is returned.

fixes https://github.com/strimzi/strimzi-kafka-bridge/issues/492