### PR TITLE
Update Strimzi Configuration Providers to 0.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
 		<log4j.version>2.13.3</log4j.version>
 		<vertx.version>4.1.2</vertx.version>
 		<kafka.version>2.7.0</kafka.version>
-		<kafka-kubernetes-config-provider.version>0.1.0</kafka-kubernetes-config-provider.version>
-		<kafka-env-var-config-provider.version>0.1.0</kafka-env-var-config-provider.version>
+		<kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>
+		<kafka-env-var-config-provider.version>0.1.1</kafka-env-var-config-provider.version>
 		<debezium.version>1.2.3.Final</debezium.version>
 		<maven.checkstyle.version>3.1.0</maven.checkstyle.version>
 		<hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
This PR updates the versions of the EnvVar and Kubernetes Configuration Providers to 0.1.1 which was released today with some bugfixes and dependency bumps.