### PR TITLE
Highlighting that TLS is not supported by the OTel Jaeger exporter

### DIFF
--- a/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
@@ -16,6 +16,10 @@ To enable distributed tracing, do the following:
 
 With the default configuration, you can implement a Jaeger tracing system based on OpenTelemetry or OpenTracing.
 
+WARNING: the OpenTelemetry specification doesn't define any https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md[SDK environment variables^] for enabling TLS on the Jaeger exporter used by default on the bridge.
+It means that you cannot enable TLS encryption on the gRPC port of your Jaeger backend, otherwise the exporter will not be able to connect.
+If you are using the Jaeger operator to deploy the Jaeger instance, set the `collector.grpc.tls.enabled: false` property under the `spec.allInOne.options` in the `Jaeger` custom resource.
+
 OpenTelemetry and OpenTracing are API specifications for collecting tracing data as _spans_ of metrics data.
 Spans represent a specific operation.
 A trace is a collection of one or more spans.
@@ -103,6 +107,9 @@ OTEL_EXPORTER_ZIPKIN_ENDPOINT=http://localhost:9411/api/v2/spans <2>
 ----
 <1> The name of the tracing system. In this example, Zipkin is specified.
 <2> The endpoint of the specific selected exporter that listens for spans. In this example, a Zipkin endpoint is specified.
+
+NOTE: when using the `otlp` exporter, it is possible to use specific https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md[OTLP environment variables^] to enable TLS.
+This way, you can enable TLS on the Jaeger backend OTLP endpoint.
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
This PR is about documenting that it's not possible to enable TLS on the Jaeger exporter in order to connect to a Jaeger instance with TLS enabled on the gRPC port.
That's related to this OpenTelemetry upstream [issue](https://github.com/open-telemetry/opentelemetry-java/issues/4917).
