### PR TITLE
Clarify that OpenTelemetry Jaeger endpoint is the gRPC based one

### DIFF
--- a/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
@@ -62,7 +62,7 @@ OTEL_SERVICE_NAME=my-tracing-service # <1>
 OTEL_EXPORTER_JAEGER_ENDPOINT=http://localhost:14250 # <2>
 ----
 <1> The name of the OpenTelemetry tracer service.
-<2> The Jaeger collector endpoint that listens for spans on port 14250.
+<2> The Jaeger collector gRPC based endpoint that listens for spans on port 14250.
 +
 .Environment variables for OpenTracing
 [source,env]

--- a/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
@@ -62,7 +62,7 @@ OTEL_SERVICE_NAME=my-tracing-service # <1>
 OTEL_EXPORTER_JAEGER_ENDPOINT=http://localhost:14250 # <2>
 ----
 <1> The name of the OpenTelemetry tracer service.
-<2> The Jaeger collector gRPC based endpoint that listens for spans on port 14250.
+<2> The gRPC-based Jaeger collector endpoint that listens for spans on port 14250.
 +
 .Environment variables for OpenTracing
 [source,env]


### PR DESCRIPTION
Just clarifying that the OpenTelemetry Jaeger endpoint has to be the one using gRPC protocol (usually on 14250 port).