### PR TITLE
Update Jaeger client to 1.8.1 to address Gson and OkHttp CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,10 +105,9 @@
 		<swagger2markup.version>1.3.4</swagger2markup.version>
 		<jackson-core.version>2.13.2</jackson-core.version>
 		<jackson-databind.version>2.13.2.2</jackson-databind.version>
-		<tomcat-embed-core.version>8.5.79</tomcat-embed-core.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
 		<strimzi-oauth.version>0.10.0</strimzi-oauth.version>
-		<jaeger.version>1.6.0</jaeger.version>
+		<jaeger.version>1.8.1</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.15</opentracing-kafka-client.version>
 		<micrometer.version>1.3.9</micrometer.version>
@@ -238,6 +237,20 @@
 			<groupId>io.jaegertracing</groupId>
 			<artifactId>jaeger-client</artifactId>
 			<version>${jaeger.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.tomcat</groupId>
+					<artifactId>tomcat-annotations-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.tomcat.embed</groupId>
+					<artifactId>tomcat-embed-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.opentracing</groupId>
@@ -316,12 +329,6 @@
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
 			<version>1.29</version>
-		</dependency>
-		<!-- overriding version of tomcat-embed-core for jaegertracing - Vulnerability -->
-		<dependency>
-			<groupId>org.apache.tomcat.embed</groupId>
-			<artifactId>tomcat-embed-core</artifactId>
-			<version>${tomcat-embed-core.version}</version>
 		</dependency>
 		<!-- Testing -->
 		<dependency>
@@ -491,7 +498,6 @@
 									<ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>io.jaegertracing:jaeger-client</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>org.yaml:snakeyaml</ignoredUnusedDeclaredDependency> <!-- CVE override -->
-									<ignoredUnusedDeclaredDependency>org.apache.tomcat.embed:tomcat-embed-core</ignoredUnusedDeclaredDependency>  <!-- CVE override -->
 								</ignoredUnusedDeclaredDependencies>
 						</configuration>
 					</execution>


### PR DESCRIPTION
Similarly to https://github.com/strimzi/strimzi-kafka-operator/pull/7009, this PR updates the the version of the Jaeger Client and Core. The new version 1.8.1 fixes CVEs in the GSON library and the OkHttp client.

This PR also excludes some of the dependencies which are not needed (and we excludes from the other operands as well). This should reduce the footprint and the CVEs which sometimes affected them.