### PR TITLE
Removed specific JNA version to ignore if unused

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,7 +569,7 @@
 									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-jaeger</ignoredUnusedDeclaredDependency>
 									<!-- Required to be able to use the Test Container on different platforms such as Arm based Macs -->
 									<!-- Can be removed once the Strimzi Test Container is using new Test Container version (should be in Strimzi Test Container 0.103) -->
-									<ignoredUnusedDeclaredDependency>net.java.dev.jna:jna:jar:5.8.0</ignoredUnusedDeclaredDependency>
+									<ignoredUnusedDeclaredDependency>net.java.dev.jna:jna</ignoredUnusedDeclaredDependency>
 									<!-- OpenTelemetry - Vert.x using old version and OpenTelemetry breaking API compatibility. See dependency declaration for details. -->
 									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-sdk-trace</ignoredUnusedDeclaredDependency>
 								</ignoredUnusedDeclaredDependencies>


### PR DESCRIPTION
As for the others not used direct dependencies, we can avoid to specify the version in order to avoid the need to update it in two different places.
The ignore unused can have just groupid and artifactid.