### PR TITLE
Use UBI8 as a new base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added a new Admin Client feature to get begin/end offsets for topic partitions
 * Move from Docker Hub to Quay.io as our container registry
+* Use Red Hat UBI8 as the base image
 
 ## 0.19.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ARG JAVA_VERSION=11
 
-RUN yum -y update \
-    && yum -y install java-${JAVA_VERSION}-openjdk-headless openssl \
-    && yum -y clean all
+USER root
+
+RUN microdnf update \
+    && microdnf install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/java
+ENV JAVA_HOME /usr/lib/jvm/jre-11
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage
@@ -25,12 +27,17 @@ COPY target/kafka-bridge-${strimzi_kafka_bridge_version}/kafka-bridge-${strimzi_
 #####
 ENV TINI_VERSION v0.19.0
 ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
 ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
 
 RUN set -ex; \
     if [[ ${TARGETPLATFORM} = "linux/ppc64le" ]]; then \
         curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \
         echo "${TINI_SHA256_PPC64LE} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    elif [[ ${TARGETPLATFORM} = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
+        echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
         chmod +x /usr/bin/tini; \
     else \
         curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini; \


### PR DESCRIPTION
This PR updates the base image used by Strimzi Bridge to Red Hat UBI8 as proposed by [SP-23](https://github.com/strimzi/proposals/blob/main/023-using-ubi8-as-base-image.md). It also adds support for ARM64 version of the `tini` utility.