### PR TITLE
Fix the upper limit in dynamic resources

### DIFF
--- a/bin/docker/dynamic_resources.sh
+++ b/bin/docker/dynamic_resources.sh
@@ -3,7 +3,7 @@
 function get_heap_size {
   CONTAINER_MEMORY_IN_BYTES=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`
    # use max of 31G memory, java performs much better with Compressed Ordinary Object Pointers
-  DEFAULT_MEMORY_CEILING=$((31 * 2**20))
+  DEFAULT_MEMORY_CEILING=$((31 * 2**30))
   if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then
     if [ -z $CONTAINER_HEAP_PERCENT ]; then
       CONTAINER_HEAP_PERCENT=0.50

--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -32,6 +32,7 @@ export KAFKA_BRIDGE_LOG4J_OPTS="-Dlog4j2.configurationFile=file:$STRIMZI_HOME/cu
 
 MAX_HEAP=$(get_heap_size)
 if [ -n "$MAX_HEAP" ]; then
+  echo "Configuring Java heap: -Xms${MAX_HEAP}m -Xmx${MAX_HEAP}m"
   export JAVA_OPTS="-Xms${MAX_HEAP}m -Xmx${MAX_HEAP}m $JAVA_OPTS"
 fi
 


### PR DESCRIPTION
The upper limit in the dynamic resources script is set to 31Mi. When the memory calculated from the container limit is higher than this limit, no heap configuration is set. This is an error since the value should really be 31Gi. This PR fixes it. In addition, it adds a message at startup which prints the used settings to make it more clear what is generated and used.