### PR TITLE
Update Strimzi Kafka OAuth library to 0.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 		<netty.version>4.1.68.Final</netty.version>
 		<tomcat-embed-core.version>8.5.68</tomcat-embed-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
-		<strimzi-oauth.version>0.8.1</strimzi-oauth.version>
+		<strimzi-oauth.version>0.9.0</strimzi-oauth.version>
 		<jaeger.version>1.6.0</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.15</opentracing-kafka-client.version>


### PR DESCRIPTION
This Pr updates the Strimzi Kafka OAuth library in the bridge to 0.9.0.