### PR TITLE
Add s390x support to multi-arch images on Azure CI

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -33,7 +33,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
   - stage: container_publish
     displayName: Publish Container
     dependsOn:
@@ -49,7 +49,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
   - stage: docs_publish
     displayName: Publish Docs
     dependsOn:

--- a/.azure/cve-pipeline.yaml
+++ b/.azure/cve-pipeline.yaml
@@ -36,7 +36,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
   - stage: containers_publish_with_suffix
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     dependsOn: 
@@ -51,7 +51,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
   - stage: manual_validation
     displayName: Validate container before pushing container as ${{ parameters.releaseVersion }}
     dependsOn:

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -38,7 +38,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']
   - stage: containers_publish
     displayName: Publish Containers for ${{ parameters.releaseVersion }}
     dependsOn:
@@ -53,4 +53,4 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x']


### PR DESCRIPTION
This PR is to add s390x support to Bridge images on Azure CI. 

Signed-off-by: Kun-Lu <kun.lu@ibm.com>