### PR TITLE
Moving from Jaeger exporter to OTLP exporter usage by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.23.0
+
+* Moved from using the Jaeger exporter to OTLP exporter by default
+
 ## 0.22.3
 
 * Strimzi OAuth updated to 0.11.0 bringing support for password grants and OAuth metrics

--- a/bin/kafka_bridge_run.sh
+++ b/bin/kafka_bridge_run.sh
@@ -13,9 +13,9 @@ fi
 # Make sure that we use /dev/urandom
 JAVA_OPTS="${JAVA_OPTS} -Dvertx.cacheDirBase=/tmp/vertx-cache -Djava.security.egd=file:/dev/./urandom"
 
-# enabling OpenTelemetry with Jaeger by default
+# enabling OpenTelemetry with OTLP by default
 if [ -n "$OTEL_SERVICE_NAME" ] && [ -z "$OTEL_TRACES_EXPORTER" ]; then
-  export OTEL_TRACES_EXPORTER="jaeger"
+  export OTEL_TRACES_EXPORTER="otlp"
 fi
 
 exec java $JAVA_OPTS $KAFKA_BRIDGE_LOG4J_OPTS -classpath "${MYPATH}/../libs/*" io.strimzi.kafka.bridge.Application "$@"

--- a/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
@@ -14,7 +14,10 @@ To enable distributed tracing, do the following:
 * Set the `bridge.tracing` property value to enable the tracing you want to use. Possible values are `jaeger` and `opentelemetry`.
 * Set environment variables for tracing.
 
-With the default configuration, you can implement a Jaeger tracing system based on OpenTelemetry or OpenTracing.
+With the default configuration, the OpenTelemetry tracing uses OTLP as exporter protocol.
+You can still use your Jaeger backend instance to get the traces, by configuring the OTLP endpoint properly.
+
+NOTE: Jaeger added the support for OTLP protocol since 1.35 release. Older releases cannot get traces via OLTP protocol.
 
 OpenTelemetry and OpenTracing are API specifications for collecting tracing data as _spans_ of metrics data.
 Spans represent a specific operation.
@@ -59,10 +62,10 @@ With tracing enabled, you initialize tracing when you run the Kafka Bridge scrip
 [source,env]
 ----
 OTEL_SERVICE_NAME=my-tracing-service # <1>
-OTEL_EXPORTER_JAEGER_ENDPOINT=http://localhost:14250 # <2>
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 # <2>
 ----
 <1> The name of the OpenTelemetry tracer service.
-<2> The gRPC-based Jaeger collector endpoint that listens for spans on port 14250.
+<2> The gRPC-based OTLP endpoint that listens for spans on port 4317.
 +
 .Environment variables for OpenTracing
 [source,env]
@@ -77,7 +80,7 @@ JAEGER_AGENT_PORT=6831 # <3>
 
 . Run the Kafka Bridge script with the property enabled for tracing:
 +
-.Running the Kafka Bridge with OpenTelementry enabled 
+.Running the Kafka Bridge with OpenTelemetry enabled
 [source,shell,subs="+quotes,attributes"]
 ----
 ./bin/kafka_bridge_run.sh --config-file=_<path>_/application.properties
@@ -87,14 +90,14 @@ The internal consumers and producers of the Kafka Bridge are now enabled for tra
 
 == Specifying tracing systems with OpenTelemetry
 
-Instead of the default Jaeger system, you can specify other tracing systems that are supported by OpenTelemetry.
+Instead of the default OTLP tracing system, you can specify other tracing systems that are supported by OpenTelemetry.
 
 If you want to use another tracing system with OpenTelemetry, do the following: 
 
 . Add the library of the tracing system to the Kafka classpath.
 . Add the name of the tracing system as an additional exporter environment variable.
 +
-.Additional environment variable when not using Jaeger 
+.Additional environment variable when not using OTLP
 [source,env]
 ----
 OTEL_SERVICE_NAME=my-tracing-service

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
-			<artifactId>opentelemetry-exporter-jaeger</artifactId>
+			<artifactId>opentelemetry-exporter-otlp</artifactId>
 			<version>${opentelemetry.version}</version>
 		</dependency>
 		<!--
@@ -566,7 +566,7 @@
 									<ignoredUnusedDeclaredDependency>org.yaml:snakeyaml</ignoredUnusedDeclaredDependency> <!-- CVE override -->
 									<ignoredUnusedDeclaredDependency>org.apache.tomcat.embed:tomcat-embed-core</ignoredUnusedDeclaredDependency>  <!-- CVE override -->
 									<!-- OpenTelemetry - used via classpath configuration -->
-									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-jaeger</ignoredUnusedDeclaredDependency>
+									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-otlp</ignoredUnusedDeclaredDependency>
 									<!-- Required to be able to use the Test Container on different platforms such as Arm based Macs -->
 									<!-- Can be removed once the Strimzi Test Container is using new Test Container version (should be in Strimzi Test Container 0.103) -->
 									<ignoredUnusedDeclaredDependency>net.java.dev.jna:jna</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
This PR fixes #685 moving from the Jaeger exporter to the OLTP exporter usage by default when using OpenTelemetry.