### PR TITLE
Bumping Jackson to fix CVE-2022-42004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,8 @@
 		<sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
-		<jackson-core.version>2.13.2</jackson-core.version>
-		<jackson-databind.version>2.13.2.2</jackson-databind.version>
+		<jackson-core.version>2.13.4</jackson-core.version>
+		<jackson-databind.version>2.13.4</jackson-databind.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
 		<strimzi-oauth.version>0.10.0</strimzi-oauth.version>
 		<jaeger.version>1.8.1</jaeger.version>


### PR DESCRIPTION
This PR updates the Jackson dependency in the operator to 2.13.4. This updates Jackson Databind and addresses [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4)

