### PR TITLE
Bump Kafka and Netty versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<vertx.version>4.3.3</vertx.version>
-		<netty.version>4.1.77.Final</netty.version>
-		<kafka.version>3.2.0</kafka.version>
+		<netty.version>4.1.78.Final</netty.version>
+		<kafka.version>3.2.3</kafka.version>
 		<qpid-proton.version>0.33.10</qpid-proton.version>
 		<kafka-kubernetes-config-provider.version>1.0.1</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
Update Kafka 3.2.3 to fix CVE-2022-34917
Align direct Netty dependencies to 4.1.78.Final as others brought by Vert.x