### PR TITLE
[Issue 508] Renamed IT tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>io.strimzi</groupId>
 	<artifactId>kafka-bridge</artifactId>
@@ -19,7 +19,7 @@
 		<hamcrest.version>2.2</hamcrest.version>
 		<maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-                <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+		<maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
 		<swagger2markup.version>1.3.7</swagger2markup.version>
 		<jackson-core.version>2.10.2</jackson-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
@@ -31,9 +31,9 @@
 		<jmx-prometheus-collector.version>0.12.0</jmx-prometheus-collector.version>
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.20.0</test-container.version>
-                <!-- property to skip surefire tests during failsafe execution -->
-                <!--suppress UnresolvedMavenProperty -->
-                <skip.surefire.tests>${skipTests}</skip.surefire.tests>
+		<!-- property to skip surefire tests during failsafe execution -->
+		<!--suppress UnresolvedMavenProperty -->
+		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
 	</properties>
 
 	<dependencies>
@@ -273,48 +273,48 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
 				<configuration>
-                                        <trimStackTrace>false</trimStackTrace>
-                                        <skipTests>${skip.surefire.tests}</skipTests>
+					<trimStackTrace>false</trimStackTrace>
+					<skipTests>${skip.surefire.tests}</skipTests>
 				</configuration>
 			</plugin>
