### PR TITLE
Bumped Jackson Databind dependency to fix CVE-2022-42003

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
 		<jackson-core.version>2.13.4</jackson-core.version>
-		<jackson-databind.version>2.13.4</jackson-databind.version>
+		<jackson-databind.version>2.13.4.1</jackson-databind.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
 		<strimzi-oauth.version>0.10.0</strimzi-oauth.version>
 		<jaeger.version>1.8.1</jaeger.version>


### PR DESCRIPTION
As per Strimzi operator PR https://github.com/strimzi/strimzi-kafka-operator/pull/7476, this PR updates the Jackson dependency in the bridge to 2.13.4.1. 
This updates Jackson Databind and addresses CVE-2022-42003 (see https://github.com/FasterXML/jackson-databind/issues/3590#issue-1362567066 for more details).