### PR TITLE
Update Azure CI for ppc64le support to multi-arch images

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -33,7 +33,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
   - stage: container_publish
     displayName: Publish Container
     dependsOn:
@@ -49,7 +49,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
   - stage: docs_publish
     displayName: Publish Docs
     dependsOn:

--- a/.azure/cve-pipeline.yaml
+++ b/.azure/cve-pipeline.yaml
@@ -36,7 +36,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
   - stage: containers_publish_with_suffix
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     dependsOn: 
@@ -51,7 +51,7 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
   - stage: manual_validation
     displayName: Validate container before pushing container as ${{ parameters.releaseVersion }}
     dependsOn:

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -38,7 +38,7 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']
   - stage: containers_publish
     displayName: Publish Containers for ${{ parameters.releaseVersion }}
     dependsOn:
@@ -53,4 +53,4 @@ stages:
           artifactPipeline: '${{ parameters.sourcePipelineId }}'
           artifactRunVersion: 'specific'
           artifactRunId: '${{ parameters.sourceBuildId }}'
-          architectures: ['amd64', 'arm64', 's390x']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.22.0
 
-* n/a
+* Support for ppc64le platform
 
 ## 0.21.4
 


### PR DESCRIPTION
Updates to Azure CI for enabling IBM Power (ppc64le) support for the multi-arch kafka-bridge image.
Signed-off-by: Abhijit Mane <abhijman@in.ibm.com>