### PR TITLE
Use better algorithms for encryption and digest of the PKCS12 stores

### DIFF
--- a/bin/docker/kafka_bridge_tls_prepare_certificates.sh
+++ b/bin/docker/kafka_bridge_tls_prepare_certificates.sh
@@ -24,7 +24,7 @@ function create_truststore {
 # $4: Private key to be imported
 # $5: Alias of the certificate
 function create_keystore {
-   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -name $5 -password pass:$2 -out $1
+   RANDFILE=/tmp/.rnd openssl pkcs12 -export -in $3 -inkey $4 -name $5 -password pass:$2 -out $1 -certpbe aes-128-cbc -keypbe aes-128-cbc -macalg sha256
 }
 
 # $1 = trusted certs, $2 = TLS auth cert, $3 = TLS auth key, $4 = truststore path, $5 = keystore path, $6 = certs and key path


### PR DESCRIPTION
Currently, when we generate the PKCS12 stores with the certificates, we use the default algorithms which are not really up to date. This is causing issues for example when trying to run under the FIPS mode in OpenJDK. This PR updates the OpenSSL command used to generate the PKCS12 store to use something better and more secure. 

This change affects only the script which is used internally when deploying through Strimzi Cluster Operator. It should not affect any other users.