### PR TITLE
Prepare build to rename master branch to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, release* ]
+    branches: [ main, release* ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '23 17 * * 3'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 env:
   global:
   - PULL_REQUEST=${TRAVIS_PULL_REQUEST}
-  - BRANCH=${TRAVIS_BRANCH:-master}
+  - BRANCH=${TRAVIS_BRANCH:-main}
   - TAG=${TRAVIS_TAG:-latest}
   - DOCKER_REGISTRY=quay.io
   - MVN_ARGS="-B"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -27,17 +27,17 @@ echo "PULL_REQUEST=$PULL_REQUEST"
 echo "TAG=$TAG"
 echo "BRANCH=$BRANCH"
 
-# Docker build and push only if on master, no pull request and "latest" tag
+# Docker build and push only if on main, no pull request and "latest" tag
 if [ "$PULL_REQUEST" != "false" ] ; then
     make docu_html
     make docu_htmlnoheader
 
     echo "Building Pull Request - nothing to push"
-elif [ "$TAG" = "latest" ] && [ "$BRANCH" != "master" ] ; then
+elif [ "$TAG" = "latest" ] && [ "$BRANCH" != "main" ] ; then
     make docu_html
     make docu_htmlnoheader
 
-    echo "Not in master branch and not in release tag - nothing to push"
+    echo "Not in main branch and not in release tag - nothing to push"
 else
     if [ "${MAIN_BUILD}" = "TRUE" ] ; then
         echo "Login into Docker Hub ..."
@@ -52,7 +52,7 @@ else
         echo "Pushing to Docker Hub ..."
         make docker_push
 
-        if [ "$BRANCH" = "master" ]; then
+        if [ "$BRANCH" = "main" ]; then
             make docu_pushtowebsite
         fi
     fi

--- a/.travis/docu-push-to-website.sh
+++ b/.travis/docu-push-to-website.sh
@@ -25,6 +25,6 @@ git config user.email "ci@travis.tld"
 
 git add -A
 git commit -s -m "Update Kafka Bridge documentation (Travis CI build ${TRAVIS_BUILD_NUMBER})" --allow-empty
-git push origin master
+git push origin main
 
 popd

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Strimzi Community Code of Conduct
 
-Strimzi Community Code of Conduct is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/CODE_OF_CONDUCT.md).
+Strimzi Community Code of Conduct is defined in the [governance repository](https://github.com/strimzi/governance/blob/main/CODE_OF_CONDUCT.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,3 @@
 # Strimzi Governance
 
-Strimzi Governance is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/GOVERNANCE.md).
+Strimzi Governance is defined in the [governance repository](https://github.com/strimzi/governance/blob/main/GOVERNANCE.md).

--- a/HACKING.md
+++ b/HACKING.md
@@ -72,6 +72,6 @@ Therefore the git tag name has to be the same as the `RELEASE_VERSION`,
 7. Once the CI build for the tag is finished and the Docker images are pushed to Docker Hub, create a GitHub release based on the tag. 
 Attach the ZIP and TAR.GZ archives to the release.
 8. Build the documentation using `make docu_html` and `make docu_htmlnoheader` and add it to the [Strimzi.io](https://strimzi.io) website.
-8. On the `master` git branch:
+8. On the `main` git branch:
   * Update the versions to the next SNAPSHOT version using the `next_version` `make` target. 
   For example to update the next version to `0.6.0-SNAPSHOT` run: `make NEXT_VERSION=0.6.0-SNAPSHOT next_version`.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,3 @@
 # Strimzi Maintainers list
 
-Strimzi Maintainers list is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/MAINTAINERS).
+Strimzi Maintainers list is defined in the [governance repository](https://github.com/strimzi/governance/blob/main/MAINTAINERS).

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include ./Makefile.docker
 include ./Makefile.maven
 
 PROJECT_NAME ?= kafka-bridge
-GITHUB_VERSION ?= master
+GITHUB_VERSION ?= main
 RELEASE_VERSION ?= latest
 
 ifneq ($(RELEASE_VERSION),latest)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/strimzi/strimzi-kafka-bridge.svg?branch=master)](https://travis-ci.org/strimzi/strimzi-kafka-bridge)
+[![Build Status](https://travis-ci.org/strimzi/strimzi-kafka-bridge.svg?branch=main)](https://travis-ci.org/strimzi/strimzi-kafka-bridge)
 [![GitHub release](https://img.shields.io/github/release/strimzi/strimzi-kafka-bridge.svg)](https://github.com/strimzi/strimzi-kafka-bridge/releases/latest)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Twitter Follow](https://img.shields.io/twitter/follow/strimziio.svg?style=social&label=Follow&style=for-the-badge)](https://twitter.com/strimziio)
@@ -32,7 +32,7 @@ bin/kafka_bridge_run.sh --config-file config/application.properties
 
 ## Documentation
 
-Documentation to the current _master_ branch as well as all releases can be found on our [website](https://strimzi.io).
+Documentation to the current _main_ branch as well as all releases can be found on our [website](https://strimzi.io).
 
 ## Getting help
 
@@ -52,7 +52,7 @@ You can contribute by:
 All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/strimzi/strimzi-kafka-bridge/issues). Issues which 
 might be a good start for new contributors are marked with ["good-start"](https://github.com/strimzi/strimzi-kafka-bridge/labels/good-start) label.
 
-The [Hacking guide](https://github.com/strimzi/strimzi-kafka-bridge/blob/master/HACKING.md) describes how to build Strimzi Kafka Bridge and how to test your changes before submitting a patch or opening a PR.
+The [Hacking guide](https://github.com/strimzi/strimzi-kafka-bridge/blob/main/HACKING.md) describes how to build Strimzi Kafka Bridge and how to test your changes before submitting a patch or opening a PR.
 
 The [Documentation Contributor Guide](http://strimzi.io/contributing/guide/) describes how to contribute to Strimzi documentation.
 

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -20,7 +20,7 @@ To run any tests you need to build whole project. You can achieve that with foll
 in root directory of the project.
 
 The next requirement is to have [docker](https://docs.docker.com/get-docker/) installed, because we use [test-containers](https://www.testcontainers.org/). 
-In case of interest you can check our implementation of Strimzi `Kafka` container [here](https://github.com/strimzi/strimzi-kafka-operator/tree/master/test-container).
+In case of interest you can check our implementation of Strimzi `Kafka` container [here](https://github.com/strimzi/strimzi-kafka-operator/tree/main/test-container).
 
 ## Package Structure
 
@@ -42,8 +42,8 @@ the following  terminology is needed.
 
 #### In-memory 
 `Kafka` = 
-- for `Http Kafka Bridge` we use [Strimzi Kafka container]([here](https://github.com/strimzi/strimzi-kafka-operator/tree/master/test-container).)
-- for `Amqp Kafka Bridge` we use [KafkaFacade](https://github.com/strimzi/strimzi-kafka-bridge/blob/master/src/test/java/io/strimzi/kafka/bridge/facades/KafkaFacade.java) 
+- for `Http Kafka Bridge` we use [Strimzi Kafka container]([here](https://github.com/strimzi/strimzi-kafka-operator/tree/main/test-container).)
+- for `Amqp Kafka Bridge` we use [KafkaFacade](https://github.com/strimzi/strimzi-kafka-bridge/blob/main/src/test/java/io/strimzi/kafka/bridge/facades/KafkaFacade.java) 
 
 `Kafka Bridge` =
  - for deployment of the `Http Kafka Bridge` and `Amqp Kafka Bridge` we are using [Vert.x](https://vertx.io/) 
@@ -170,7 +170,7 @@ The following table shows currently used tags:
 There is also a mvn profile for the main groups - `httpbridge`, `amqpbridge` and `all`, but we suggest to use profile with id `all` (default) and then include or exclude specific groups.
 If you want specify the profile, use the `-P` flag - for example `-Phttpbridge`.
 
-All available test groups are listed in [Constants](https://github.com/strimzi/strimzi-kafka-bridge/blob/master/src/test/java/io/strimzi/kafka/bridge/Constants.java) class.
+All available test groups are listed in [Constants](https://github.com/strimzi/strimzi-kafka-bridge/blob/main/src/test/java/io/strimzi/kafka/bridge/Constants.java) class.
 
 ## Environment variables
 


### PR DESCRIPTION
This PR updates the build in this repository so that we can rename the `master` branch to `main`.

_Note: This should be merged only after the strimzi.github.io repo is updated._