### PR TITLE
Move to Java 17 at runtime and drop Java 8

### DIFF
--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -4,15 +4,15 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-8':
-          image: 'Ubuntu-20.04'
-          jdk_version: '1.8'
-          jdk_path: '/usr/lib/jvm/java-8-openjdk-amd64'
-          main_build: 'false'
         'java-11':
           image: 'Ubuntu-20.04'
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+          main_build: 'true'
+        'java-17':
+          image: 'Ubuntu-20.04'
+          jdk_version: '17'
+          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
           main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -13,7 +13,7 @@ jobs:
           image: 'Ubuntu-20.04'
           jdk_version: '17'
           jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
-          main_build: 'true'
+          main_build: 'false'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -31,8 +31,8 @@ jobs:
         parameters:
           JDK_PATH: $(jdk_path)
           JDK_VERSION: $(jdk_version)
-      - bash: "make findbugs"
-        displayName: "Findbugs"
+      - bash: "make spotbugs"
+        displayName: "Spotbugs"
         env:
           MVN_ARGS: "-e -V -B"
       - bash: ".azure/scripts/java-build.sh"

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -1,33 +1,33 @@
 # Step to setup JAVA on the agent
-# We use openjdk-X, where X is Java version (8 or 11). Images are based on Java 11
+# We use openjdkX, where X is Java version (e.g. 11 for OpenJDK 11).
 parameters:
   - name: JDK_PATH
-    default: '/usr/lib/jvm/java-8-openjdk-amd64'
+    default: '/usr/lib/jvm/java-11-openjdk-amd64'
   - name: JDK_VERSION
-    default: '1.8'
+    default: '11'
 
 steps:
   - bash: |
       sudo apt-get update
     displayName: 'Update package list'
   - bash: |
-      sudo apt-get install openjdk-8-jdk
-    displayName: 'Install openjdk8'
-    condition: eq(variables['JDK_VERSION'], '1.8')
-  - bash: |
       sudo apt-get install openjdk-11-jdk
     displayName: 'Install openjdk11'
     condition: eq(variables['JDK_VERSION'], '11')
   - bash: |
-      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]1.8"
-      echo "##vso[task.setvariable variable=JAVA_VERSION]1.8.0"
-    displayName: 'Setup JAVA_VERSION=1.8'
-    condition: eq(variables['JDK_VERSION'], '1.8')
+      sudo apt-get install openjdk-17-jdk
+    displayName: 'Install openjdk17'
+    condition: eq(variables['JDK_VERSION'], '17')
   - bash: |
       echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]11"
       echo "##vso[task.setvariable variable=JAVA_VERSION]11"
     displayName: 'Setup JAVA_VERSION=11'
     condition: eq(variables['JDK_VERSION'], '11')
+  - bash: |
+      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]17"
+      echo "##vso[task.setvariable variable=JAVA_VERSION]17"
+    displayName: 'Setup JAVA_VERSION=17'
+    condition: eq(variables['JDK_VERSION'], '17')
   - bash: |
       echo "##vso[task.setvariable variable=JAVA_HOME]$(JDK_PATH)"
       echo "##vso[task.setvariable variable=JAVA_HOME__X64]$(JDK_PATH)"

--- a/.spotbugs/spotbugs-exclude.xml
+++ b/.spotbugs/spotbugs-exclude.xml
@@ -1,3 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
 </FindBugsFilter>

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -13,8 +13,8 @@ if [ ${JAVA_MAJOR_VERSION} -eq 11 ] && [ ${TRAVIS_CPU_ARCH} = "amd64" ] ; then
 fi
 
 if [ "${MAIN_BUILD}" = "TRUE" ] ; then
-    echo "Run Findbugs ..."
-    make findbugs
+    echo "Run Spotbugs ..."
+    make spotbugs
 fi
 
 echo "Run docu check ..."

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -3,7 +3,7 @@ set -e
 
 # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-if [ ${JAVA_MAJOR_VERSION} -gt 1 ] ; then
