### PR TITLE
Add all architectures to the CVE re-spin pipeline

### DIFF
--- a/.azure/cve-pipeline.yaml
+++ b/.azure/cve-pipeline.yaml
@@ -86,4 +86,4 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
-          architectures: ['amd64', 'arm64']
+          architectures: ['amd64', 'arm64', 's390x', 'ppc64le']


### PR DESCRIPTION
The CVE re-spin pipeline for rebuilding the container images in case of base image CVEs is missing the `ppc64le` and `s390x` architectures in the last stage. This PR fixes that.