### PR TITLE
Update Apache Tomcat dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 		<swagger2markup.version>1.3.4</swagger2markup.version>
 		<jackson-core.version>2.13.2</jackson-core.version>
 		<jackson-databind.version>2.13.2.2</jackson-databind.version>
-		<tomcat-embed-core.version>8.5.73</tomcat-embed-core.version>
+		<tomcat-embed-core.version>8.5.75</tomcat-embed-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
 		<strimzi-oauth.version>0.10.0</strimzi-oauth.version>
 		<jaeger.version>1.6.0</jaeger.version>


### PR DESCRIPTION
This PR updates the Apache Tomcat:tomcat-embed-core. It mitigate the [CVE-2022-23181](https://github.com/advisories/GHSA-9f3j-pm6f-9fm5) in Apache Tomcat.

Signed-off-by: Joel Hanson <joelhanson025@gmail.com>