### PR TITLE
Fixed OpenTracing test

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/tracing/OpenTracingTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/tracing/OpenTracingTest.java
@@ -7,6 +7,7 @@ package io.strimzi.kafka.bridge.tracing;
 
 import io.vertx.core.tracing.TracingOptions;
 import io.vertx.tracing.opentracing.OpenTracingOptions;
+import io.vertx.tracing.opentracing.OpenTracingTracerFactory;
 
 /**
  * OpenTracing tests
@@ -19,7 +20,9 @@ import io.vertx.tracing.opentracing.OpenTracingOptions;
 public class OpenTracingTest extends TracingTestBase {
     @Override
     protected TracingOptions tracingOptions() {
-        System.setProperty("otel.metrics.exporter", "none"); // disable OTel metrics -- they slip in via ServiceLoader
-        return new OpenTracingOptions();
+        System.setProperty("JAEGER_SERVICE_NAME", "my-jaeger-service");
+        System.setProperty("JAEGER_SAMPLER_TYPE", "const");
+        System.setProperty("JAEGER_SAMPLER_PARAM", "1");
+        return new OpenTracingOptions().setFactory(new OpenTracingTracerFactory());
     }
 }


### PR DESCRIPTION
This PR fixes #645 by initializing Vert.x OpenTracing support in the right way and taking the OpenTelemetry out.