### PR TITLE
Fix container architectures in CVE re-spin pipeline

### DIFF
--- a/.azure/cve-pipeline.yaml
+++ b/.azure/cve-pipeline.yaml
@@ -86,3 +86,4 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
+          architectures: ['amd64', 'arm64']


### PR DESCRIPTION
The CVE re-spin pipeline is missing the required container architectures in the CVE pipeline. As a result, the re-spin would not work properly. This PR fixes it and adds the desired architectures.