-                        <plugin>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-failsafe-plugin</artifactId>
-                                <version>${maven-failsafe-plugin.version}</version>
-                                <executions>
-                                        <execution>
-                                                <goals>
-                                                        <goal>integration-test</goal>
-                                                        <goal>verify</goal>
-                                                </goals>
-                                                <configuration>
-                                                        <trimStackTrace>false</trimStackTrace>
-                                                        <forkCount>0</forkCount>
-                                                        <!-- This is workaround for https://issues.apache.org/jira/browse/SUREFIRE-1809 -->
-                                                        <useModulePath>false</useModulePath>
-                                                        <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
-                                                                <disable>false</disable>
-                                                                <version>3.0</version>
-                                                                <usePhrasedFileName>false</usePhrasedFileName>
-                                                                <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
-                                                                <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
-                                                                <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
-                                                        </statelessTestsetReporter>
-                                                        <consoleOutputReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
-                                                                <disable>false</disable>
-                                                                <encoding>UTF-8</encoding>
-                                                                <usePhrasedFileName>true</usePhrasedFileName>
-                                                        </consoleOutputReporter>
-                                                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
-                                                                <disable>false</disable>
-                                                                <usePhrasedFileName>false</usePhrasedFileName>
-                                                                <usePhrasedClassNameInRunning>false</usePhrasedClassNameInRunning>
-                                                                <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
-                                                        </statelessTestsetInfoReporter>
-                                                </configuration>
-                                        </execution>
-                                </executions>
-                        </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${maven-failsafe-plugin.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+						<configuration>
+							<trimStackTrace>false</trimStackTrace>
+							<forkCount>0</forkCount>
+							<!-- This is workaround for https://issues.apache.org/jira/browse/SUREFIRE-1809 -->
+							<useModulePath>false</useModulePath>
+							<statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+								<disable>false</disable>
+								<version>3.0</version>
+								<usePhrasedFileName>false</usePhrasedFileName>
+								<usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+								<usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+								<usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+							</statelessTestsetReporter>
+							<consoleOutputReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+								<disable>false</disable>
+								<encoding>UTF-8</encoding>
+								<usePhrasedFileName>true</usePhrasedFileName>
+							</consoleOutputReporter>
+							<statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+								<disable>false</disable>
+								<usePhrasedFileName>false</usePhrasedFileName>
+								<usePhrasedClassNameInRunning>false</usePhrasedClassNameInRunning>
+								<usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+							</statelessTestsetInfoReporter>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -273,9 +273,6 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
 				<configuration>
-					<excludes>
-						<exclude>**/*StaticTests.java</exclude>
-					</excludes>
                                         <trimStackTrace>false</trimStackTrace>
                                         <skipTests>${skip.surefire.tests}</skipTests>
 				</configuration>
@@ -291,11 +288,6 @@
                                                         <goal>verify</goal>
                                                 </goals>
                                                 <configuration>
-                                                        <includes>
-                                                                <include>**/IT*.java</include>
-                                                                <include>**/*IT.java</include>
-                                                                <include>**/*StaticTest.java</include>
-                                                        </includes>
                                                         <trimStackTrace>false</trimStackTrace>
                                                         <forkCount>0</forkCount>
                                                         <!-- This is workaround for https://issues.apache.org/jira/browse/SUREFIRE-1809 -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
 	<groupId>io.strimzi</groupId>
 	<artifactId>kafka-bridge</artifactId>
 	<version>0.20.0-SNAPSHOT</version>
@@ -19,6 +19,7 @@
 		<hamcrest.version>2.2</hamcrest.version>
 		<maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
 		<swagger2markup.version>1.3.7</swagger2markup.version>
 		<jackson-core.version>2.10.2</jackson-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
@@ -30,6 +31,9 @@
 		<jmx-prometheus-collector.version>0.12.0</jmx-prometheus-collector.version>
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.20.0</test-container.version>
+    <!-- property to skip surefire tests during failsafe execution -->
+    <!--suppress UnresolvedMavenProperty -->
+    <skip.surefire.tests>${skipTests}</skip.surefire.tests>
 	</properties>
 
 	<dependencies>
@@ -272,25 +276,53 @@
 					<excludes>
 						<exclude>**/*StaticTests.java</exclude>
 					</excludes>
+          <trimStackTrace>false</trimStackTrace>
+          <skipTests>${skip.surefire.tests}</skipTests>
 				</configuration>
-				<executions>
-					<execution>
-						<id>integration-test</id>
-						<goals>
-							<goal>test</goal>
-						</goals>
-						<phase>integration-test</phase>
-						<configuration>
-							<excludes>
-								<exclude>none</exclude>
-							</excludes>
-							<includes>
-								<include>**/*StaticTests.java</include>
-							</includes>
-						</configuration>
-					</execution>
-				</executions>
 			</plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
+          <executions>
+              <execution>
+                  <goals>
+                      <goal>integration-test</goal>
+                      <goal>verify</goal>
+                  </goals>
+                  <configuration>
+                      <includes>
+                          <include>**/IT*.java</include>
+                          <include>**/*IT.java</include>
+                          <include>**/*StaticTest.java</include>
+                      </includes>
+                      <trimStackTrace>false</trimStackTrace>
+                      <forkCount>0</forkCount>
+                      <!-- This is workaround for https://issues.apache.org/jira/browse/SUREFIRE-1809 -->
+                      <useModulePath>false</useModulePath>
+                      <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                          <disable>false</disable>
+                          <version>3.0</version>
+                          <usePhrasedFileName>false</usePhrasedFileName>
+                          <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                          <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                          <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                      </statelessTestsetReporter>
+                      <consoleOutputReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+                          <disable>false</disable>
+                          <encoding>UTF-8</encoding>
+                          <usePhrasedFileName>true</usePhrasedFileName>
+                      </consoleOutputReporter>
+                      <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+                          <disable>false</disable>
+                          <usePhrasedFileName>false</usePhrasedFileName>
+                          <usePhrasedClassNameInRunning>false</usePhrasedClassNameInRunning>
+                          <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+                      </statelessTestsetInfoReporter>
+                  </configuration>
+              </execution>
+          </executions>
+      </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -413,5 +445,5 @@
             <organizationUrl>https://www.redhat.com</organizationUrl>
         </developer>
     </developers>
-  
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<hamcrest.version>2.2</hamcrest.version>
 		<maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+                <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
 		<swagger2markup.version>1.3.7</swagger2markup.version>
 		<jackson-core.version>2.10.2</jackson-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
@@ -31,9 +31,9 @@
 		<jmx-prometheus-collector.version>0.12.0</jmx-prometheus-collector.version>
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.20.0</test-container.version>
-    <!-- property to skip surefire tests during failsafe execution -->
-    <!--suppress UnresolvedMavenProperty -->
-    <skip.surefire.tests>${skipTests}</skip.surefire.tests>
+                <!-- property to skip surefire tests during failsafe execution -->
+                <!--suppress UnresolvedMavenProperty -->
+                <skip.surefire.tests>${skipTests}</skip.surefire.tests>
 	</properties>
 
 	<dependencies>
@@ -276,53 +276,53 @@
 					<excludes>
 						<exclude>**/*StaticTests.java</exclude>
 					</excludes>
-          <trimStackTrace>false</trimStackTrace>
-          <skipTests>${skip.surefire.tests}</skipTests>
+                                        <trimStackTrace>false</trimStackTrace>
+                                        <skipTests>${skip.surefire.tests}</skipTests>
 				</configuration>
 			</plugin>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${maven-failsafe-plugin.version}</version>
-          <executions>
-              <execution>
-                  <goals>
-                      <goal>integration-test</goal>
-                      <goal>verify</goal>
-                  </goals>
-                  <configuration>
-                      <includes>
-                          <include>**/IT*.java</include>
-                          <include>**/*IT.java</include>
-                          <include>**/*StaticTest.java</include>
-                      </includes>
-                      <trimStackTrace>false</trimStackTrace>
-                      <forkCount>0</forkCount>
-                      <!-- This is workaround for https://issues.apache.org/jira/browse/SUREFIRE-1809 -->
-                      <useModulePath>false</useModulePath>
-                      <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
-                          <disable>false</disable>
-                          <version>3.0</version>
-                          <usePhrasedFileName>false</usePhrasedFileName>
-                          <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
-                          <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
-                          <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
-                      </statelessTestsetReporter>
-                      <consoleOutputReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
-                          <disable>false</disable>
-                          <encoding>UTF-8</encoding>
-                          <usePhrasedFileName>true</usePhrasedFileName>
-                      </consoleOutputReporter>
-                      <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
-                          <disable>false</disable>
-                          <usePhrasedFileName>false</usePhrasedFileName>
-                          <usePhrasedClassNameInRunning>false</usePhrasedClassNameInRunning>
-                          <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
-                      </statelessTestsetInfoReporter>
-                  </configuration>
-              </execution>
-          </executions>
-      </plugin>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-failsafe-plugin</artifactId>
+                                <version>${maven-failsafe-plugin.version}</version>
+                                <executions>
+                                        <execution>
+                                                <goals>
+                                                        <goal>integration-test</goal>
+                                                        <goal>verify</goal>
+                                                </goals>
+                                                <configuration>
+                                                        <includes>
+                                                                <include>**/IT*.java</include>
+                                                                <include>**/*IT.java</include>
+                                                                <include>**/*StaticTest.java</include>
+                                                        </includes>
+                                                        <trimStackTrace>false</trimStackTrace>
+                                                        <forkCount>0</forkCount>
+                                                        <!-- This is workaround for https://issues.apache.org/jira/browse/SUREFIRE-1809 -->
+                                                        <useModulePath>false</useModulePath>
+                                                        <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                                                                <disable>false</disable>
+                                                                <version>3.0</version>
+                                                                <usePhrasedFileName>false</usePhrasedFileName>
+                                                                <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                                                                <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                                                                <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                                                        </statelessTestsetReporter>
+                                                        <consoleOutputReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+                                                                <disable>false</disable>
+                                                                <encoding>UTF-8</encoding>
+                                                                <usePhrasedFileName>true</usePhrasedFileName>
+                                                        </consoleOutputReporter>
+                                                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+                                                                <disable>false</disable>
+                                                                <usePhrasedFileName>false</usePhrasedFileName>
+                                                                <usePhrasedClassNameInRunning>false</usePhrasedClassNameInRunning>
+                                                                <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+                                                        </statelessTestsetInfoReporter>
+                                                </configuration>
+                                        </execution>
+                                </executions>
+                        </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/src/test/java/io/strimzi/kafka/bridge/amqp/AmqpBridgeIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/amqp/AmqpBridgeIT.java
@@ -71,9 +71,9 @@ import static org.hamcrest.Matchers.nullValue;
 @ExtendWith(VertxExtension.class)
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity", "ClassDataAbstractionCoupling"})
 @Tag(AMQP_BRIDGE)
-class AmqpBridgeTest {
+class AmqpBridgeIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AmqpBridgeTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AmqpBridgeIT.class);
 
     private static Map<String, Object> config = new HashMap<>();
 
@@ -137,7 +137,7 @@ class AmqpBridgeTest {
 
         Checkpoint consume = context.checkpoint();
 
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -197,7 +197,7 @@ class AmqpBridgeTest {
 
         ProtonClient client = ProtonClient.create(this.vertx);
 
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -257,7 +257,7 @@ class AmqpBridgeTest {
         ProtonClient client = ProtonClient.create(this.vertx);
 
         Checkpoint consume = context.checkpoint();
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -316,7 +316,7 @@ class AmqpBridgeTest {
         ProtonClient client = ProtonClient.create(this.vertx);
 
         Checkpoint consume = context.checkpoint();
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -369,7 +369,7 @@ class AmqpBridgeTest {
         ProtonClient client = ProtonClient.create(this.vertx);
 
         Checkpoint consume = context.checkpoint();
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -422,7 +422,7 @@ class AmqpBridgeTest {
         ProtonClient client = ProtonClient.create(this.vertx);
 
         Checkpoint consume = context.checkpoint();
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -477,7 +477,7 @@ class AmqpBridgeTest {
         ProtonClient client = ProtonClient.create(this.vertx);
 
         Checkpoint consume = context.checkpoint();
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -532,7 +532,7 @@ class AmqpBridgeTest {
         ProtonClient client = ProtonClient.create(this.vertx);
 
         Checkpoint consume = context.checkpoint();
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -567,7 +567,7 @@ class AmqpBridgeTest {
 
                 this.count = 0;
 
-                this.vertx.setPeriodic(AmqpBridgeTest.PERIODIC_DELAY, timerId -> {
+                this.vertx.setPeriodic(AmqpBridgeIT.PERIODIC_DELAY, timerId -> {
 
                     if (connection.isDisconnected()) {
                         this.vertx.cancelTimer(timerId);
@@ -575,7 +575,7 @@ class AmqpBridgeTest {
                         context.verify(() -> assertThat(false, is(true)));
                     } else {
 
-                        if (this.count < AmqpBridgeTest.PERIODIC_MAX_MESSAGE) {
+                        if (this.count < AmqpBridgeIT.PERIODIC_MAX_MESSAGE) {
 
                             // sending with a key
                             Map<Symbol, Object> map = new HashMap<>();
@@ -619,7 +619,7 @@ class AmqpBridgeTest {
         ProtonClient client = ProtonClient.create(this.vertx);
 
         Checkpoint consume = context.checkpoint();
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
 
             if (ar.succeeded()) {
 
@@ -670,7 +670,7 @@ class AmqpBridgeTest {
         KAFKA_FACADE.produceStrings(topic, sentBody, 1, 0);
 
         ProtonClient client = ProtonClient.create(this.vertx);
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -730,7 +730,7 @@ class AmqpBridgeTest {
 
         ProtonClient client = ProtonClient.create(this.vertx);
 
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -794,7 +794,7 @@ class AmqpBridgeTest {
 
         ProtonClient client = ProtonClient.create(this.vertx);
 
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();
@@ -857,7 +857,7 @@ class AmqpBridgeTest {
 
         ProtonClient client = ProtonClient.create(this.vertx);
         Checkpoint noPartition = context.checkpoint();
-        client.connect(AmqpBridgeTest.BRIDGE_HOST, AmqpBridgeTest.BRIDGE_PORT, ar -> {
+        client.connect(AmqpBridgeIT.BRIDGE_HOST, AmqpBridgeIT.BRIDGE_PORT, ar -> {
             if (ar.succeeded()) {
 
                 ProtonConnection connection = ar.result();

--- a/src/test/java/io/strimzi/kafka/bridge/http/AdminClientIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/AdminClientIT.java
@@ -6,7 +6,7 @@ package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeTestAbstract;
+import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class AdminClientTest extends HttpBridgeTestAbstract {
+public class AdminClientIT extends HttpBridgeITAbstract {
     @Test
     void listTopicsTest(VertxTestContext context) throws Exception {
         setupTopic(context, topic, 1);

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
@@ -49,9 +49,9 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(VertxExtension.class)
 @Tag(HTTP_BRIDGE)
 @DisabledIfEnvironmentVariable(named = "EXTERNAL_BRIDGE", matches = "((?i)TRUE(?-i))")
-public class ConsumerGeneratedNameTest {
+public class ConsumerGeneratedNameIT {
 
-    private static final Logger LOGGER = LogManager.getLogger(ConsumerGeneratedNameTest.class);
+    private static final Logger LOGGER = LogManager.getLogger(ConsumerGeneratedNameIT.class);
 
     private static Map<String, Object> config = new HashMap<>();
     private static StrimziKafkaContainer kafkaContainer;

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -7,7 +7,7 @@ package io.strimzi.kafka.bridge.http;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeTestAbstract;
+import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
 import io.strimzi.kafka.bridge.utils.Urls;
 import io.vertx.core.MultiMap;
@@ -41,7 +41,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ConsumerTest extends HttpBridgeTestAbstract {
+public class ConsumerIT extends HttpBridgeITAbstract {
 
     private static final String FORWARDED = "Forwarded";
     private static final String X_FORWARDED_HOST = "X-Forwarded-Host";

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -6,7 +6,7 @@ package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeTestAbstract;
+import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
 import io.strimzi.kafka.bridge.utils.Urls;
 import io.vertx.core.json.JsonArray;
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeoutException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class ConsumerSubscriptionTest extends HttpBridgeTestAbstract {
+public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
 
     String groupId = "my-group";
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
@@ -45,9 +45,9 @@ import static org.hamcrest.Matchers.hasItem;
 
 @ExtendWith(VertxExtension.class)
 @SuppressWarnings({"checkstyle:JavaNCSS"})
-public class HttpCorsTests {
+public class HttpCorsIT {
 
-    static final Logger LOGGER = LogManager.getLogger(HttpCorsTests.class);
+    static final Logger LOGGER = LogManager.getLogger(HttpCorsIT.class);
     static Map<String, Object> config = new HashMap<>();
     static long timeout = 5L;
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
@@ -5,7 +5,7 @@
 package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeTestAbstract;
+import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
@@ -19,7 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class OtherServicesTest extends HttpBridgeTestAbstract {
+public class OtherServicesIT extends HttpBridgeITAbstract {
 
     @Test
     void readyTest(VertxTestContext context) throws InterruptedException {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -8,7 +8,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.clients.Consumer;
 import io.strimzi.kafka.bridge.config.KafkaProducerConfig;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeTestAbstract;
+import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
 import io.strimzi.kafka.bridge.utils.KafkaJsonDeserializer;
 import io.vertx.core.AsyncResult;
@@ -45,9 +45,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class ProducerTest extends HttpBridgeTestAbstract {
+public class ProducerIT extends HttpBridgeITAbstract {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProducerTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProducerIT.class);
 
     @Test
     void sendSimpleMessage(VertxTestContext context) throws InterruptedException, ExecutionException {
@@ -313,9 +313,9 @@ public class ProducerTest extends HttpBridgeTestAbstract {
 
         this.count = 0;
 
-        vertx.setPeriodic(HttpBridgeTestAbstract.PERIODIC_DELAY, timerId -> {
+        vertx.setPeriodic(HttpBridgeITAbstract.PERIODIC_DELAY, timerId -> {
 
-            if (this.count < HttpBridgeTestAbstract.PERIODIC_MAX_MESSAGE) {
+            if (this.count < HttpBridgeITAbstract.PERIODIC_MAX_MESSAGE) {
 
                 JsonArray records = new JsonArray();
                 JsonObject json = new JsonObject();

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -6,7 +6,7 @@ package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeTestAbstract;
+import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
 import io.strimzi.kafka.bridge.utils.Urls;
 import io.vertx.core.json.JsonArray;
@@ -28,7 +28,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class SeekTest extends HttpBridgeTestAbstract {
+public class SeekIT extends HttpBridgeITAbstract {
 
     private String name = "my-kafka-consumer";
     private String groupId = "my-group";
@@ -395,7 +395,7 @@ public class SeekTest extends HttpBridgeTestAbstract {
         JsonObject jsonConsumer = new JsonObject()
                                     .put("name", name)
                                     .put("format", "json");
-        
+
         JsonObject topics = new JsonObject()
                                     .put("topics", new JsonArray().add(subscribedTopic));
 
@@ -404,7 +404,7 @@ public class SeekTest extends HttpBridgeTestAbstract {
         consumerService()
             .createConsumer(context, groupId, jsonConsumer)
             .subscribeConsumer(context, groupId, name, topics);
-        
+
         CompletableFuture<Boolean> consume = new CompletableFuture<>();
 
         // poll to subscribe
@@ -459,16 +459,16 @@ public class SeekTest extends HttpBridgeTestAbstract {
         JsonObject jsonConsumer = new JsonObject()
                                     .put("name", name)
                                     .put("format", "json");
-        
+
         JsonObject topics = new JsonObject()
                                     .put("topics", new JsonArray().add(subscribedTopic));
-        
+
         // create consumer
         // subscribe to a topic
         consumerService()
             .createConsumer(context, groupId, jsonConsumer)
             .subscribeConsumer(context, groupId, name, topics);
-        
+
         CompletableFuture<Boolean> consume = new CompletableFuture<>();
 
         // poll to subscribe

--- a/src/test/java/io/strimzi/kafka/bridge/http/StaticIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/StaticIT.java
@@ -16,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  *  Static tests are those that does not applies for the regular @beforeAll, @beforeEach and @afterEach methods
  *  So this class of tests does not extends HttpBridgeTestBase
  */
-public class StaticTests {
+public class StaticIT {
 
     @Test
     /**

--- a/src/test/java/io/strimzi/kafka/bridge/http/StaticIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/StaticIT.java
@@ -28,8 +28,9 @@ public class StaticIT {
         String kBVersion = Utils.getKafkaBridgeVersionFromFile("release.version");
 
         ProcessBuilder bridgeJar = new ProcessBuilder(
-                "target/kafka-bridge-" + kBVersion + "/kafka-bridge-" + kBVersion + "/bin/kafka_bridge_run.sh",
-                "--config-file", "target/kafka-bridge-" + kBVersion + "/kafka-bridge-" + kBVersion + "/config/application.properties");
+                String.format("target/kafka-bridge-%s/kafka-bridge-%s/bin/kafka_bridge_run.sh", kBVersion, kBVersion),
+                "--config-file",
+                String.format("target/kafka-bridge-%s/kafka-bridge-%s/config/application.properties", kBVersion, kBVersion));
         Process bridgeProc = bridgeJar.start();
 
         InputStreamReader inputStreamReader = new InputStreamReader(bridgeProc.getInputStream());

--- a/src/test/java/io/strimzi/kafka/bridge/http/StaticTests.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/StaticTests.java
@@ -16,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  *  Static tests are those that does not applies for the regular @beforeAll, @beforeEach and @afterEach methods
  *  So this class of tests does not extends HttpBridgeTestBase
  */
-public class StaticIT {
+public class StaticTests {
 
     @Test
     /**

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -50,9 +50,9 @@ import static io.strimzi.kafka.bridge.Constants.HTTP_BRIDGE;
 @ExtendWith(VertxExtension.class)
 @SuppressWarnings({"checkstyle:JavaNCSS"})
 @Tag(HTTP_BRIDGE)
-public abstract class HttpBridgeTestAbstract {
+public abstract class HttpBridgeITAbstract {
 
-    protected static final Logger LOGGER = LogManager.getLogger(HttpBridgeTestAbstract.class);
+    protected static final Logger LOGGER = LogManager.getLogger(HttpBridgeITAbstract.class);
     protected static Map<String, Object> config = new HashMap<>();
 
     // for periodic/multiple messages test


### PR DESCRIPTION
Signed-off-by: Kate Chernousova <eachernous@gmail.com>

The change addresses https://github.com/strimzi/strimzi-kafka-bridge/issues/508, renamed some of tests as ITs.