### PR TITLE
Update Config Providers, Vert.x and Jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,10 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.17.1</log4j.version>
-		<vertx.version>4.2.1</vertx.version>
+		<vertx.version>4.2.4</vertx.version>
 		<kafka.version>2.8.1</kafka.version>
-		<kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>
-		<kafka-env-var-config-provider.version>0.1.1</kafka-env-var-config-provider.version>
+		<kafka-kubernetes-config-provider.version>1.0.0</kafka-kubernetes-config-provider.version>
+		<kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>
 		<debezium.version>1.2.3.Final</debezium.version>
 		<maven.checkstyle.version>3.1.2</maven.checkstyle.version>
 		<hamcrest.version>2.2</hamcrest.version>
@@ -98,7 +98,7 @@
 		<maven.gpg.version>1.6</maven.gpg.version>
 		<sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 		<swagger2markup.version>1.3.7</swagger2markup.version>
-		<jackson-core.version>2.11.3</jackson-core.version>
+		<jackson-core.version>2.13.1</jackson-core.version>
 		<netty.version>4.1.72.Final</netty.version>
 		<tomcat-embed-core.version>8.5.73</tomcat-embed-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>


### PR DESCRIPTION
This PR updates the Config Providers to the new 1.0.0 versions. It is currently using the RC1 versions. In order to make sure we use the same Jackson version accross all dependencies (Vert.x, direct Jackson dependency and Kubernetes Config Provider), it also updates the Vert.x and Jakcson versions. This aligns all of them on Jackson 2.13.1.