### PR TITLE
Bumped Jackson databing to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
 		<jackson-core.version>2.13.4</jackson-core.version>
-		<jackson-databind.version>2.13.4.1</jackson-databind.version>
+		<jackson-databind.version>2.13.4.2</jackson-databind.version>
 		<spotbugs.version>4.0.1</spotbugs.version>
 		<strimzi-oauth.version>0.10.0</strimzi-oauth.version>
 		<jaeger.version>1.8.1</jaeger.version>


### PR DESCRIPTION
Bumping Jackson databind to fix https://nvd.nist.gov/vuln/detail/CVE-2022-42003 and https://nvd.nist.gov/vuln/detail/CVE-2022-42004