### PR TITLE
Add support for multi-arch image manifests and for AArch64 / ARM64 container builds

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -33,6 +33,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
+          architectures: ['amd64', 'arm64']
   - stage: container_publish
     displayName: Publish Container
     dependsOn:
@@ -48,6 +49,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
+          architectures: ['amd64', 'arm64']
   - stage: docs_publish
     displayName: Publish Docs
     dependsOn:

--- a/.azure/cve-pipeline.yaml
+++ b/.azure/cve-pipeline.yaml
@@ -36,6 +36,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
+          architectures: ['amd64', 'arm64']
   - stage: containers_publish_with_suffix
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     dependsOn: 
@@ -50,6 +51,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
+          architectures: ['amd64', 'arm64']
   - stage: manual_validation
     displayName: Validate container before pushing container as ${{ parameters.releaseVersion }}
     dependsOn:

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -38,6 +38,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
+          architectures: ['amd64', 'arm64']
   - stage: containers_publish
     displayName: Publish Containers for ${{ parameters.releaseVersion }}
     dependsOn:
@@ -52,3 +53,4 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
+          architectures: ['amd64', 'arm64']

--- a/.azure/scripts/container-push.sh
+++ b/.azure/scripts/container-push.sh
@@ -3,10 +3,18 @@ set -e
 
 echo "Build reason: ${BUILD_REASON}"
 echo "Source branch: ${BRANCH}"
+echo "Requested architectures ${ARCHITECTURES}"
 echo "Pushing container images for ${DOCKER_TAG}"
 
 # Tag and Push the container
 echo "Login into Docker Hub ..."
 docker login -u $DOCKER_USER -p $DOCKER_PASS $DOCKER_REGISTRY
 
-make docker_load docker_tag docker_push
+make docker_delete_manifest
+
+for ARCH in $ARCHITECTURES
+do
+    DOCKER_ARCHITECTURE=$ARCH make docker_load docker_tag docker_push docker_amend_manifest
+done
+
+make docker_push_manifest

--- a/.azure/templates/jobs/build_container.yaml
+++ b/.azure/templates/jobs/build_container.yaml
@@ -1,6 +1,12 @@
 jobs:
   - job: 'build_container'
     displayName: 'Build'
+    # Strategy for the job
+    strategy:
+      matrix:
+        ${{ each arch in parameters.architectures }}:
+          ${{ arch }}:
+            arch: ${{ arch }}
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system
@@ -22,10 +28,12 @@ jobs:
         displayName: "Untar the target directory"
       - bash: ".azure/scripts/container-build.sh"
         env:
+          DOCKER_BUILDKIT: 1
           BUILD_REASON: $(Build.Reason)
           BRANCH: $(Build.SourceBranch)
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi"
-        displayName: "Build container"
-      - publish: $(System.DefaultWorkingDirectory)/kafka-bridge.tar.gz
-        artifact: Container
+          DOCKER_ARCHITECTURE: $(arch)
+        displayName: "Build container - $(arch)"
+      - publish: $(System.DefaultWorkingDirectory)/kafka-bridge-$(arch).tar.gz
+        artifact: Container-$(arch)

--- a/.azure/templates/jobs/push_container.yaml
+++ b/.azure/templates/jobs/push_container.yaml
@@ -9,15 +9,16 @@ jobs:
     # Pipeline steps
     steps:
       - template: '../steps/setup_docker.yaml'
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          source: '${{ parameters.artifactSource }}'
-          artifact: Container
-          path: $(System.DefaultWorkingDirectory)
-          project: '${{ parameters.artifactProject }}'
-          pipeline: '${{ parameters.artifactPipeline }}'
-          runVersion: '${{ parameters.artifactRunVersion }}'
-          runId: '${{ parameters.artifactRunId }}'
+      - ${{ each arch in parameters.architectures }}:
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            source: '${{ parameters.artifactSource }}'
+            artifact: Container-${{ arch }}
+            path: $(System.DefaultWorkingDirectory)
+            project: '${{ parameters.artifactProject }}'
+            pipeline: '${{ parameters.artifactPipeline }}'
+            runVersion: '${{ parameters.artifactRunVersion }}'
+            runId: '${{ parameters.artifactRunId }}'
       - bash: ".azure/scripts/container-push.sh"
         env:
           BUILD_REASON: $(Build.Reason)
@@ -27,4 +28,5 @@ jobs:
           DOCKER_REGISTRY: "quay.io"
           DOCKER_ORG: "strimzi"
           DOCKER_TAG: '${{ parameters.dockerTag }}'
+          ARCHITECTURES: ${{ join(' ', parameters.architectures) }}
         displayName: "Tag & Push container"

--- a/.azure/templates/steps/setup_docker.yaml
+++ b/.azure/templates/steps/setup_docker.yaml
@@ -5,3 +5,6 @@ steps:
     inputs:
       dockerVersion: 20.10.8
       releaseType: stable
