### PR TITLE
Remove duplicate Prometheus JMX Collector dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,11 +284,6 @@
 			<version>${prometheus-simpleclient.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.prometheus.jmx</groupId>
-			<artifactId>collector</artifactId>
-			<version>${jmx-prometheus-collector.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>${commons-cli.version}</version>


### PR DESCRIPTION
It looks like probably during the #592 work, I by mistake introduced duplicate dependency for the Prometheus JMX collector. This does not cause any harm, just triggers a warning in the Maven build. But it should be fixed. (If needed, check the lines 271-275 where the other record is present)