### PR TITLE
Fix Vert.x cache directory

### DIFF
--- a/bin/kafka_bridge_run.sh
+++ b/bin/kafka_bridge_run.sh
@@ -10,6 +10,6 @@ then
 fi
 
 # Make sure that we use /dev/urandom
-JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp -Djava.security.egd=file:/dev/./urandom"
+JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp/vertx-cache -Djava.security.egd=file:/dev/./urandom"
 
 exec java $JAVA_OPTS $KAFKA_BRIDGE_LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"


### PR DESCRIPTION
#504 updated Vert.x to version 4.0.3. But due to some changes, Vert.x 4 requires different configuration for the cache directory to work with Strimzi. This is not found int he tests because it does not show up when running outside of containers. This Pr fixes the cache path and makes the container image work.