### PR TITLE
Removed push based mechanism to send messages to consumer (because part of old AMQP 1.0 support)

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -567,6 +567,8 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         }
     }
 
+    // TODO: to remove when figuring out if handleCommit is really not needed anymore
+    @SuppressFBWarnings({"UPM_UNCALLED_PRIVATE_METHOD"})
     private void handleCommit(AsyncResult<Void> commitResult) {
         if (this.commitHandler != null) {
             this.commitHandler.handle(commitResult);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -140,7 +140,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
                 isolationLevel != null ? String.valueOf(isolationLevel) : null, config);
 
         // create the consumer
-        this.initConsumer(false, config);
+        this.initConsumer(config);
 
         handler.handle(this);
 
@@ -368,7 +368,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
             }
         });
 
-        this.assign(false);
+        this.assign();
     }
 
     private void doSubscribe(RoutingContext routingContext, JsonObject bodyAsJson) {
@@ -408,10 +408,10 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
                         .map(topic -> new SinkTopicSubscription(topic))
                         .collect(Collectors.toList())
             );
-            this.subscribe(false);
+            this.subscribe();
         } else if (bodyAsJson.containsKey("topic_pattern")) {
             Pattern pattern = Pattern.compile(bodyAsJson.getString("topic_pattern"));
-            this.subscribe(pattern, false);
+            this.subscribe(pattern);
         }
     }
 


### PR DESCRIPTION
This PR fixes #699 
It removes the part of code that was used by AMQP 1.0 support in order to push messages to the receiver (limited by credits) while the HTTP protocol works in polling mode as a normal Kafka native consumer.