### PR TITLE
Update Vert.x, Kafka and some other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.13.3</log4j.version>
-		<vertx.version>4.0.3</vertx.version>
+		<vertx.version>4.1.0</vertx.version>
+		<kafka.version>2.7.0</kafka.version>
 		<debezium.version>1.2.3.Final</debezium.version>
 		<maven.checkstyle.version>3.1.0</maven.checkstyle.version>
 		<hamcrest.version>2.2</hamcrest.version>
@@ -21,12 +22,12 @@
 		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
 		<swagger2markup.version>1.3.7</swagger2markup.version>
-		<jackson-core.version>2.10.2</jackson-core.version>
+		<jackson-core.version>2.11.3</jackson-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
-		<strimzi-oauth.version>0.6.1</strimzi-oauth.version>
+		<strimzi-oauth.version>0.7.2</strimzi-oauth.version>
 		<jaeger.version>1.1.0</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
-		<opentracing-kafka-client.version>0.1.12</opentracing-kafka-client.version>
+		<opentracing-kafka-client.version>0.1.15</opentracing-kafka-client.version>
 		<micrometer.version>1.3.9</micrometer.version>
 		<jmx-prometheus-collector.version>0.12.0</jmx-prometheus-collector.version>
 		<commons-cli.version>1.4</commons-cli.version>
@@ -66,6 +67,11 @@
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-micrometer-metrics</artifactId>
 			<version>${vertx.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>${kafka.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
@@ -168,7 +174,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka_2.12</artifactId>
-			<version>2.6.0</version>
+			<version>${kafka.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This PR updates Vert.x to 4.1.0, Kafka to 2.7.0 + some other dependencies such as OAuth etc. It is intentionally not updating the tests to Kafka 2.8.0 or 2.7.1 because that seems to break some Admin API tests (due to behaviour changes in the Kafka Admin API) and the AMQP tests (which seem to use the Debezium Kafka Cluster which does not support 2.8.0).