+  - bash: |
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    displayName: 'Register QEMU binary'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.21.0
+
+* Multi-arch container image with support for x86_64 / AMD64 and AArch64 / ARM64 platforms
+  _(The support AArch64 is currently considered as experimental. We are not aware of any issues, but the AArch64 build doesn't at this point undergo the same level of testing as the AMD64 container images.)_
+
 ## 0.20.0
 
 * Added a new Admin Client feature to get begin/end offsets for topic partitions
@@ -17,7 +22,7 @@
 
 * Use Java 11 as the Java runtime
 * Renamed exposed HTTP server and Kafka consumer and producer metrics, using `strimzi_bridge` as prefix
-* Added topic-partition retrivial operation to the Admin Client endpoint
+* Added topic-partition retrieval operation to the Admin Client endpoint
 
 ## 0.17.0
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -13,32 +13,52 @@ DOCKER_TAG         ?= latest
 BUILD_TAG          ?= latest
 RELEASE_VERSION    ?= $(shell cat $(TOPDIR)/release.version)
 
+ifdef DOCKER_ARCHITECTURE
+  DOCKER_PLATFORM = --platform linux/$(DOCKER_ARCHITECTURE)
+  DOCKER_PLATFORM_TAG_SUFFIX = -$(DOCKER_ARCHITECTURE)
+endif
+
 .PHONY: docker_build
 docker_build:
 	# Build Docker image ...
-	docker $(DOCKER_BUILDX) build $(DOCKER_BUILD_ARGS) --build-arg strimzi_kafka_bridge_version=$(RELEASE_VERSION) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
+	docker $(DOCKER_BUILDX) build $(DOCKER_PLATFORM) $(DOCKER_BUILD_ARGS) --build-arg strimzi_kafka_bridge_version=$(RELEASE_VERSION) -t strimzi/$(PROJECT_NAME):latest $(DOCKERFILE_DIR)
 #   The Dockerfiles all use FROM ...:latest, so it is necessary to tag images with latest (-t above)
 #   But because we generate Kafka images for different versions we also need to tag with something
 #   including the kafka version number. This BUILD_TAG is used by the docker_tag target.
 	# Also tag with $(BUILD_TAG)
-	docker tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)
+	docker tag strimzi/$(PROJECT_NAME):latest strimzi/$(PROJECT_NAME):$(BUILD_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
 
 .PHONY: docker_save
 docker_save:
 	# Saves the container as TGZ file
-	docker save strimzi/$(PROJECT_NAME):$(BUILD_TAG) | gzip > kafka-bridge.tar.gz
+	docker save strimzi/$(PROJECT_NAME):$(BUILD_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) | gzip > kafka-bridge$(DOCKER_PLATFORM_TAG_SUFFIX).tar.gz
 
 .PHONY: docker_load
 docker_load:
 	# Loads the container as TGZ file
-	docker load < kafka-bridge.tar.gz
+	docker load < kafka-bridge$(DOCKER_PLATFORM_TAG_SUFFIX).tar.gz
 
 .PHONY: docker_tag
 docker_tag:
 	# Tag the $(BUILD_TAG) image we built with the given $(DOCKER_TAG) tag
-	docker tag strimzi/$(PROJECT_NAME):$(BUILD_TAG) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	docker tag strimzi/$(PROJECT_NAME):$(BUILD_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX) $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
 
 .PHONY: docker_push
 docker_push: docker_tag
 	# Push the $(DOCKER_TAG)-tagged image to the registry
-	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+	docker push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
+
+.PHONY: docker_amend_manifest
+docker_amend_manifest:
+	# Create / Amend the manifest
+	docker manifest create $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) --amend $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)$(DOCKER_PLATFORM_TAG_SUFFIX)
+
+.PHONY: docker_push_manifest
+docker_push_manifest:
+	# Push the manifest to the registry
+	docker manifest push $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG)
+
+.PHONY: docker_delete_manifest
+docker_delete_manifest:
+	# Delete the manifest to the registry, ignore the error if manifest doesn't exist
+	docker manifest rm $(DOCKER_REGISTRY)/$(DOCKER_ORG)/$(PROJECT_NAME):$(DOCKER_TAG) || true


### PR DESCRIPTION
This PR adds support for multi-arch container builds and experimental support for the AArch64 / ARM64 platform.

Most of the logic is done inside the Azure Pipelines CI and in the Make build system. When building locally, the default build should work exactly as it worked up until now. It builds a regular image based on your platform and tags it as `:latest` by default. This way, there is minimal disruption for local development and the build is also faster without the multi-arch build. If you would want to build for another architecture and your Docker supports it, you can use the environment variable `DOCKER_ARCHITECTURE` ... for example `DOCKER_ARCHITECTURE=arm64 make all`.

But on the CI, it does the builds for both AMD64 and ARM64. These images are Since we use Java, these images use always the same java binaries (TAR.GZ with JARs), but differ in platform. They are pushed into the container registry with the platform as part of the tag - e.g. `:latest-amd64` and `:latest-arm64`. Afterwards, the build creates the multi-arch manifest which is tagged as `:latest` and pushed into the registry as well. That way, the image name will be still `quay.io/strimzi/kafka-bridge:latest` as before (technically, this would be the multi-arch manifest) and each platform will pull the right image based on it.

You can check how it will look in Quay on the example build I did and on this screenshot:
![Screenshot 2021-11-01 at 23 21 30](https://user-images.githubusercontent.com/5658439/139749817-b4a49e62-fc2f-4844-8965-86f5b1956c0c.png)
