### PR TITLE
Add configuration providers and bump some dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,13 +113,6 @@
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>env-var-config-provider-staging</id>
-			<url>https://oss.sonatype.org/content/repositories/iostrimzi-1112/</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,10 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.13.3</log4j.version>
-		<vertx.version>4.1.0</vertx.version>
+		<vertx.version>4.1.2</vertx.version>
 		<kafka.version>2.7.0</kafka.version>
+		<kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
+		<kafka-env-var-config-provider.version>0.1.0</kafka-env-var-config-provider.version>
 		<debezium.version>1.2.3.Final</debezium.version>
 		<maven.checkstyle.version>3.1.0</maven.checkstyle.version>
 		<hamcrest.version>2.2</hamcrest.version>
@@ -110,6 +112,13 @@
 		<!--suppress UnresolvedMavenProperty -->
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
 	</properties>
+
+	<repositories>
+		<repository>
+			<id>env-var-config-provider-staging</id>
+			<url>https://oss.sonatype.org/content/repositories/iostrimzi-1112/</url>
+		</repository>
+	</repositories>
 
 	<dependencies>
 		<dependency>
@@ -213,6 +222,46 @@
 			<artifactId>commons-cli</artifactId>
 			<version>${commons-cli.version}</version>
 		</dependency>
+		<!-- Kubernetes Configuration Provider for Apache Kafka -->
+		<dependency>
+			<groupId>io.strimzi</groupId>
+			<artifactId>kafka-kubernetes-config-provider</artifactId>
+			<version>${kafka-kubernetes-config-provider.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- EnvVar Configuration Provider for Apache Kafka -->
+		<dependency>
+			<groupId>io.strimzi</groupId>
+			<artifactId>kafka-env-var-config-provider</artifactId>
+			<version>${kafka-env-var-config-provider.version}</version>
+		</dependency>
+
+		<!-- Transitive dependency version overrides for Vulnerabilities: -->
+		<!-- overriding version commons-io for Vert.x - Vulnerability -->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.7</version>
+		</dependency>
+		<!-- overriding version of snakeyaml for prometheus.jmx.collector 0.12.0: Vulnerability: DOS -->
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<version>1.29</version>
+		</dependency>
 
 		<!-- Testing -->
 		<dependency>
@@ -270,20 +319,6 @@
 			<version>${debezium.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
-		</dependency>
-
-		<!-- Transitive dependency version overrides for Vulnerabilities: -->
-		<!-- overriding version commons-io for vertex 3.9.3 - Vulnerability -->
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.7</version>
-		</dependency>
-		<!-- overriding version of snakeyaml for prometheus.jmx.collector 0.12.0: Vulnerability: DOS -->
-		<dependency>
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>1.26</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This PR adds the Kubernetes and EnvVar configuration providers to Kafka Bridge. It also bumps the Vert.x and SnakeYAML dependencies (and reorders the `pom.xml` so that runtime dependencies overriding the transitive dependencies with CVEs are not lost behind the test dependencies.)