### PR TITLE
docs: adds a section on OpenAPI spec and how to locate the JSON

### DIFF
--- a/documentation/assemblies/assembly-kafka-bridge-overview.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-overview.adoc
@@ -18,6 +18,8 @@ include::modules/con-overview-running-kafka-bridge.adoc[leveloffset=+1]
 
 include::modules/con-overview-components-kafka-bridge.adoc[leveloffset=+1]
 
+include::modules/con-overview-open-api-spec-kafka-bridge.adoc[leveloffset=+1]
+
 include::modules/con-securing-kafka-bridge.adoc[leveloffset=+1]
 
 include::modules/con-securing-http-interface.adoc[leveloffset=+1]

--- a/documentation/common/attributes.adoc
+++ b/documentation/common/attributes.adoc
@@ -24,3 +24,4 @@
 
 //External links
 :external-cors-link: https://fetch.spec.whatwg.org/[Fetch CORS specification^]
+:openapis: https://www.openapis.org/[OpenAPI initiative^]

--- a/documentation/modules/con-loggers-kafka-bridge.adoc
+++ b/documentation/modules/con-loggers-kafka-bridge.adoc
@@ -7,7 +7,8 @@
 [role="_abstract"]
 = Configuring loggers for the Kafka Bridge
 
-The Strimzi Kafka bridge allows you to set a different log level for each operation that is defined by the related OpenAPI specification.
+[role="_abstract"]
+You can set a different log level for each operation that is defined by the Kafka Bridge OpenAPI specification.
 
 Each operation has a corresponding API endpoint through which the bridge receives requests from HTTP clients.
 You can change the log level on each endpoint to produce more or less fine-grained logging information about the incoming and outgoing HTTP requests.

--- a/documentation/modules/con-overview-open-api-spec-kafka-bridge.adoc
+++ b/documentation/modules/con-overview-open-api-spec-kafka-bridge.adoc
@@ -1,0 +1,20 @@
+// This assembly is included in the following assemblies:
+//
+// assembly-kafka-bridge-overview.adoc
+
+[id='overview-open-api-spec-kafka-bridge-{context}']
+= Kafka Bridge OpenAPI specification
+
+[role="_abstract"]
+Kafka Bridge APIs use the OpenAPI Specification (OAS).
+OAS provides a standard framework for describing and implementing HTTP APIs.
+
+The Kafka Bridge OpenAPI specification is in JSON format.
+You can find the OpenAPI JSON files in the `src/main/resources/` folder of the Kafka Bridge source download files.
+The download files are available from the {ReleaseDownload}.
+
+You can also use the xref:_openapi[`GET /openapi` method] to retrieve the OpenAPI v2 specification in JSON format.
+
+[role="_additional-resources"]
+.Additional resources
+* {openapis}

--- a/documentation/modules/con-overview-running-kafka-bridge.adoc
+++ b/documentation/modules/con-overview-running-kafka-bridge.adoc
@@ -2,7 +2,7 @@
 //
 // assembly-kafka-bridge-overview.adoc
 
-[id="overview-components-running-kafka-bridge_{context}"]
+[id="overview-components-running-kafka-bridge-{context}"]
 = Running the Kafka Bridge
 
 [role="_abstract"]
@@ -13,8 +13,8 @@ To try out the Kafka Bridge in your local environment, see the xref:assembly-kaf
 
 If you deployed Strimzi on Kubernetes, you can use the Strimzi Cluster Operator to deploy the Kafka Bridge to the Kubernetes cluster.
 You'll need a running Kafka cluster that was deployed by the Cluster Operator in a Kubernetes namespace.
-You can configure your deployment to access the Kafka Bridge outside the Kubernetes cluster. 
+You can configure your deployment to access the Kafka Bridge outside the Kubernetes cluster.
 
 [role="_additional-resources"]
 .Additional resources
-* {BookURLConfiguring}
+* {BookURLConfiguring} describes how to deploy the Kafka Bridge with Strimzi


### PR DESCRIPTION
Signed-off-by: prmellor <pmellor@redhat.com>

Adds a new section to the overview of the Kafka Bridge doc that describes the use of the OpenAPI specification and how to locate the OpenAPI JSON. 