### PR TITLE
Update Log4j2 and Jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<log4j.version>2.17.1</log4j.version>
+		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<vertx.version>4.2.5</vertx.version>
 		<netty.version>4.1.74.Final</netty.version>
@@ -103,7 +103,8 @@
 		<sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
-		<jackson-core.version>2.13.1</jackson-core.version>
+		<jackson-core.version>2.13.2</jackson-core.version>
+		<jackson-databind.version>2.13.2.2</jackson-databind.version>
 		<tomcat-embed-core.version>8.5.73</tomcat-embed-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
 		<strimzi-oauth.version>0.10.0</strimzi-oauth.version>
@@ -195,7 +196,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson-core.version}</version>
+			<version>${jackson-databind.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR updates the Jackson and Log4j2 dependencies. In case of Jackson, it addresses the CVE-2020-36518 in Jackson Databind.