### PR TITLE
Enable DOCKER_BUILDX value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ARG JAVA_VERSION=11
+ARG TARGETPLATFORM
 
 USER root
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -75,3 +75,16 @@ Attach the ZIP and TAR.GZ archives to the release.
 8. On the `main` git branch:
   * Update the versions to the next SNAPSHOT version using the `next_version` `make` target. 
   For example to update the next version to `0.6.0-SNAPSHOT` run: `make NEXT_VERSION=0.6.0-SNAPSHOT next_version`.
+
+## Building container images for other platforms with Docker `buildx`
+
+Docker supports building images for different platforms using the `docker buildx` command. If you want to use it to
+build Strimzi images, you can just set the environment variable `DOCKER_BUILDX` to `buildx`, set the environment
+variable `DOCKER_BUILD_ARGS` to pass additional build options such as the platform and run the build. For example
+following can be used to build Strimzi images for Linux on PowerPC/ppc64le architecture:
+
+```
+export DOCKER_BUILDX=buildx
+export DOCKER_BUILD_ARGS="--platform linux/ppc64le"
+make all
+```

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -16,7 +16,7 @@ RELEASE_VERSION    ?= $(shell cat $(TOPDIR)/release.version)
 .PHONY: docker_build
 docker_build:
 	# Build Docker image ...
-	docker build $(DOCKER_BUILD_ARGS) --build-arg strimzi_kafka_bridge_version=$(RELEASE_VERSION) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
+	docker $(DOCKER_BUILDX) build $(DOCKER_BUILD_ARGS) --build-arg strimzi_kafka_bridge_version=$(RELEASE_VERSION) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
 #   The Dockerfiles all use FROM ...:latest, so it is necessary to tag images with latest (-t above)
 #   But because we generate Kafka images for different versions we also need to tag with something
 #   including the kafka version number. This BUILD_TAG is used by the docker_tag target.


### PR DESCRIPTION
Make it easier to build strimzi-kafka-bridge
container images for other platforms.

Signed-off-by: Krishna Harsha Voora <krishvoor@in.ibm.com>