### PR TITLE
Add support for disabling the FIPS mode in OpenJDK

### DIFF
--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -63,6 +63,11 @@ if [ -n "$STRIMZI_JAVA_OPTS" ]; then
     export JAVA_OPTS="${JAVA_OPTS} ${STRIMZI_JAVA_OPTS}"
 fi
 
+# Disable FIPS if needed
+if [ "$FIPS_MODE" = "disabled" ]; then
+    export JAVA_OPTS="${JAVA_OPTS} -Dcom.redhat.fips=false"
+fi
+
 # Deny illegal access option is supported only on Java 9 and higher
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
 if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then

--- a/bin/docker/kafka_bridge_tls_prepare_certificates.sh
+++ b/bin/docker/kafka_bridge_tls_prepare_certificates.sh
@@ -6,7 +6,15 @@
 # $3: Public key to be imported
 # $4: Alias of the certificate
 function create_truststore {
-   keytool -keystore $1 -storepass $2 -noprompt -alias $4 -import -file $3 -storetype PKCS12
+   # Disable FIPS if needed
+   if [ "$FIPS_MODE" = "disabled" ]; then
+       KEYTOOL_OPTS="${KEYTOOL_OPTS} -J-Dcom.redhat.fips=false"
+   else
+       KEYTOOL_OPTS=""
+   fi
+
+   # shellcheck disable=SC2086
+   keytool ${KEYTOOL_OPTS} -keystore $1 -storepass $2 -noprompt -alias $4 -import -file $3 -storetype PKCS12
 }
 
 # Parameters:


### PR DESCRIPTION
When running Strimzi in FIPS enabled Kubernetes or OpenShift clusters. the new versions of OpenJDK automatically enforces the FIPS limitations and allows the applications to use only SunPKCS11 security provider. This is currently not supported by Strimzi and the bridge fails (and so would the operands if deployed).

While we currently do not support running the Strimzi Bridge in FIPS compliant mode, this PR allows to disable the OpenJDK FIPS mode by setting the `FIPS_MODE` environment variable to `disabled`.

The main part of this work is in the operators in the PR strimzi/strimzi-kafka-operator#6252