### PR TITLE
Fix typo in openApi spec

### DIFF
--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1398,7 +1398,7 @@
                 "title": "KafkaHeaderList",
                 "type": "array",
                 "items": {
-                    "$ref": "#/definitions/KafkaHeader"
+                    "$ref": "#/components/schemas/KafkaHeader"
                 },
                 "example": [
                     {
@@ -1448,7 +1448,7 @@
                         "type": "string"
                     },
                     "headers": {
-                        "$ref": "#/definitions/KafkaHeaderList"
+                        "$ref": "#/components/schemas/KafkaHeaderList"
                     }
                 },
                 "title": "ConsumerRecord",
@@ -1737,7 +1737,7 @@
                         ]
                     },
                     "headers": {
-                        "$ref": "#/definitions/KafkaHeaderList"
+                        "$ref": "#/components/schemas/KafkaHeaderList"
                     }
                 },
                 "additionalProperties": false,

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1716,15 +1716,14 @@
                     "value": {
                         "oneOf": [
                             {
-                                "type": "object"
+                                "type": "object",
+                                "nullable": true
                             },
                             {
                                 "type": "string"
-                            },
-                            {
-                                "type": "null"
                             }
-                        ]
+                        ],
+                        "nullable" : true
                     },
                     "key": {
                         "oneOf": [


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Copypaste error. `definitions` is openApi v2 format.