### PR TITLE
Fix CHANGELOG.md and add some new records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # CHANGELOG
 
+## 0.22.0
+
+* Add `async` query parameter to publish endpoint to allow for immediate responses from the bridge (reduces latency)
+* Dependency updates (Vert.x 4.3.1, Apache Kafka 3.2.0, etc.)
+* Documentation improvements
+
 ## 0.21.5
 
 * Support for ppc64le platform
 * Documentation improvements
 * Dependency updates
-* Add `async` query parameter to publish endpoint to allow for immediate responses from the bridge (reduces latency)
 
 ## 0.21.4
 


### PR DESCRIPTION
This PR fixes the CHANGELOG.md where the record for PR #625 was added under 0.21.5 instead of 0.22.0. It also adds CHANGELOG items for dependency updates (Vert.x and Kafka seem notable enough to be mentioned) and documentation (since we had several docs improvements).