### PR TITLE
Clean up attributes in the AsciiDoc documentation

### DIFF
--- a/documentation/book/bridge.adoc
+++ b/documentation/book/bridge.adoc
@@ -2,7 +2,7 @@ include::common/attributes.adoc[]
 
 :context: book
 
-= {ProductLongName} API reference
+= Strimzi Kafka Bridge API reference
 
 [id='api_reference-{context}']
 

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -12,11 +12,3 @@
 :linkattrs:
 :toclevels: 3
 :sectlinks:
-
-// Name and version placeholders
-:ProductLongName: Strimzi Kafka Bridge
-:ProductName: Kafka Bridge
-
-//Latest Strimzi version
-:ProductVersion: 0.12.0
-


### PR DESCRIPTION
The Bridge documentation currently has several attributes:
* `ProductVersion` is not used anywhere
* `ProductName` is not used anywhere
* `ProductLongName` is actually used, but in the past we agreed to not use any name attributes like this.

This PR removes the attributes from the documentation.