### PR TITLE
Added disable FIPS mode in OpenJDK to the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.22.0
+
+* Add support for disabling the FIPS mode in OpenJDK
+
 ## 0.21.0
 
 * Multi-arch container image with support for x86_64 / AMD64 and AArch64 / ARM64 platforms


### PR DESCRIPTION
Just adding the "disable FIPS mode in OpenJDK" to the CHANGELOG.