### PR TITLE
Removing debezium version from pom since its not being used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
 		<qpid-proton.version>0.33.10</qpid-proton.version>
 		<kafka-kubernetes-config-provider.version>1.0.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>
-		<debezium.version>1.2.3.Final</debezium.version>
 		<maven.checkstyle.version>3.1.2</maven.checkstyle.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<junit.version>5.8.2</junit.version>


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

The debezium version seems to be not used anywhere now but the pom still contains the version for it. This PR removes that version.