### PR TITLE
Added Jaeger endpoint on OpenTelemetry related documentation

### DIFF
--- a/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
@@ -59,8 +59,10 @@ With tracing enabled, you initialize tracing when you run the Kafka Bridge scrip
 [source,env]
 ----
 OTEL_SERVICE_NAME=my-tracing-service # <1>
+OTEL_EXPORTER_JAEGER_ENDPOINT=http://localhost:14250 # <2>
 ----
 <1> The name of the OpenTelemetry tracer service.
+<2> The Jaeger collector endpoint that listens for spans on port 14250.
 +
 .Environment variables for OpenTracing
 [source,env]
@@ -97,8 +99,10 @@ If you want to use another tracing system with OpenTelemetry, do the following:
 ----
 OTEL_SERVICE_NAME=my-tracing-service
 OTEL_TRACES_EXPORTER=zipkin # <1>
+OTEL_EXPORTER_ZIPKIN_ENDPOINT=http://localhost:9411/api/v2/spans <2>
 ----
 <1> The name of the tracing system. In this example, Zipkin is specified.
+<2> The endpoint of the specific selected exporter that listens for spans. In this example, a Zipkin endpoint is specified.
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
@@ -41,7 +41,7 @@ CAUTION: The OpenTracing project is now archived, so Strimzi has deprecated supp
 +
 Use the `bridge.tracing` property to enable the tracing you want to use. 
 +
-.Example configuration to enable OpeTelemetry
+.Example configuration to enable OpenTelemetry
 [source,properties]
 ----
 #bridge.tracing=jaeger # <1>


### PR DESCRIPTION
The OpenTelemetry documentation was missing the env var related to the endpoint for reaching the tracing system which collects the spans.
This PR adds the env var specific for OpenTelemetry when using Jaeger as default and the corresponding env var if the user wants to use a different tracing system.