### PR TITLE
Added doc about Ryuk in privileged mode when running IT tests

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -25,6 +25,7 @@ In case of interest you can check our implementation of Strimzi `Kafka` containe
 > The test-containers project uses [Moby Ryuk](https://github.com/testcontainers/moby-ryuk) to automatic cleanup of containers after the execution. Ryuk must be started as a privileged container.
 Running in privileged mode could not apply for all environments by default. If you get any error running Ryuk, you can set `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true`
 or disable Ryuk by setting `TESTCONTAINERS_RYUK_DISABLED=true`.
+One of the potential issues is about having `java.lang.IllegalArgumentException: Requested port (8080) is not mapped`.
 
 ## Package Structure
 

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -22,9 +22,9 @@ in root directory of the project.
 The next requirement is to have [docker](https://docs.docker.com/get-docker/) installed, because we use [test-containers](https://www.testcontainers.org/). 
 In case of interest you can check our implementation of Strimzi `Kafka` container [here](https://github.com/strimzi/strimzi-kafka-operator/tree/main/test-container).
 
-> The test-containers project uses [Moby Ryuk](https://github.com/testcontainers/moby-ryuk) to automatic cleanup of containers after the execution. Ryuk must be started as a privileged container.
-Running in privileged mode could not apply for all environments by default.  If you get an error like this `java.lang.IllegalArgumentException: Requested port (8080) is not mapped` 
-when test-containers tries to start, then you can set `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true` or disable Ryuk by setting `TESTCONTAINERS_RYUK_DISABLED=true`. 
+> The `test-containers` project uses [Moby Ryuk](https://github.com/testcontainers/moby-ryuk) to automatic cleanup of containers after the execution. Ryuk must be started as a privileged container.
+Running in privileged mode might not apply for all environments by default.  If you get an error like `java.lang.IllegalArgumentException: Requested port (8080) is not mapped` 
+when `test-containers` tries to start, you can set `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true` or disable Ryuk by setting `TESTCONTAINERS_RYUK_DISABLED=true`. 
 
 ## Package Structure
 

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -22,6 +22,10 @@ in root directory of the project.
 The next requirement is to have [docker](https://docs.docker.com/get-docker/) installed, because we use [test-containers](https://www.testcontainers.org/). 
 In case of interest you can check our implementation of Strimzi `Kafka` container [here](https://github.com/strimzi/strimzi-kafka-operator/tree/main/test-container).
 
+> The test-containers project uses [Moby Ryuk](https://github.com/testcontainers/moby-ryuk) to automatic cleanup of containers after the execution. Ryuk must be started as a privileged container.
+Running in privileged mode could not apply for all environments by default. If you get any error running Ryuk, you can set `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true`
+or disable Ryuk by setting `TESTCONTAINERS_RYUK_DISABLED=true`.
+
 ## Package Structure
 
 You can find tests inside `src.test.java` package. Moreover we have the auxiliary classes and the most notable one are:

--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -23,9 +23,8 @@ The next requirement is to have [docker](https://docs.docker.com/get-docker/) in
 In case of interest you can check our implementation of Strimzi `Kafka` container [here](https://github.com/strimzi/strimzi-kafka-operator/tree/main/test-container).
 
 > The test-containers project uses [Moby Ryuk](https://github.com/testcontainers/moby-ryuk) to automatic cleanup of containers after the execution. Ryuk must be started as a privileged container.
-Running in privileged mode could not apply for all environments by default. If you get any error running Ryuk, you can set `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true`
-or disable Ryuk by setting `TESTCONTAINERS_RYUK_DISABLED=true`.
-One of the potential issues is about having `java.lang.IllegalArgumentException: Requested port (8080) is not mapped`.
+Running in privileged mode could not apply for all environments by default.  If you get an error like this `java.lang.IllegalArgumentException: Requested port (8080) is not mapped` 
+when test-containers tries to start, then you can set `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true` or disable Ryuk by setting `TESTCONTAINERS_RYUK_DISABLED=true`. 
 
 ## Package Structure
 


### PR DESCRIPTION
I was having hard times to run IT tests on my laptop.
It turned out that it was Ryuk (used by test-containers for cleanup) not able to start in privileged mode as it should be.
This PR adds a little bit of documentation about how you can run Ryuk in privileged mode or disable it.