### PR TITLE
docs: removes context tags from bridge doc

### DIFF
--- a/documentation/assemblies/assembly-kafka-bridge-overview.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-overview.adoc
@@ -2,8 +2,6 @@
 //
 // bridge.adoc
 
-:context: kafka-bridge-overview
-
 [id='assembly-kafka-bridge-overview-{context}']
 = Kafka Bridge overview
 

--- a/documentation/assemblies/assembly-kafka-bridge-quickstart.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-quickstart.adoc
@@ -2,8 +2,6 @@
 //
 // bridge.adoc
 
-:context: kafka-bridge-quickstart
-
 [id='assembly-kafka-bridge-quickstart-{context}']
 = Kafka Bridge quickstart
 

--- a/documentation/book/api/overview.adoc
+++ b/documentation/book/api/overview.adoc
@@ -1,9 +1,9 @@
-= Strimzi HTTP Bridge for Apache Kafka
+= Strimzi Kafka Bridge API Reference
 
 
 [[_overview]]
 == Overview
-The Strimzi HTTP Bridge for Apache Kafka provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol.
+The Strimzi Kafka Bridge provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol.
 
 
 === Version information
@@ -31,7 +31,7 @@ __Version__ : 0.1.0
 
 === External Docs
 [%hardbreaks]
-__Description__ : Find out more about the Strimzi HTTP Bridge
+__Description__ : Find out more about the Strimzi Kafka Bridge
 __URL__ : https://strimzi.io/documentation/
 
 

--- a/documentation/book/api/overview.adoc
+++ b/documentation/book/api/overview.adoc
@@ -29,10 +29,4 @@ __Version__ : 0.1.0
 * `application/json`
 
 
-=== External Docs
-[%hardbreaks]
-__Description__ : Find out more about the Strimzi Kafka Bridge
-__URL__ : https://strimzi.io/documentation/
-
-
 

--- a/documentation/book/bridge.adoc
+++ b/documentation/book/bridge.adoc
@@ -10,8 +10,6 @@ include::assemblies/assembly-kafka-bridge-overview.adoc[leveloffset=+1]
 include::assemblies/assembly-kafka-bridge-quickstart.adoc[leveloffset=+1]
 
 [id='api_reference-{context}']
-== Strimzi Kafka Bridge API reference
-
 include::api/overview.adoc[leveloffset=+1]
 
 include::api/definitions.adoc[leveloffset=+1]

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -2069,9 +2069,5 @@
             "name": "Producer",
             "description": "Producer operations to send records to a specified topic or topic partition."
         }
-    ],
-    "externalDocs": {
-        "description": "Find out more about the Strimzi Kafka Bridge",
-        "url": "https://strimzi.io/documentation/"
-    }
+    ]
 }

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1,8 +1,8 @@
 {
     "openapi": "3.0.0",
     "info": {
-        "title": "Strimzi HTTP Bridge for Apache Kafka",
-        "description": "The Strimzi HTTP Bridge for Apache Kafka provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol. ",
+      "title": "Strimzi Kafka Bridge API Reference",
+      "description": "The Strimzi Kafka Bridge provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol. ",
         "version": "0.1.0"
     },
     "paths": {
@@ -2071,7 +2071,7 @@
         }
     ],
     "externalDocs": {
-        "description": "Find out more about the Strimzi HTTP Bridge",
+        "description": "Find out more about the Strimzi Kafka Bridge",
         "url": "https://strimzi.io/documentation/"
     }
 }

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1924,9 +1924,5 @@
       "name": "Producer",
       "description": "Producer operations to send records to a specified topic or topic partition."
     }
-  ],
-  "externalDocs": {
-    "description": "Find out more about the Strimzi Kafka Bridge",
-    "url": "https://strimzi.io/documentation/"
-  }
+  ]
 }

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1,8 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "Strimzi HTTP Bridge for Apache Kafka",
-    "description": "The Strimzi HTTP Bridge for Apache Kafka provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol. ",
+    "title": "Strimzi Kafka Bridge API Reference",
+    "description": "The Strimzi Kafka Bridge provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol. ",
     "version": "0.1.0"
   },
   "consumes": [
@@ -370,7 +370,7 @@
           "type": "string"
         }
       ]
-      }    
+      }
     },
     "/consumers/{groupid}/instances/{name}/positions": {
       "post": {
@@ -1926,7 +1926,7 @@
     }
   ],
   "externalDocs": {
-    "description": "Find out more about the Strimzi HTTP Bridge",
+    "description": "Find out more about the Strimzi Kafka Bridge",
     "url": "https://strimzi.io/documentation/"
   }
 }


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Removes a couple of _context_ tags from the doc that aren't needed.
Also updates the API reference title and description.
