### PR TITLE
Fix Maven caching in Azure Pipelines

### DIFF
--- a/.azure/templates/jobs/build_docs.yaml
+++ b/.azure/templates/jobs/build_docs.yaml
@@ -13,11 +13,8 @@ jobs:
       MVN_ARGS: '-e -V -B'
     # Pipeline steps
     steps:
-      - task: Cache@2
-        inputs:
-          key: 'mvn-m2-cache | $(System.JobName)'
-          path: "$(MVN_CACHE_FOLDER)"
-        displayName: Maven cache
+      # Get cached Maven repository
+      - template: "../steps/maven_cache.yaml"
       - template: '../steps/setup_java.yaml'
         parameters:
           JDK_PATH: '/usr/lib/jvm/java-11-openjdk-amd64'

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -25,11 +25,8 @@ jobs:
       MVN_ARGS: '-e -V -B'
     # Pipeline steps
     steps:
-      - task: Cache@2
-        inputs:
-          key: 'mvn-m2-cache | $(System.JobName)'
-          path: "$(MVN_CACHE_FOLDER)"
-        displayName: Maven cache
+      # Get cached Maven repository
+      - template: "../steps/maven_cache.yaml"
       - template: '../steps/setup_java.yaml'
         parameters:
           JDK_PATH: $(jdk_path)

--- a/.azure/templates/steps/maven_cache.yaml
+++ b/.azure/templates/steps/maven_cache.yaml
@@ -1,0 +1,9 @@
+steps:
+  - task: Cache@2
+    inputs:
+      key: 'maven-cache | $(System.JobName) | **/pom.xml'
+      restoreKeys: |
+        maven-cache | $(System.JobName)
+        maven-cache
+      path: $(HOME)/.m2/repository
+    displayName: Maven cache


### PR DESCRIPTION
This PR fixes the Maven cache use in the Azure Pipelines builds to make sure it is updated during the builds.