### PR TITLE
Bump the kafka version to 3.2.0 and vertx version to 4.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
-		<vertx.version>4.2.5</vertx.version>
-		<netty.version>4.1.74.Final</netty.version>
-		<kafka.version>2.8.1</kafka.version>
+		<vertx.version>4.3.1</vertx.version>
+		<netty.version>4.1.77.Final</netty.version>
+		<kafka.version>3.2.0</kafka.version>
 		<qpid-proton.version>0.33.10</qpid-proton.version>
 		<kafka-kubernetes-config-provider.version>1.0.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
@@ -156,7 +156,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                 root.put("partitions", partitionsArray);
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
 
-            } else if (done.cause() instanceof UnknownTopicOrPartitionException) {
+            } else if (done.cause() != null && done.cause().getCause() instanceof UnknownTopicOrPartitionException) {
                 HttpBridgeError error = new HttpBridgeError(
                         HttpResponseStatus.NOT_FOUND.code(),
                         done.cause().getMessage()
@@ -187,7 +187,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                     });
                 }
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
-            } else if (describeTopicsResult.cause() instanceof UnknownTopicOrPartitionException) {
+            } else if (describeTopicsResult.cause() != null && describeTopicsResult.cause().getCause() instanceof UnknownTopicOrPartitionException) {
                 HttpBridgeError error = new HttpBridgeError(
                         HttpResponseStatus.NOT_FOUND.code(),
                         describeTopicsResult.cause().getMessage()
@@ -233,7 +233,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                     HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
                             BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
                 }
-            } else if (describeTopicsResult.cause() instanceof UnknownTopicOrPartitionException) {
+            } else if (describeTopicsResult.cause() != null && describeTopicsResult.cause().getCause() instanceof UnknownTopicOrPartitionException) {
                 HttpBridgeError error = new HttpBridgeError(
                         HttpResponseStatus.NOT_FOUND.code(),
                         describeTopicsResult.cause().getMessage()
@@ -277,7 +277,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
         this.describeTopics(Collections.singletonList(topicName), topicExistenceCheck);
         topicExistenceCheck.future().onComplete(t -> {
             Throwable e = null;
-            if (t.cause() instanceof UnknownTopicOrPartitionException) {
+            if (t.cause() != null && t.cause().getCause() instanceof UnknownTopicOrPartitionException) {
                 e = t.cause();
             } else if (t.result().get(topicName).getPartitions().size() <= partitionId) {
                 e = new UnknownTopicOrPartitionException("Topic '" + topicName + "' does not have partition with id " + partitionId);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -276,7 +276,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.CREATE_CONSUMER);
 
         // check for an empty body
-        JsonObject body = routingContext.body().buffer() != null && routingContext.body().buffer().length() != 0 ? routingContext.getBodyAsJson() : new JsonObject();
+        JsonObject body = !routingContext.body().isEmpty() ? routingContext.body().asJsonObject() : new JsonObject();
         SinkBridgeEndpoint<byte[], byte[]> sink = null;
 
         try {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -276,7 +276,7 @@ public class HttpBridge extends AbstractVerticle implements HealthCheckable {
         this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.CREATE_CONSUMER);
 
         // check for an empty body
-        JsonObject body = routingContext.getBody() != null && routingContext.getBody().length() != 0 ? routingContext.getBodyAsJson() : new JsonObject();
+        JsonObject body = routingContext.body().buffer() != null && routingContext.body().buffer().length() != 0 ? routingContext.getBodyAsJson() : new JsonObject();
         SinkBridgeEndpoint<byte[], byte[]> sink = null;
 
         try {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -502,8 +502,8 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         JsonObject bodyAsJson = EMPTY_JSON;
         try {
             // check for an empty body
-            if (routingContext.getBody() != null && routingContext.getBody().length() != 0) {
-                bodyAsJson = routingContext.getBodyAsJson();
+            if (routingContext.body().buffer() != null && routingContext.body().buffer().length() != 0) {
+                bodyAsJson = routingContext.body().asJsonObject();
             }
             log.debug("[{}] Request: body = {}", routingContext.get("request-id"), bodyAsJson);
         } catch (DecodeException ex) {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -502,7 +502,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         JsonObject bodyAsJson = EMPTY_JSON;
         try {
             // check for an empty body
-            if (routingContext.body().buffer() != null && routingContext.body().buffer().length() != 0) {
+            if (!routingContext.body().isEmpty()) {
                 bodyAsJson = routingContext.body().asJsonObject();
             }
             log.debug("[{}] Request: body = {}", routingContext.get("request-id"), bodyAsJson);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -118,7 +118,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
                 span.finish();
                 return;
             }
-            records = messageConverter.toKafkaRecords(topic, partition, routingContext.getBody());
+            records = messageConverter.toKafkaRecords(topic, partition, routingContext.body().buffer());
 
             for (KafkaProducerRecord<K, V> record :records)   {
                 tracer.inject(span.context(), Format.Builtin.TEXT_MAP, new TextMap() {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -475,7 +475,7 @@ public class ConsumerIT extends HttpBridgeITAbstract {
     @Test
     void createConsumerWithNotExistingParameter(VertxTestContext context) throws InterruptedException, TimeoutException, ExecutionException {
         checkCreatingConsumer("foo", "bar", HttpResponseStatus.BAD_REQUEST,
-                "Validation error on:  - provided object should not contain additional properties", context);
+                "Validation error on:  - Provided object contains unexpected additional property: foo", context);
 
         context.completeNow();
         assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
@@ -110,6 +110,7 @@ public class HttpCorsIT {
                         client.request(HttpMethod.POST, 8080, "localhost", "/consumers/1/instances/1/subscription")
                                 .putHeader("Origin", "https://evil.io")
                                 .send(ar2 -> context.verify(() -> {
+                                    System.out.println(ar2.result().body());
                                     assertThat(ar2.result().statusCode(), is(400));
                                     context.completeNow();
                                 }));
@@ -180,8 +181,8 @@ public class HttpCorsIT {
                                 .putHeader("Origin", "https://strimzi.io")
                                 .putHeader("content-type", BridgeContentType.KAFKA_JSON)
                                 .sendJsonObject(topicsRoot, ar2 -> context.verify(() -> {
-                                    //we are not creating a topic, so we will get a 404 status code
-                                    assertThat(ar2.result().statusCode(), is(404));
+                                    //we are not creating a topic, so we will get a 400 status code
+                                    assertThat(ar2.result().statusCode(), is(400));
                                     context.completeNow();
                                 }));
                     }))));

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
@@ -94,7 +94,6 @@ public class HttpCorsIT {
         }
     }
 
-
     @Test
     public void testCorsNotEnabled(VertxTestContext context) {
         createWebClient();
@@ -110,7 +109,6 @@ public class HttpCorsIT {
                         client.request(HttpMethod.POST, 8080, "localhost", "/consumers/1/instances/1/subscription")
                                 .putHeader("Origin", "https://evil.io")
                                 .send(ar2 -> context.verify(() -> {
-                                    System.out.println(ar2.result().body());
                                     assertThat(ar2.result().statusCode(), is(400));
                                     context.completeNow();
                                 }));

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -671,7 +671,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsToPartitionRequest(topic, partition, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - provided object should not contain additional properties"));
+            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: partition"));
     }
 
     @Test
@@ -714,7 +714,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - provided object should not contain additional properties"));
+            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: foo"));
     }
 
     Handler<AsyncResult<HttpResponse<JsonObject>>> verifyBadRequest(VertxTestContext context, String message) {
@@ -816,7 +816,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsToPartitionRequest(topic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - provided object should not contain additional properties"));
+            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: partition"));
 
         records.remove(json);
         records.clear();

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -657,11 +657,12 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         String value = "Hi, This is kafka bridge";
         int partition = 1;
+        String testProp = "partition";
 
         JsonArray records = new JsonArray();
         JsonObject json = new JsonObject();
         json.put("value", value);
-        json.put("partition", 2);
+        json.put(testProp, 2);
         records.add(json);
 
         JsonObject root = new JsonObject();
@@ -671,7 +672,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsToPartitionRequest(topic, partition, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: partition"));
+            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: " + testProp));
     }
 
     @Test
@@ -700,11 +701,12 @@ public class ProducerIT extends HttpBridgeITAbstract {
         KafkaFuture<Void> future = adminClientFacade.createTopic(topic);
 
         String value = "message-value";
+        String testProp = "foo";
 
         JsonArray records = new JsonArray();
         JsonObject json = new JsonObject();
         json.put("value", value);
-        json.put("foo", "unknown property");
+        json.put(testProp, "unknown property");
         records.add(json);
 
         JsonObject root = new JsonObject();
@@ -714,7 +716,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: foo"));
+            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: " + testProp));
     }
 
     Handler<AsyncResult<HttpResponse<JsonObject>>> verifyBadRequest(VertxTestContext context, String message) {
@@ -801,12 +803,13 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         String value = "Hello from the other side";
         String key = "message-key";
+        String testProp = "partition";
 
         JsonArray records = new JsonArray();
         JsonObject json = new JsonObject();
         json.put("value", value);
         json.put("key", key);
-        json.put("partition", 0);
+        json.put(testProp, 0);
         records.add(json);
 
         JsonObject root = new JsonObject();
@@ -816,7 +819,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsToPartitionRequest(topic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: partition"));
+            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: " + testProp));
 
         records.remove(json);
         records.clear();


### PR DESCRIPTION
Signed-off-by: ShubhamRwt <srawat@redhat.com>

This PR bumps the Kafka version in the bridge to 3.2.0 since vertx 4.3.1 is released and is compatible to work with kafka version >= 3.0.0 also.The PR replaces the deprecated `routingContext.getbody()` methods with the new alternatives and also other fixes