### PR TITLE
Improve the naming of the JARs in the `libs/` directory

### DIFF
--- a/src/main/assembly/zip.xml
+++ b/src/main/assembly/zip.xml
@@ -35,6 +35,7 @@
             <scope>runtime</scope>
             <outputDirectory>/libs</outputDirectory>
             <fileMode>0644</fileMode>
+            <outputFileNameMapping>${artifact.groupId}.${artifact.artifactId}-${artifact.version}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
         </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
Currently, the JARs in the Bridge's `libs/` directory are names just by the artifact name. This is sometimes confusing as for some of the JARs, it is not clear what they really are. This PR changes the naming to have the group in the name as well. E.g.:

```
sh-4.4$ ls -1 libs
com.fasterxml.jackson.core.jackson-annotations-2.13.2.jar
com.fasterxml.jackson.core.jackson-core-2.13.2.jar
com.fasterxml.jackson.core.jackson-databind-2.13.2.2.jar
com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.13.2.jar
com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.13.1.jar
com.github.luben.zstd-jni-1.5.2-1.jar
com.github.mifmif.generex-1.0.2.jar
com.github.stephenc.jcip.jcip-annotations-1.0-1.jar
com.google.code.gson.gson-2.9.0.jar
com.nimbusds.nimbus-jose-jwt-9.10.jar
com.squareup.okhttp3.logging-interceptor-3.12.12.jar
com.squareup.okhttp3.okhttp-4.9.3.jar
com.squareup.okio.okio-2.8.0.jar
commons-cli.commons-cli-1.4.jar
dk.brics.automaton.automaton-1.11-8.jar
io.fabric8.kubernetes-client-5.12.0.jar
io.fabric8.kubernetes-model-apps-5.12.0.jar
io.fabric8.kubernetes-model-batch-5.12.0.jar
io.fabric8.kubernetes-model-certificates-5.12.0.jar
io.fabric8.kubernetes-model-common-5.12.0.jar
io.fabric8.kubernetes-model-core-5.12.0.jar
io.fabric8.kubernetes-model-extensions-5.12.0.jar
io.fabric8.zjsonpatch-0.3.0.jar
io.jaegertracing.jaeger-client-1.8.1.jar
io.jaegertracing.jaeger-core-1.8.1.jar
io.jaegertracing.jaeger-thrift-1.8.1.jar
io.jaegertracing.jaeger-tracerresolver-1.8.1.jar
io.micrometer.micrometer-core-1.3.9.jar
io.micrometer.micrometer-registry-prometheus-1.3.9.jar
io.netty.netty-buffer-4.1.77.Final.jar
io.netty.netty-codec-4.1.77.Final.jar
io.netty.netty-codec-dns-4.1.77.Final.jar
io.netty.netty-codec-http-4.1.77.Final.jar
io.netty.netty-codec-http2-4.1.77.Final.jar
io.netty.netty-codec-socks-4.1.77.Final.jar
io.netty.netty-common-4.1.77.Final.jar
io.netty.netty-handler-4.1.77.Final.jar
io.netty.netty-handler-proxy-4.1.77.Final.jar
io.netty.netty-resolver-4.1.77.Final.jar
io.netty.netty-resolver-dns-4.1.77.Final.jar
io.netty.netty-transport-4.1.77.Final.jar
io.opentracing.contrib.opentracing-kafka-client-0.1.15.jar
io.opentracing.contrib.opentracing-tracerresolver-0.1.8.jar
io.opentracing.opentracing-api-0.33.0.jar
io.opentracing.opentracing-noop-0.33.0.jar
io.opentracing.opentracing-util-0.33.0.jar
io.prometheus.jmx.collector-0.12.0.jar
io.prometheus.simpleclient-0.7.0.jar
io.prometheus.simpleclient_common-0.7.0.jar
io.strimzi.kafka-bridge-0.22.0-SNAPSHOT.jar
io.strimzi.kafka-env-var-config-provider-1.0.0.jar
io.strimzi.kafka-kubernetes-config-provider-1.0.0.jar
io.strimzi.kafka-oauth-client-0.10.0.jar
io.strimzi.kafka-oauth-common-0.10.0.jar
io.vertx.vertx-auth-common-4.3.1.jar
io.vertx.vertx-bridge-common-4.3.1.jar
io.vertx.vertx-config-4.3.1.jar
io.vertx.vertx-core-4.3.1.jar
io.vertx.vertx-json-schema-4.3.1.jar
io.vertx.vertx-kafka-client-4.3.1.jar
io.vertx.vertx-micrometer-metrics-4.3.1.jar
io.vertx.vertx-proton-4.3.1.jar
io.vertx.vertx-web-4.3.1.jar
io.vertx.vertx-web-common-4.3.1.jar
io.vertx.vertx-web-openapi-4.3.1.jar
io.vertx.vertx-web-validation-4.3.1.jar
jakarta.activation.jakarta.activation-api-1.2.1.jar
jakarta.xml.bind.jakarta.xml.bind-api-2.3.2.jar
org.apache.kafka.kafka-clients-3.2.0.jar
org.apache.logging.log4j.log4j-api-2.17.2.jar
org.apache.logging.log4j.log4j-core-2.17.2.jar
org.apache.logging.log4j.log4j-slf4j-impl-2.17.2.jar
org.apache.qpid.proton-j-0.33.10.jar
org.apache.thrift.libthrift-0.15.0.jar
org.hdrhistogram.HdrHistogram-2.1.12.jar
org.jetbrains.annotations-13.0.jar
org.jetbrains.kotlin.kotlin-stdlib-1.4.10.jar
org.jetbrains.kotlin.kotlin-stdlib-common-1.4.0.jar
org.latencyutils.LatencyUtils-2.0.3.jar
org.lz4.lz4-java-1.8.0.jar
org.slf4j.slf4j-api-1.7.21.jar
org.xerial.snappy.snappy-java-1.1.8.4.jar
org.yaml.snakeyaml-1.29.jar
```

This should make it more clear what these JARs actually are.