### PR TITLE
Fixed ignored JVM options

### DIFF
--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -55,6 +55,14 @@ function get_gc_opts {
 
 export JAVA_OPTS="${JAVA_OPTS} $(get_gc_opts)"
 
+if [ -n "$STRIMZI_JAVA_SYSTEM_PROPERTIES" ]; then
+    export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_SYSTEM_PROPERTIES}"
+fi
+
+if [ -n "$STRIMZI_JAVA_OPTS" ]; then
+    export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_OPTS}"
+fi
+
 # Deny illegal access option is supported only on Java 9 and higher
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
 if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then

--- a/bin/kafka_bridge_run.sh
+++ b/bin/kafka_bridge_run.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -x
 
 # Find my path to use when calling scripts
 MYPATH="$(dirname "$0")"


### PR DESCRIPTION
This PR fixes #571 allowing the bridge to use the system properties and general Java options they are passed.
It also enable trace on script to print the executed command.