### PR TITLE
Update OAuth library to 0.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
 		<swagger2markup.version>1.3.7</swagger2markup.version>
 		<jackson-core.version>2.11.3</jackson-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
-		<strimzi-oauth.version>0.8.0</strimzi-oauth.version>
-		<jaeger.version>1.1.0</jaeger.version>
+		<strimzi-oauth.version>0.8.1</strimzi-oauth.version>
+		<jaeger.version>1.3.2</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.15</opentracing-kafka-client.version>
 		<micrometer.version>1.3.9</micrometer.version>


### PR DESCRIPTION
This PR updates the OAuth library to 0.8.1 to address CVE-2021-27568. It also updates the Jaeger client to 1.3.2 to match the version used in our other components.