### PR TITLE
Fixed old OpenTelemetry dependency in Vert.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,16 @@
 			<artifactId>opentelemetry-exporter-jaeger</artifactId>
 			<version>${opentelemetry.version}</version>
 		</dependency>
+		<!--
+		Not used directly in the bridge code but brought by Vert.x which is using a pretty old version (1.13.0)
+		OpenTelemetry also introduced a breaking change in the API (SdkTraceBuilder.build() method) starting from 1.17.0
+		Need to override to a more recent version
+		-->
+		<dependency>
+			<groupId>io.opentelemetry</groupId>
+			<artifactId>opentelemetry-sdk-trace</artifactId>
+			<version>${opentelemetry.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-opentelemetry</artifactId>
@@ -560,6 +570,8 @@
 									<!-- Required to be able to use the Test Container on different platforms such as Arm based Macs -->
 									<!-- Can be removed once the Strimzi Test Container is using new Test Container version (should be in Strimzi Test Container 0.103) -->
 									<ignoredUnusedDeclaredDependency>net.java.dev.jna:jna:jar:5.8.0</ignoredUnusedDeclaredDependency>
+									<!-- OpenTelemetry - Vert.x using old version and OpenTelemetry breaking API compatibility. See dependency declaration for details. -->
+									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-sdk-trace</ignoredUnusedDeclaredDependency>
 								</ignoredUnusedDeclaredDependencies>
 						</configuration>
 					</execution>


### PR DESCRIPTION
The current `vertx-opentelemetry` component is bringing the `opentelemetry-sdk-trace` dependency which is pretty old (1.13.0).
Starting from OpenTelemetry 1.17.0 there was a breaking change in the API (more specifically `SdkTraceBuilder.build` method in the above library).
For this reason, in the current status the OpenTelemetry code 1.18.0 at some point jumps into old 1.13.0 code (brought by Vert.x) and crashed with a `NoSuchMethod` exception.
Upgrading Vert.x to 4.3.4 doesn't help.
This PR is adding the `opentelemetry-sdk-trace` as a direct dependency overriding what Vert.x is bringing.