### PR TITLE
Updated vertx and jackson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.17.1</log4j.version>
-		<vertx.version>4.2.1</vertx.version>
+		<vertx.version>4.2.4</vertx.version>
 		<kafka.version>2.8.1</kafka.version>
 		<kafka-kubernetes-config-provider.version>0.1.1</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>0.1.1</kafka-env-var-config-provider.version>
@@ -98,7 +98,7 @@
 		<maven.gpg.version>1.6</maven.gpg.version>
 		<sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 		<swagger2markup.version>1.3.7</swagger2markup.version>
-		<jackson-core.version>2.11.3</jackson-core.version>
+		<jackson-core.version>2.13.0</jackson-core.version>
 		<netty.version>4.1.72.Final</netty.version>
 		<tomcat-embed-core.version>8.5.73</tomcat-embed-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

Updated the vertx version to 4.2.4 and also updated jackson since previous jackson version 2.11.3 was giving test failures with vertx 4.2.4