### PR TITLE
Do not install weak dependencies when installing OpenJDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETPLATFORM
 USER root
 
 RUN microdnf update \
-    && microdnf install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
     && microdnf clean all
 
 # Set JAVA_HOME env var


### PR DESCRIPTION
This PR mirrors the https://github.com/strimzi/strimzi-kafka-operator/pull/7041 from the operator repo. It disables installing of weak dependencies and docs when installing the RHEL packages. This cause the Python PIP package which has some CVEs to be not installed and makes our image scans cleaner.