+if [ ${JAVA_MAJOR_VERSION} -eq 11 ] ; then
   export JAVA_VERSION=${JAVA_MAJOR_VERSION}
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.23.0
 
 * Moved from using the Jaeger exporter to OTLP exporter by default
+* Moved to Java 11 at language level, dropped Java 8 and use Java 17 as the runtime for all containers
 
 ## 0.22.3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=17
 ARG TARGETPLATFORM
 
 USER root
@@ -9,7 +9,7 @@ RUN microdnf update \
     && microdnf clean all
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-11
+ENV JAVA_HOME /usr/lib/jvm/jre-${JAVA_VERSION}
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage

--- a/Makefile.maven
+++ b/Makefile.maven
@@ -26,6 +26,6 @@ java_clean:
 	echo "Cleaning Maven build ..."
 	mvn clean
 
-.PHONY: findbugs
-findbugs: java_compile
-	mvn $(MVN_ARGS) org.codehaus.mojo:findbugs-maven-plugin:check
+.PHONY: spotbugs
+spotbugs: java_compile
+	mvn $(MVN_ARGS) spotbugs:check

--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -69,11 +69,5 @@ if [ "$FIPS_MODE" = "disabled" ]; then
     export JAVA_OPTS="${JAVA_OPTS} -Dcom.redhat.fips=false"
 fi
 
-# Deny illegal access option is supported only on Java 9 and higher
-JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
-  JAVA_OPTS="${JAVA_OPTS} --illegal-access=deny"
-fi
-
 # starting Kafka Bridge with final configuration
 exec /usr/bin/tini -s -w -e 143 -- "${MYPATH}"/../kafka_bridge_run.sh --config-file=/tmp/kafka-bridge.properties "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -88,23 +88,24 @@
 		<kafka.version>3.2.3</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.0.1</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>
-		<maven.checkstyle.version>3.1.2</maven.checkstyle.version>
+		<maven.checkstyle.version>3.2.0</maven.checkstyle.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<junit.version>5.8.2</junit.version>
-		<maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
-		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-		<maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
-		<maven.assembly.version>3.1.0</maven.assembly.version>
-		<maven.javadoc.version>3.1.0</maven.javadoc.version>
-		<maven.source.version>3.0.1</maven.source.version>
+		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+		<maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
+		<maven-failsafe-plugin.version>3.0.0-M7</maven-failsafe-plugin.version>
+		<maven.assembly.version>3.4.2</maven.assembly.version>
+		<maven.javadoc.version>3.4.1</maven.javadoc.version>
+		<maven.source.version>3.2.1</maven.source.version>
 		<maven.dependency.version>3.3.0</maven.dependency.version>
-		<maven.gpg.version>1.6</maven.gpg.version>
-		<sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
+		<maven.gpg.version>3.0.1</maven.gpg.version>
+		<sonatype.nexus.staging>1.6.7</sonatype.nexus.staging>
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
 		<jackson-core.version>2.13.4</jackson-core.version>
 		<jackson-databind.version>2.13.4.2</jackson-databind.version>
-		<spotbugs.version>4.0.1</spotbugs.version>
+		<spotbugs.version>4.7.3</spotbugs.version>
+		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
 		<strimzi-oauth.version>0.11.0</strimzi-oauth.version>
 		<jaeger.version>1.8.1</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
@@ -613,7 +614,7 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>3.1.12</version>
+				<version>${maven.spotbugs.version}</version>
 				<dependencies>
 					<!-- overwrite dependency on spotbugs if you want to specify the version of˓→spotbugs -->
 					<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<vertx.version>4.3.3</vertx.version>
@@ -97,7 +97,7 @@
 		<maven.assembly.version>3.1.0</maven.assembly.version>
 		<maven.javadoc.version>3.1.0</maven.javadoc.version>
 		<maven.source.version>3.0.1</maven.source.version>
-		<maven.dependency.version>3.1.1</maven.dependency.version>
+		<maven.dependency.version>3.3.0</maven.dependency.version>
 		<maven.gpg.version>1.6</maven.gpg.version>
 		<sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
