### PR TITLE
Fixes for running ITs with external Kafka and KafkaBridge

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/amqp/AmqpBridgeIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/amqp/AmqpBridgeIT.java
@@ -104,13 +104,12 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
 
     @BeforeAll
     public static void setUp(VertxTestContext context) {
-        adminClientFacade = AdminClientFacade.create(kafkaContainer.getBootstrapServers());
-        config.put(KafkaConfig.KAFKA_CONFIG_PREFIX + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        adminClientFacade = AdminClientFacade.create(kafkaUri);
+        config.put(KafkaConfig.KAFKA_CONFIG_PREFIX + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         vertx = Vertx.vertx();
 
         if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
-
             bridgeConfig = BridgeConfig.fromMap(config);
             bridge = new AmqpBridge(bridgeConfig, new MetricsReporter(null, meterRegistry));
 
@@ -145,7 +144,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
                 String body = "Simple message from " + connection.getContainer();
                 Message message = ProtonHelper.message(topic, body);
 
-                Properties config = Consumer.fillProperties(kafkaContainer.getBootstrapServers(), "groupId", null, OffsetResetStrategy.EARLIEST);
+                Properties config = Consumer.fillProperties(kafkaUri, "groupId", null, OffsetResetStrategy.EARLIEST);
 
                 config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
                 config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -207,7 +206,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
                 String body = "Simple message from " + connection.getContainer();
                 Message message = ProtonHelper.message(topic, body);
 
-                Properties config = Consumer.fillProperties(kafkaContainer.getBootstrapServers(), "groupId", null, OffsetResetStrategy.EARLIEST);
+                Properties config = Consumer.fillProperties(kafkaUri, "groupId", null, OffsetResetStrategy.EARLIEST);
                 config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
                 config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 
@@ -269,7 +268,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
                 String body = "Simple message from " + connection.getContainer();
                 Message message = ProtonHelper.message(topic, body);
 
-                Properties config = Consumer.fillProperties(kafkaContainer.getBootstrapServers(), "groupId", null, OffsetResetStrategy.EARLIEST);
+                Properties config = Consumer.fillProperties(kafkaUri, "groupId", null, OffsetResetStrategy.EARLIEST);
 
                 config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
                 config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -329,7 +328,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
 
                 String value = "Binary message from " + connection.getContainer();
 
-                Properties config = Consumer.fillProperties(kafkaContainer.getBootstrapServers(), "groupId", null, OffsetResetStrategy.EARLIEST);
+                Properties config = Consumer.fillProperties(kafkaUri, "groupId", null, OffsetResetStrategy.EARLIEST);
 
                 config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
                 config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
@@ -385,7 +384,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
                 // send an array (i.e. integer values)
                 int[] array = {1, 2};
 
-                Properties config = Consumer.fillProperties(kafkaContainer.getBootstrapServers(), "groupId", null, OffsetResetStrategy.EARLIEST);
+                Properties config = Consumer.fillProperties(kafkaUri, "groupId", null, OffsetResetStrategy.EARLIEST);
 
                 config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
                 config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, DefaultDeserializer.class);
@@ -444,7 +443,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
                 list.add("item1");
                 list.add(2);
 
-                Properties config = Consumer.fillProperties(kafkaContainer.getBootstrapServers(), "groupId", null, OffsetResetStrategy.EARLIEST);
+                Properties config = Consumer.fillProperties(kafkaUri, "groupId", null, OffsetResetStrategy.EARLIEST);
 
                 config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
                 config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, DefaultDeserializer.class);
@@ -503,7 +502,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
                 map.put("1", 10);
                 map.put(2, "Hello");
 
-                Properties config = Consumer.fillProperties(kafkaContainer.getBootstrapServers(), "groupId", null, OffsetResetStrategy.EARLIEST);
+                Properties config = Consumer.fillProperties(kafkaUri, "groupId", null, OffsetResetStrategy.EARLIEST);
 
                 config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
                 config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, DefaultDeserializer.class);
@@ -557,7 +556,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
                 ProtonSender sender = connection.createSender(null);
                 sender.open();
 
