### PR TITLE
Update the versions for vertx and netty dependecies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.13.3</log4j.version>
-		<vertx.version>4.1.5</vertx.version>
+		<vertx.version>4.2.1</vertx.version>
 		<kafka.version>2.8.1</kafka.version>
 		<kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>0.1.1</kafka-env-var-config-provider.version>
@@ -99,7 +99,7 @@
 		<sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 		<swagger2markup.version>1.3.7</swagger2markup.version>
 		<jackson-core.version>2.11.3</jackson-core.version>
-		<netty.version>4.1.68.Final</netty.version>
+		<netty.version>4.1.70.Final</netty.version>
 		<tomcat-embed-core.version>8.5.68</tomcat-embed-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
 		<strimzi-oauth.version>0.9.0</strimzi-oauth.version>


### PR DESCRIPTION
This PR updates the version of netty dependency to 4.1.70.Final and vertx version to 4.2.1