### PR TITLE
Remove the possibility to enable/disable HTTP

### DIFF
--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -141,7 +141,6 @@ done
 
 HTTP_PROPERTIES=$(cat <<-EOF
 #HTTP configuration
-http.enabled=${KAFKA_BRIDGE_HTTP_ENABLED}
 http.host=${KAFKA_BRIDGE_HTTP_HOST}
 http.port=${KAFKA_BRIDGE_HTTP_PORT}
 http.cors.enabled=${KAFKA_BRIDGE_CORS_ENABLED}
@@ -150,7 +149,6 @@ http.cors.allowedMethods=${KAFKA_BRIDGE_CORS_ALLOWED_METHODS}
 EOF
 )
 
-# if http is disabled, do not print its configuration
 PROPERTIES=$(cat <<EOF
 $BRIDGE_PROPERTIES
 
@@ -161,16 +159,10 @@ $ADMIN_CLIENT_PROPERTIES
 $PRODUCER_PROPERTIES
 
 $CONSUMER_PROPERTIES
-EOF
-)
-if [[ -n "$KAFKA_BRIDGE_HTTP_ENABLED" && "$KAFKA_BRIDGE_HTTP_ENABLED" = "true" ]]; then
-	PROPERTIES=$(cat <<EOF
-$PROPERTIES
 
 $HTTP_PROPERTIES
 EOF
 )
-fi
 
 cat <<EOF
 $PROPERTIES

--- a/config/application.properties
+++ b/config/application.properties
@@ -16,7 +16,6 @@ kafka.producer.acks=1
 kafka.consumer.auto.offset.reset=earliest
 
 #HTTP related settings
-http.enabled=true
 http.host=0.0.0.0
 http.port=8080
 #Enable CORS

--- a/documentation/modules/proc-configuring-kafka-bridge.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge.adoc
@@ -46,7 +46,6 @@ For example:
 [source,properties]
 ----
 bridge.id=my-bridge
-http.enabled=true
 http.host=0.0.0.0
 http.port=8080 <1>
 http.cors.enabled=true <2>

--- a/documentation/modules/proc-installing-kafka-bridge.adoc
+++ b/documentation/modules/proc-installing-kafka-bridge.adoc
@@ -14,7 +14,6 @@ The following default property values configure the Kafka Bridge to listen for r
 .Default configuration properties
 [source,shell,subs=attributes+]
 ----
-http.enabled=true
 http.host=0.0.0.0
 http.port=8080
 ----

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
@@ -17,7 +17,6 @@ public class HttpConfig extends AbstractConfig {
 
     public static final String HTTP_CONFIG_PREFIX = "http.";
 
-    public static final String HTTP_ENABLED = HTTP_CONFIG_PREFIX + "enabled";
     public static final String HTTP_CORS_ENABLED = HTTP_CONFIG_PREFIX + "cors.enabled";
     public static final String HTTP_CORS_ALLOWED_ORIGINS = HTTP_CONFIG_PREFIX + "cors.allowedOrigins";
     public static final String HTTP_CORS_ALLOWED_METHODS = HTTP_CONFIG_PREFIX + "cors.allowedMethods";
@@ -25,7 +24,6 @@ public class HttpConfig extends AbstractConfig {
     public static final String HTTP_PORT = HTTP_CONFIG_PREFIX + "port";
     public static final String HTTP_CONSUMER_TIMEOUT = HTTP_CONFIG_PREFIX + "timeoutSeconds";
 
-    public static final boolean DEFAULT_HTTP_ENABLED = true;
     public static final String DEFAULT_HOST = "0.0.0.0";
     public static final int DEFAULT_PORT = 8080;
     public static final long DEFAULT_CONSUMER_TIMEOUT = -1L;
@@ -37,13 +35,6 @@ public class HttpConfig extends AbstractConfig {
      */
     private HttpConfig(Map<String, Object> config) {
         super(config);
-    }
-
-    /**
-     * @return if the HTTP protocol head is enabled
-     */
-    public boolean isEnabled() {
-        return Boolean.valueOf(this.config.getOrDefault(HTTP_ENABLED, DEFAULT_HTTP_ENABLED).toString());
     }
 
     /**


### PR DESCRIPTION
Now that the bridge has HTTP support only, it doesn't make any more sense to have a way to disable it.
This PR removes the possibility to enable/disable HTTP.

It also removes a couple of constant definitions related to the embedded http server I removed in a previous PR.