@@ -140,11 +140,6 @@
 		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
-			<artifactId>vertx-web-common</artifactId>
-			<version>${vertx.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.vertx</groupId>
 			<artifactId>vertx-web-openapi</artifactId>
 			<version>${vertx.version}</version>
 		</dependency>
@@ -182,11 +177,6 @@
 			<groupId>io.netty</groupId>
 			<artifactId>netty-common</artifactId>
 			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>${jackson-databind.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -373,6 +363,12 @@
 		</dependency>
 		<!-- Testing -->
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson-databind.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<version>${junit.version}</version>
@@ -393,6 +389,12 @@
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-opentracing</artifactId>
+			<version>${vertx.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.vertx</groupId>
+			<artifactId>vertx-web-common</artifactId>
 			<version>${vertx.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -539,6 +541,10 @@
 						</goals>
 						<configuration>
 							<failOnWarning>true</failOnWarning>
+								<ignoredNonTestScopedDependencies>
+									<!-- OpenTelemetry - The SDK is using this at runtime to load the Vert.x “context storage provider”. To ignore because it is detected as used for test only. -->
+									<ignoredNonTestScopedDependency>io.vertx:vertx-opentelemetry</ignoredNonTestScopedDependency>
+								</ignoredNonTestScopedDependencies>
 								<ignoredUnusedDeclaredDependencies>
 									<ignoredUnusedDeclaredDependency>io.strimzi:kafka-env-var-config-provider</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>io.strimzi:kafka-kubernetes-config-provider</ignoredUnusedDeclaredDependency>

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -53,6 +53,11 @@ public class Application {
 
     private static final String KAFKA_BRIDGE_METRICS_ENABLED = "KAFKA_BRIDGE_METRICS_ENABLED";
 
+    /**
+     * Bridge entrypoint
+     *
+     * @param args command line arguments
+     */
     @SuppressWarnings({"checkstyle:NPathComplexity"})
     public static void main(String[] args) {
         log.info("Strimzi Kafka Bridge {} is starting", Application.class.getPackage().getImplementationVersion());

--- a/src/main/java/io/strimzi/kafka/bridge/BridgeContentType.java
+++ b/src/main/java/io/strimzi/kafka/bridge/BridgeContentType.java
@@ -10,11 +10,15 @@ package io.strimzi.kafka.bridge;
  */
 public class BridgeContentType {
 
-    // JSON encoding with JSON embedded format
+    /** JSON encoding with JSON embedded format */
     public static final String KAFKA_JSON_JSON = "application/vnd.kafka.json.v2+json";
-    // JSON encoding with BINARY embedded format
+
+    /** JSON encoding with BINARY embedded format */
     public static final String KAFKA_JSON_BINARY = "application/vnd.kafka.binary.v2+json";
-    // JSON encoding
+
+    /** Specific Kafka JSON encoding */
     public static final String KAFKA_JSON = "application/vnd.kafka.v2+json";
+
+    /** JSON encoding */
     public static final String JSON = "application/json";
 }

--- a/src/main/java/io/strimzi/kafka/bridge/EmbeddedFormat.java
+++ b/src/main/java/io/strimzi/kafka/bridge/EmbeddedFormat.java
@@ -5,10 +5,23 @@
 
 package io.strimzi.kafka.bridge;
 
+/**
+ * Define the data format inside the HTTP messages
+ */
 public enum EmbeddedFormat {
+
+    /** Define "binary" data as embedded format */
     BINARY,
+
+    /** Define "json" data as embedded format */
     JSON;
 
+    /**
+     * Convert the String value in the corresponding enum
+     *
+     * @param value value to be converted
+     * @return corresponding enum
+     */
     public static EmbeddedFormat from(String value) {
         switch (value) {
             case "json":

--- a/src/main/java/io/strimzi/kafka/bridge/IllegalEmbeddedFormatException.java
+++ b/src/main/java/io/strimzi/kafka/bridge/IllegalEmbeddedFormatException.java
@@ -12,6 +12,11 @@ public class IllegalEmbeddedFormatException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructor
+     *
+     * @param message message to set in the exception
+     */
     public IllegalEmbeddedFormatException(String message) {
         super(message);
     }

--- a/src/main/java/io/strimzi/kafka/bridge/QoSEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/QoSEndpoint.java
@@ -10,6 +10,8 @@ package io.strimzi.kafka.bridge;
  */
 public enum QoSEndpoint {
 
+    /** at most once delivery */
     AT_MOST_ONCE,
+    /** at least once delivery */
     AT_LEAST_ONCE
 }

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
  * @param <V>   type of Kafka message payload
  */
 // TODO: to remove when offsetTracker and QoS handling (used by AMQP 1.0 support) will be removed as well
-@SuppressFBWarnings({"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"})
+@SuppressFBWarnings({"NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"})
 public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -144,6 +144,9 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         this.handleClose();
     }
 
+    /**
+     * @return the consumer instance id
+     */
     public ConsumerInstanceId consumerInstanceId() {
         return this.consumerInstanceId;
     }

--- a/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/BridgeConfig.java
@@ -15,9 +15,13 @@ import io.strimzi.kafka.bridge.http.HttpConfig;
  */
 public class BridgeConfig extends AbstractConfig {
 
+    /** Prefix for all the specific bridge configuration parameters */
     public static final String BRIDGE_CONFIG_PREFIX = "bridge.";
 
+    /** Bridge identification number */
     public static final String BRIDGE_ID = BRIDGE_CONFIG_PREFIX + "id";
+
+    /** Tracing system to be used in the bridge */
     public static final String TRACING_TYPE = BRIDGE_CONFIG_PREFIX + "tracing";
 
     private KafkaConfig kafkaConfig;
@@ -75,6 +79,9 @@ public class BridgeConfig extends AbstractConfig {
                 ")";
     }
 
+    /**
+     * @return the bridge identification number
+     */
     public String getBridgeID() {
         if (config.get(BridgeConfig.BRIDGE_ID) == null) {
             return null;
@@ -83,6 +90,9 @@ public class BridgeConfig extends AbstractConfig {
         }
     }
 
+    /**
+     * @return the tracing system to be used in the bridge
+     */
     public String getTracing() {
         if (config.get(BridgeConfig.TRACING_TYPE) == null) {
             return null;

--- a/src/main/java/io/strimzi/kafka/bridge/config/KafkaAdminConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/KafkaAdminConfig.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
  */
 public class KafkaAdminConfig extends AbstractConfig {
 
+    /** Prefix for administration related configuration parameters */
     public static final String KAFKA_ADMIN_CONFIG_PREFIX = KafkaConfig.KAFKA_CONFIG_PREFIX + "admin.";
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/config/KafkaConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/KafkaConfig.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
  */
 public class KafkaConfig extends AbstractConfig {
 
+    /** Prefix for Kafka related configuration parameters */
     public static final String KAFKA_CONFIG_PREFIX = "kafka.";
 
     private KafkaProducerConfig producerConfig;

--- a/src/main/java/io/strimzi/kafka/bridge/config/KafkaConsumerConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/KafkaConsumerConfig.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
  */
 public class KafkaConsumerConfig extends AbstractConfig {
 
+    /** Prefix for consumer related configuration parameters */
     public static final String KAFKA_CONSUMER_CONFIG_PREFIX = KafkaConfig.KAFKA_CONFIG_PREFIX + "consumer.";
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/config/KafkaProducerConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/KafkaProducerConfig.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
  */
 public class KafkaProducerConfig extends AbstractConfig {
 
+    /** Prefix for producer related configuration parameters */
     public static final String KAFKA_PRODUCER_CONFIG_PREFIX = KafkaConfig.KAFKA_CONFIG_PREFIX + "producer.";
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
@@ -35,10 +35,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Implementation of the admin client endpoint based on HTTP
+ */
 public class HttpAdminClientEndpoint extends AdminClientEndpoint {
 
     private HttpBridgeContext httpBridgeContext;
 
+    /**
+     *
+     * @param vertx the Vert.x instance
+     * @param bridgeConfig the bridge configuration
+     * @param context the HTTP bridge context
+     */
     public HttpAdminClientEndpoint(Vertx vertx, BridgeConfig bridgeConfig, HttpBridgeContext context) {
         super(vertx, bridgeConfig);
         this.httpBridgeContext = context;
@@ -84,6 +93,11 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
         }
     }
 
+    /**
+     * List all the topics
+     *
+     * @param routingContext the routing context
+     */
     public void doListTopics(RoutingContext routingContext) {
         listTopics(listTopicsResult -> {
             if (listTopicsResult.succeeded()) {
@@ -104,6 +118,11 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
         });
     }
 
+    /**
+     * Get information about the topic in the HTTP request
+     *
+     * @param routingContext the routing context
+     */
     public void doGetTopic(RoutingContext routingContext) {
         String topicName = routingContext.pathParam("topicname");
 
@@ -174,6 +193,11 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
         });
     }
 
+    /**
+     * Get partitions information related to the topic in the HTTP request
+     *
+     * @param routingContext the routing context
+     */
     public void doListPartitions(RoutingContext routingContext) {
         String topicName = routingContext.pathParam("topicname");
         describeTopics(Collections.singletonList(topicName), describeTopicsResult -> {
@@ -205,6 +229,11 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
         });
     }
 
+    /**
+     * Get information about a specific topic partition in the HTTP request
+     *
+     * @param routingContext the routing context
+     */
     public void doGetPartition(RoutingContext routingContext) {
         String topicName = routingContext.pathParam("topicname");
         final int partitionId;
@@ -251,6 +280,11 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
         });
     }
 
+    /**
+     * Get offsets information about a specific topic partition in the HTTP request
+     *
+     * @param routingContext the routing context
+     */
     public void doGetOffsets(RoutingContext routingContext) {
         String topicName = routingContext.pathParam("topicname");
         final int partitionId;

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
@@ -75,6 +75,9 @@ public class HttpBridgeContext<K, V> {
         return this.openApiOperation;
     }
 
+    /**
+     * Close all the sink endpoints
+     */
     public void closeAllSinkBridgeEndpoints() {
         for (Map.Entry<ConsumerInstanceId, SinkBridgeEndpoint<K, V>> sink: getHttpSinkEndpoints().entrySet()) {
             if (sink.getValue() != null)
@@ -83,6 +86,9 @@ public class HttpBridgeContext<K, V> {
         getHttpSinkEndpoints().clear();
     }
 
+    /**
+     * Close all the source endpoints
+     */
     public void closeAllSourceBridgeEndpoints() {
         for (Map.Entry<HttpConnection, SourceBridgeEndpoint<K, V>> source: getHttpSourceEndpoints().entrySet()) {
             if (source.getValue() != null)
@@ -91,6 +97,9 @@ public class HttpBridgeContext<K, V> {
         getHttpSourceEndpoints().clear();
     }
 
+    /**
+     * Close the admin client endpoint
+     */
     public void closeAdminClientEndpoint() {
         if (this.adminClientEndpoint != null)
             this.adminClientEndpoint.close();

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
@@ -15,17 +15,34 @@ import java.util.stream.Collectors;
  */
 public class HttpConfig extends AbstractConfig {
 
+    /** Prefix for the HTTP protocol related configuration */
     public static final String HTTP_CONFIG_PREFIX = "http.";
 
+    /** Enable CORS on HTTP */
     public static final String HTTP_CORS_ENABLED = HTTP_CONFIG_PREFIX + "cors.enabled";
+
+    /** Allowed origins with CORS */
     public static final String HTTP_CORS_ALLOWED_ORIGINS = HTTP_CONFIG_PREFIX + "cors.allowedOrigins";
+
+    /** Allowed methods with CORS */
     public static final String HTTP_CORS_ALLOWED_METHODS = HTTP_CONFIG_PREFIX + "cors.allowedMethods";
+
+    /** HTTP bridge host address */
     public static final String HTTP_HOST = HTTP_CONFIG_PREFIX + "host";
+
+    /** HTTP bridge port */
     public static final String HTTP_PORT = HTTP_CONFIG_PREFIX + "port";
+
+    /** HTTP consumer timeouts */
     public static final String HTTP_CONSUMER_TIMEOUT = HTTP_CONFIG_PREFIX + "timeoutSeconds";
 
+    /** Default HTTP host address if not specified */
     public static final String DEFAULT_HOST = "0.0.0.0";
+
+    /** Default HTTP port if not specified */
     public static final int DEFAULT_PORT = 8080;
+
+    /** Default HTTP consumer timeout if not specified (no timeout) */
     public static final long DEFAULT_CONSUMER_TIMEOUT = -1L;
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpEndpoint.java
@@ -8,10 +8,18 @@ package io.strimzi.kafka.bridge.http;
 import io.strimzi.kafka.bridge.Endpoint;
 import io.vertx.ext.web.RoutingContext;
 
+/**
+ * HTTP implementation for an endpoint
+ */
 public class HttpEndpoint implements Endpoint<RoutingContext> {
 
     private RoutingContext routingContext;
 
+    /**
+     * Constructor
+     *
+     * @param routingContext the routing context
+     */
     public HttpEndpoint(RoutingContext routingContext) {
         this.routingContext = routingContext;
     }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperation.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperation.java
@@ -20,12 +20,22 @@ public abstract class HttpOpenApiOperation implements Handler<RoutingContext> {
 
     protected Logger log;
     protected final HttpOpenApiOperations operationId;
-    
+
+    /**
+     * Constructor
+     *
+     * @param operationId operation ID
+     */
     public HttpOpenApiOperation(HttpOpenApiOperations operationId) {
         this.operationId = operationId;
         this.log = LoggerFactory.getLogger(LOGGER_NAME_PREFIX + operationId.toString());
     }
 
+    /**
+     * Process to run for a specific OpenAPI operation
+     *
+     * @param routingContext the routing context
+     */
     public abstract void process(RoutingContext routingContext);
 
     @Override

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -10,27 +10,49 @@ package io.strimzi.kafka.bridge.http;
  */
 public enum HttpOpenApiOperations {
 
+    /** send a message */
     SEND("send"),
+    /** send a message to a specific partition */
     SEND_TO_PARTITION("sendToPartition"),
+    /** create a consumer instance */
     CREATE_CONSUMER("createConsumer"),
+    /** delete a specific consumer instance */
     DELETE_CONSUMER("deleteConsumer"),
+    /** subscribe to topic(s) */
     SUBSCRIBE("subscribe"),
+    /** unsubscribe from topic(s) */
     UNSUBSCRIBE("unsubscribe"),
+    /** list topics subscription */
     LIST_SUBSCRIPTIONS("listSubscriptions"),
+    /** list topics on the cluster */
     LIST_TOPICS("listTopics"),
+    /** get information for a specific topic */
     GET_TOPIC("getTopic"),
+    /** list partitions for a specific topic */
     LIST_PARTITIONS("listPartitions"),
+    /** get partition information for a specific topic */
     GET_PARTITION("getPartition"),
+    /** get offesets information for a specific topic partition */
     GET_OFFSETS("getOffsets"),
+    /** assign a consumer to topic partition(s) */
     ASSIGN("assign"),
+    /** run a consumer poll to read messages */
     POLL("poll"),
+    /** commit consumer offset */
     COMMIT("commit"),
+    /** seek to a specific offset of a topic partition */
     SEEK("seek"),
+    /** seek to the beginning of a topic partition */
     SEEK_TO_BEGINNING("seekToBeginning"),
+    /** seek to the end of a topic partition */
     SEEK_TO_END("seekToEnd"),
+    /** check liveness of the bridge */
     HEALTHY("healthy"),
+    /** check the readiness of the bridge */
     READY("ready"),
+    /** get the OpenAPI specification */
     OPENAPI("openapi"),
+    /** get general information (i.e. version) about the bridge */
     INFO("info");
 
     private final String text;

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -49,6 +49,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * Implementation of an HTTP based sink endpoint
+ *
+ * @param <K> type of Kafka message key
+ * @param <V> type of Kafka message payload
+ */
 @SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
 
@@ -78,6 +84,13 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         this.handle(endpoint, null);
     }
 
+    /**
+     * Create a Kafka consumer
+     *
+     * @param routingContext the routing context
+     * @param bodyAsJson HTTP request body bringing consumer settings
+     * @param handler handler for the request
+     */
     public void doCreateConsumer(RoutingContext routingContext, JsonObject bodyAsJson, Handler<SinkBridgeEndpoint<K, V>> handler) {
         // get the consumer group-id
         this.groupId = routingContext.pathParam("groupid");
@@ -402,6 +415,11 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         }
     }
 
+    /**
+     * Run list subscriptions operation for the Kafka consumer
+     *
+     * @param routingContext the routing context
+     */
     public void doListSubscriptions(RoutingContext routingContext) {
         this.listSubscriptions(listSubscriptionsResult -> {
 
@@ -440,6 +458,11 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         });
     }
 
+    /**
+     * Run the topic unsubscribe operation for the Kafka consumer
+     *
+     * @param routingContext the routing context
+     */
     public void doUnsubscribe(RoutingContext routingContext) {
         this.setUnsubscribeHandler(unsubscribeResult -> {
             if (unsubscribeResult.succeeded()) {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -37,12 +37,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Implementation of an HTTP based source endpoint
+ *
+ * @param <K> type of Kafka message key
+ * @param <V> type of Kafka message payload
+ */
 public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
 
     private MessageConverter<K, V, Buffer, Buffer> messageConverter;
     private boolean closing;
 
-    public HttpSourceBridgeEndpoint(Vertx vertx, BridgeConfig bridgeConfig,
+    HttpSourceBridgeEndpoint(Vertx vertx, BridgeConfig bridgeConfig,
                                     EmbeddedFormat format, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         super(vertx, bridgeConfig, format, keySerializer, valueSerializer);
     }
@@ -55,6 +61,9 @@ public class HttpSourceBridgeEndpoint<K, V> extends SourceBridgeEndpoint<K, V> {
         super.open();
     }
 
+    /**
+     * Close the source endpoint
+     */
     public void maybeClose() {
         if (this.closing) {
             this.close();

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
@@ -12,10 +12,21 @@ import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Provides some utility methods for HTTP request/response
+ */
 public class HttpUtils {
 
     private static final Logger log = LoggerFactory.getLogger(HttpUtils.class);
 
+    /**
+     * Send an HTTP response
+     *
+     * @param routingContext the routing context used to send the HTTP response
+     * @param statusCode the HTTP status code
+     * @param contentType the content-type to set in the HTTP response
+     * @param body the body to set in the HTTP response
+     */
     public static void sendResponse(RoutingContext routingContext, int statusCode, String contentType, Buffer body) {
         if (!routingContext.response().closed() && !routingContext.response().ended()) {
             routingContext.response().setStatusCode(statusCode);
@@ -31,6 +42,14 @@ public class HttpUtils {
         }
     }
 
+    /**
+     * Send a file over an HTTP response
+     *
+     * @param routingContext the routing context used to send the HTTP response
+     * @param statusCode the HTTP status code
+     * @param contentType the content-type to set in the HTTP response
+     * @param filename path to the file to send
+     */
     public static void sendFile(RoutingContext routingContext, int statusCode, String contentType, String filename) {
         if (!routingContext.response().closed() && !routingContext.response().ended()) {
             routingContext.response().setStatusCode(statusCode);

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
@@ -19,6 +19,9 @@ import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Implementation of a message converter to deal with the "binary" embedded data format
+ */
 public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte[], Buffer, Buffer> {
 
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
@@ -20,6 +20,9 @@ import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Implementation of a message converter to deal with the "json" embedded data format
+ */
 public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[], Buffer, Buffer> {
 
     @Override

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTracingHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTracingHandle.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.bridge.tracing;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jaegertracing.Configuration;
 import io.opentracing.References;
 import io.opentracing.Span;
@@ -68,6 +69,7 @@ class OpenTracingHandle implements TracingHandle {
         return buildSpan(spanBuilder, routingContext);
     }
 
+    @SuppressFBWarnings({"BC_UNCONFIRMED_CAST"})
     @Override
     public <K, V> void handleRecordSpan(SpanHandle<K, V> parentSpanHandle, KafkaConsumerRecord<K, V> record) {
         Tracer tracer = GlobalTracer.get();

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/TracingConstants.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/TracingConstants.java
@@ -9,14 +9,23 @@ package io.strimzi.kafka.bridge.tracing;
  * Tracing constants.
  */
 public final class TracingConstants {
+
+    /** tracing component name definition */
     public static final String COMPONENT = "strimzi-kafka-bridge";
+    /** Kafka service name definition */
     public static final String KAFKA_SERVICE = "kafka";
 
+    /** Jaeger/OpenTracing tracing type */
     public static final String JAEGER = "jaeger";
+    /** OpenTelemetry tracing type */
     public static final String OPENTELEMETRY = "opentelemetry";
 
+    /** OpenTelemetry service name env var */
     public static final String OPENTELEMETRY_SERVICE_NAME_ENV_KEY = "OTEL_SERVICE_NAME";
+    /** OpenTelemetry service name system property */
     public static final String OPENTELEMETRY_SERVICE_NAME_PROPERTY_KEY = "otel.service.name";
+    /** OpenTelemetry traces exporter env var */
     public static final String OPENTELEMETRY_TRACES_EXPORTER_ENV_KEY = "OTEL_TRACES_EXPORTER";
+    /** OpenTelemetry traces exporter system property */
     public static final String OPENTELEMETRY_TRACES_EXPORTER_PROPERTY_KEY = "otel.traces.exporter";
 }

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/TracingUtil.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/TracingUtil.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.bridge.tracing;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
@@ -21,6 +22,7 @@ import static io.strimzi.kafka.bridge.tracing.TracingConstants.OPENTELEMETRY;
 /**
  * Tracing util to hold app's Tracing instance.
  */
+@SuppressFBWarnings({"MS_EXPOSE_REP"})
 public class TracingUtil {
     private static final Logger log = LoggerFactory.getLogger(TracingUtil.class);
     private static TracingHandle tracing = new NoopTracingHandle();

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/TracingUtil.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/TracingUtil.java
@@ -27,10 +27,18 @@ public class TracingUtil {
     private static final Logger log = LoggerFactory.getLogger(TracingUtil.class);
     private static TracingHandle tracing = new NoopTracingHandle();
 
+    /**
+     * @return the current tracing instance
+     */
     public static TracingHandle getTracing() {
         return tracing;
     }
 
+    /**
+     * Initialize the proper tracing system based on the bridge configuration
+     *
+     * @param config bridge configuration
+     */
     public static void initialize(BridgeConfig config) {
         String tracingConfig = config.getTracing();
         if (tracingConfig != null && (tracingConfig.equals(JAEGER) || tracingConfig.equals(OPENTELEMETRY))) {


### PR DESCRIPTION
This PR is about:

* dropping support for Java 8
* moving to Java 11 at compile time
* moving to Java 17 as runtime

It upgrades the version of the maven-dependency-plugin because not compatible with new version of Java.
It moves some dependency to be test scoped (web-common and jackson-databind) that were detected by the new version of the maven-dependency-plugin.
It adds the vertx-opentelemetry to be ignored by the maven-dependency-plugin, because it is detected as test scoped but not marked this way. While it's true that at compile time it's used in tests only, it's also true that it's needed at runtime because the opentelemetry SDK will get from it (in the classpath) the Vert.x “context storage provider”).
It also adds more missing Javadoc on classes and methods because the maven-javadoc-plugin complains about their miss when compiling with Java 17.