-                Properties config = Consumer.fillProperties(kafkaContainer.getBootstrapServers(), "groupId", null, OffsetResetStrategy.EARLIEST);
+                Properties config = Consumer.fillProperties(kafkaUri, "groupId", null, OffsetResetStrategy.EARLIEST);
 
                 config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
                 config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -691,7 +690,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
         Checkpoint consume = context.checkpoint();
         future.get();
 
-        BasicKafkaClient basicKafkaClient = new BasicKafkaClient(kafkaContainer.getBootstrapServers());
+        BasicKafkaClient basicKafkaClient = new BasicKafkaClient(kafkaUri);
 
         basicKafkaClient.sendStringMessagesPlain(topic, sentBody, 1, 0);
         // topic, body, message-count, partition
@@ -756,7 +755,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
         // Futures for wait
         Checkpoint consume = context.checkpoint();
 
-        BasicKafkaClient basicKafkaClient = new BasicKafkaClient(kafkaContainer.getBootstrapServers());
+        BasicKafkaClient basicKafkaClient = new BasicKafkaClient(kafkaUri);
         basicKafkaClient.sendStringMessagesPlain(topic, sentBody, 1, 1);
 
         ProtonClient client = ProtonClient.create(this.vertx);
@@ -824,7 +823,7 @@ class AmqpBridgeIT extends HttpBridgeITAbstract {
         // Futures for wait
         Checkpoint consume = context.checkpoint();
 
-        BasicKafkaClient basicKafkaClient = new BasicKafkaClient(kafkaContainer.getBootstrapServers());
+        BasicKafkaClient basicKafkaClient = new BasicKafkaClient(kafkaUri);
         basicKafkaClient.sendStringMessagesPlain(topic, "value", 11, 0, false);
 
         ProtonClient client = ProtonClient.create(this.vertx);

--- a/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -74,16 +75,20 @@ public class InvalidProducerIT extends HttpBridgeITAbstract {
 
         LOGGER.info("Environment variable EXTERNAL_BRIDGE:" + BRIDGE_EXTERNAL_ENV);
 
-        bridgeConfig = BridgeConfig.fromMap(cfg);
-        httpBridge = new HttpBridge(bridgeConfig, new MetricsReporter(jmxCollectorRegistry, meterRegistry));
-        httpBridge.setHealthChecker(new HealthChecker());
+        if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
+            bridgeConfig = BridgeConfig.fromMap(cfg);
+            httpBridge = new HttpBridge(bridgeConfig, new MetricsReporter(jmxCollectorRegistry, meterRegistry));
+            httpBridge.setHealthChecker(new HealthChecker());
 
-        LOGGER.info("Deploying in-memory bridge");
-        vertx.deployVerticle(httpBridge, context.succeeding(id -> context.completeNow()));
+            LOGGER.info("Deploying in-memory bridge");
+            vertx.deployVerticle(httpBridge, context.succeeding(id -> context.completeNow()));
+        } else {
+            context.completeNow();
+        }
 
         client = WebClient.create(vertx, new WebClientOptions()
-                .setDefaultHost(Urls.BRIDGE_HOST)
-                .setDefaultPort(Urls.BRIDGE_PORT)
+            .setDefaultHost(Urls.BRIDGE_HOST)
+            .setDefaultPort(Urls.BRIDGE_PORT)
         );
     }
 }


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This PR fixes issues with some test suites when running ITs against external Kafka and KafkaBridge.

Currently, in `AmqpBridgeIT` we are getting the bootstrap address from `kafkaContainer.getBootstrapServers()` - if we are running Kafka externally, the `kafkaContainer` is empty (`null`), so execution of `kafkaContainer.getBootstrapServers()` will lead to NPE. `kafkaUri` contains bootstrap address of Kafka container or external Kafka, depending on env (if `EXTERNAL_KAFKA` is set to `TRUE`)

Second issue was with `InvalidProducerIT`, which was implemented only for container run -> so if we deployed external Kafka and Bridge, test just failed on `BeforeAll` as the addresses are already binded and the test checks weren't executed against the external components.