### PR TITLE
Replace Log4j API use in some tests with SLF4J API used elsewhere

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,11 +204,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>${log4j.version}</version>
 		</dependency>

--- a/src/test/java/io/strimzi/kafka/bridge/clients/ClientHandlerBase.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/ClientHandlerBase.java
@@ -5,15 +5,11 @@
 package io.strimzi.kafka.bridge.clients;
 
 import io.vertx.core.AbstractVerticle;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.IntPredicate;
 
 public abstract class ClientHandlerBase<T> extends AbstractVerticle {
-
-    static final Logger LOGGER = LogManager.getLogger(ClientHandlerBase.class);
     final CompletableFuture<T> resultPromise;
     final IntPredicate msgCntPredicate;
 

--- a/src/test/java/io/strimzi/kafka/bridge/clients/Consumer.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/Consumer.java
@@ -12,8 +12,8 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 import java.util.Random;
@@ -22,8 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 
 public class Consumer extends ClientHandlerBase<Integer> implements AutoCloseable {
-
-    private static final Logger LOGGER = LogManager.getLogger(Consumer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Consumer.class);
     private final Properties properties;
     private final AtomicInteger numReceived = new AtomicInteger(0);
     private final String topic;

--- a/src/test/java/io/strimzi/kafka/bridge/clients/Producer.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/Producer.java
@@ -13,8 +13,8 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,8 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 
 public class Producer extends ClientHandlerBase<Integer> implements AutoCloseable {
-
-    private static final Logger LOGGER = LogManager.getLogger(Producer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Producer.class);
     private Properties properties;
     private final AtomicInteger numSent = new AtomicInteger(0);
     private final String topic;

--- a/src/test/java/io/strimzi/kafka/bridge/facades/AdminClientFacade.java
+++ b/src/test/java/io/strimzi/kafka/bridge/facades/AdminClientFacade.java
@@ -10,8 +10,8 @@ import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.KafkaFuture;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -23,8 +23,7 @@ import java.util.concurrent.ExecutionException;
  * Class AdminClientFacade used for encapsulate complexity and asynchronous code of AdminClient.
  */
 public class AdminClientFacade {
-
-    private static final Logger LOGGER = LogManager.getLogger(AdminClientFacade.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdminClientFacade.class);
     private static AdminClient adminClient;
     private static AdminClientFacade adminClientFacade;
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
@@ -26,14 +26,14 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -50,8 +50,7 @@ import static org.hamcrest.Matchers.is;
 @Tag(HTTP_BRIDGE)
 @DisabledIfEnvironmentVariable(named = "EXTERNAL_BRIDGE", matches = "((?i)TRUE(?-i))")
 public class ConsumerGeneratedNameIT {
-
-    private static final Logger LOGGER = LogManager.getLogger(ConsumerGeneratedNameIT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerGeneratedNameIT.class);
 
     private static Map<String, Object> config = new HashMap<>();
     private static StrimziKafkaContainer kafkaContainer;

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
@@ -43,7 +45,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConsumerIT extends HttpBridgeITAbstract {
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerIT.class);
     private static final String FORWARDED = "Forwarded";
     private static final String X_FORWARDED_HOST = "X-Forwarded-Host";
     private static final String X_FORWARDED_PROTO = "X-Forwarded-Proto";

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -18,6 +18,8 @@ import org.apache.kafka.common.KafkaFuture;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -28,6 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerSubscriptionIT.class);
 
     String groupId = "my-group";
 
@@ -235,7 +238,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
                 .as(BodyCodec.jsonArray())
                 .send(ar -> {
                     if (ar.succeeded()) {
-                        LOGGER.info(ar.result().body());
+                        LOGGER.info("Request result: {}", ar.result().body());
                         consume.complete(true);
                     }
                 });

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
@@ -24,14 +24,14 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,8 +46,7 @@ import static org.hamcrest.Matchers.hasItem;
 @ExtendWith(VertxExtension.class)
 @SuppressWarnings({"checkstyle:JavaNCSS"})
 public class HttpCorsIT {
-
-    static final Logger LOGGER = LogManager.getLogger(HttpCorsIT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpCorsIT.class);
     static Map<String, Object> config = new HashMap<>();
     static long timeout = 5L;
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
@@ -12,6 +12,8 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -20,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class OtherServicesIT extends HttpBridgeITAbstract {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OtherServicesIT.class);
 
     @Test
     void readyTest(VertxTestContext context) throws InterruptedException {

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -17,6 +17,8 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.common.KafkaFuture;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -30,6 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class SeekIT extends HttpBridgeITAbstract {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SeekIT.class);
 
     private String name = "my-kafka-consumer";
     private String groupId = "my-group";

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -30,14 +30,14 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,8 +51,7 @@ import static io.strimzi.kafka.bridge.Constants.HTTP_BRIDGE;
 @SuppressWarnings({"checkstyle:JavaNCSS"})
 @Tag(HTTP_BRIDGE)
 public abstract class HttpBridgeITAbstract {
-
-    protected static final Logger LOGGER = LogManager.getLogger(HttpBridgeITAbstract.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpBridgeITAbstract.class);
     protected static Map<String, Object> config = new HashMap<>();
 
     // for periodic/multiple messages test

--- a/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
@@ -15,8 +15,8 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxTestContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -30,8 +30,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConsumerService extends BaseService {
-
-    static final Logger LOGGER = LogManager.getLogger(ConsumerService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerService.class);
 
     private static final int POLL_TIMEOUT = 4000;
 


### PR DESCRIPTION
The Bridge seems to be currently using directly two logging APIs. Most of the code seems to rely on SLF4J. But some tests seem to use Log4j. It does not seem to make sense to depend on both APIs. This PR updates the code to use SLF4J everywhere and removes the dependency on the Log4j2 API. (Log4j2 is still used as the implementation behind SLF4J)