### PR TITLE
Add `async` query parameter to control send endpoint behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support for ppc64le platform
 * Documentation improvements
 * Dependency updates
+* Add `async` query parameter to publish endpoint to allow for immediate responses from the bridge (reduces latency)
 
 ## 0.21.4
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -1001,6 +1001,8 @@ Sends one or more records to a given topic, optionally specifying a partition, k
 |Type|Name|Description|Schema
 |**Path**|**topicname** +
 __required__|Name of the topic to send records to or retrieve metadata from.|string
+|**Query**|**async** +
+__optional__|Whether to return immediately upon sending records, instead of waiting for metadata. No offsets will be returned if specified. Defaults to false.|boolean
 |**Body**|**body** +
 __required__||<<_producerrecordlist,ProducerRecordList>>
 |===

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -615,6 +615,13 @@
             "schema": {
               "$ref": "#/definitions/ProducerRecordList"
             }
+          },
+          {
+            "name": "async",
+            "in": "query",
+            "description": "Whether to return immediately upon sending records, instead of waiting for metadata. No offsets will be returned if specified. Defaults to false.",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {


### PR DESCRIPTION
Open to naming suggestions for the query parameter.

Closes: #607