### PR TITLE
Update Kafka Bridge to use OAuth library 0.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,13 @@
 	<name>kafka-bridge</name>
 	<description>Apache Kafka bridge</description>
 
+	<repositories>
+		<repository>
+			<id>oauth-staging</id>
+			<url>https://oss.sonatype.org/content/repositories/iostrimzi-1104</url>
+		</repository>
+	</repositories>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
@@ -24,7 +31,7 @@
 		<swagger2markup.version>1.3.7</swagger2markup.version>
 		<jackson-core.version>2.11.3</jackson-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
-		<strimzi-oauth.version>0.7.2</strimzi-oauth.version>
+		<strimzi-oauth.version>0.8.0</strimzi-oauth.version>
 		<jaeger.version>1.1.0</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.15</opentracing-kafka-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,6 @@
 	<name>kafka-bridge</name>
 	<description>Apache Kafka bridge</description>
 
-	<repositories>
-		<repository>
-			<id>oauth-staging</id>
-			<url>https://oss.sonatype.org/content/repositories/iostrimzi-1104</url>
-		</repository>
-	</repositories>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
This PR updates the Kafka Bridge to use the OAuth library version 0.8.0.