### PR TITLE
Bump Netty to 4.1.78

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<vertx.version>4.3.1</vertx.version>
-		<netty.version>4.1.77.Final</netty.version>
+		<netty.version>4.1.78.Final</netty.version>
 		<kafka.version>3.2.0</kafka.version>
 		<qpid-proton.version>0.33.10</qpid-proton.version>
 		<kafka-kubernetes-config-provider.version>1.0.0</kafka-kubernetes-config-provider.version>


### PR DESCRIPTION
Netty 4.1.77 seems to have some vulnerabilities. This PR updates Netty to 4.1.78.