### PR TITLE
Added `isolation.level` to read  commited / all transactional messages

### DIFF
--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -38,6 +38,8 @@ __optional__|If set to `true`, message offsets are committed automatically for t
 __optional__|Sets the minimum ammount of data, in bytes, for the consumer to receive. The broker waits until the data to send exceeds this amount.|integer
 |**format** +
 __optional__|The allowable message format for the consumer, which can be `binary` (default) or `json`. The messages are converted into a JSON format.|string
+|**isolation.level** +
+__optional__|If set to `read_uncommitted`, all transaction records are retrieved. If set to `read_committed` , the records from committed transactions are retrieved.|string
 |**name** +
 __optional__|The unique name for the consumer instance. The name is unique within the scope of the consumer group. The name is used in URLs.|string
 |===

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -90,7 +90,8 @@ __required__|Name and configuration of the consumer. The name is unique within t
   "auto.offset.reset" : "earliest",
   "enable.auto.commit" : false,
   "fetch.min.bytes" : 512,
-  "consumer.request.timeout.ms" : 30000
+  "consumer.request.timeout.ms" : 30000,
+  "isolation.level" : "read_committed"
 }
 ----
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -131,6 +131,9 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         addConfigParameter(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG,
             requestTimeoutMs != null ? String.valueOf(requestTimeoutMs) : null, config);
         addConfigParameter(ConsumerConfig.CLIENT_ID_CONFIG, this.name, config);
+        Object isolationLevel = bodyAsJson.getValue(ConsumerConfig.ISOLATION_LEVEL_CONFIG);
+        addConfigParameter(ConsumerConfig.ISOLATION_LEVEL_CONFIG,
+                isolationLevel != null ? String.valueOf(isolationLevel) : null, config);
 
         // create the consumer
         this.initConsumer(false, config);

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1596,6 +1596,10 @@
                     "enable.auto.commit": {
                         "description": "If set to `true`, message offsets are committed automatically for the consumer. If set to `false`, message offsets must be committed manually.",
                         "type": "boolean"
+                    },
+                    "isolation.level": {
+                        "description": "If set to `read_uncommitted`, all transaction records are retrieved, independently on the transaction outcome (if any), and `read_committed` to get the records from committed transactions.",
+                        "type": "string"
                     }
                 },
                 "additionalProperties": false,
@@ -1605,7 +1609,8 @@
                     "auto.offset.reset": "earliest",
                     "enable.auto.commit": false,
                     "fetch.min.bytes": 512,
-                    "consumer.request.timeout.ms": 30000
+                    "consumer.request.timeout.ms": 30000,
+                    "isolation.level": "read_committed"
                 }
             },
             "OffsetCommitSeek": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1439,6 +1439,10 @@
         "enable.auto.commit": {
           "description": "If set to `true`, message offsets are committed automatically for the consumer. If set to `false`, message offsets must be committed manually.",
           "type": "boolean"
+        },
+        "isolation.level": {
+          "description": "If set to `read_uncommitted`, all transaction records are retrieved. If set to `read_committed` , the records from committed transactions are retrieved.",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -1448,7 +1452,8 @@
         "auto.offset.reset": "earliest",
         "enable.auto.commit": false,
         "fetch.min.bytes": 512,
-        "consumer.request.timeout.ms": 30000
+        "consumer.request.timeout.ms": 30000,
+        "isolation.level": "read_committed"
       }
     },
     "OffsetCommitSeek": {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -435,6 +435,15 @@ public class ConsumerIT extends HttpBridgeITAbstract {
     }
 
     @Test
+    void createConsumerWithWrongIsolationLevel(VertxTestContext context) throws InterruptedException, TimeoutException, ExecutionException {
+        checkCreatingConsumer("isolation.level", "foo", HttpResponseStatus.UNPROCESSABLE_ENTITY,
+                "Invalid value foo for configuration isolation.level: String must be one of: read_committed, read_uncommitted", context);
+
+        context.completeNow();
+        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+    }
+
+    @Test
     void createConsumerWithWrongAutoOffsetReset(VertxTestContext context) throws InterruptedException, TimeoutException, ExecutionException {
         checkCreatingConsumer("auto.offset.reset", "foo", HttpResponseStatus.UNPROCESSABLE_ENTITY,
                 "Invalid value foo for configuration auto.offset.reset: String must be one of: latest, earliest, none", context);


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

This PR fixes the issue mentioned in #577. Now isolation level can be set to `read_committed` to see the commited transaction records or it can set to `read_uncommited` to read all transaction records.