### PR TITLE
Fixed warning on unchecked cast on empty list

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/clients/BasicKafkaClient.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/BasicKafkaClient.java
@@ -16,7 +16,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -81,7 +80,7 @@ public class BasicKafkaClient {
      */
     public int sendStringMessagesPlain(String topicName, int messageCount) {
         return sendStringMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount,
-            Collections.emptyList(), "\"Hello\" : \"World\"", 0, false);
+            List.of(), "\"Hello\" : \"World\"", 0, false);
     }
 
     /**
@@ -94,12 +93,12 @@ public class BasicKafkaClient {
      */
     public int sendStringMessagesPlain(String topicName, String message, int messageCount, int partition) {
         return sendStringMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount,
-            Collections.emptyList(), message, partition, true);
+                List.of(), message, partition, true);
     }
 
     public int sendStringMessagesPlain(String topicName, String message, int messageCount, int partition, boolean withNullKeyRecord) {
         return sendStringMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount,
-            Collections.emptyList(), message, partition, withNullKeyRecord);
+                List.of(), message, partition, withNullKeyRecord);
     }
 
     /**
@@ -149,7 +148,7 @@ public class BasicKafkaClient {
      * @return sent message count
      */
     public int sendJsonMessagesPlain(String topicName, int messageCount, String message, int partition, boolean withNullKeyRecord) {
-        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.emptyList(),
+        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, List.of(),
             message, partition, withNullKeyRecord);
     }
 
@@ -177,7 +176,7 @@ public class BasicKafkaClient {
      * @return sent message count
      */
     public int sendJsonMessagesPlain(String topicName, int messageCount, String message, int partition) {
-        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.emptyList(),
+        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, List.of(),
             message, partition, false);
     }
 
@@ -189,7 +188,7 @@ public class BasicKafkaClient {
      * @return sent message count
      */
     public int sendJsonMessagesPlain(String topicName, int messageCount, String message) {
-        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.emptyList(),
+        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, List.of(),
             message, 0, false);
     }
 
@@ -200,7 +199,7 @@ public class BasicKafkaClient {
      * @return sent message count
      */
     public int sendJsonMessagesPlain(String topicName, int messageCount) {
-        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.emptyList(),
+        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, List.of(),
             "{\"Hello\" : \"World\"}", 0, false);
     }
 

--- a/src/test/java/io/strimzi/kafka/bridge/clients/BasicKafkaClient.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/BasicKafkaClient.java
@@ -81,7 +81,7 @@ public class BasicKafkaClient {
      */
     public int sendStringMessagesPlain(String topicName, int messageCount) {
         return sendStringMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount,
-            Collections.EMPTY_LIST, "\"Hello\" : \"World\"", 0, false);
+            Collections.emptyList(), "\"Hello\" : \"World\"", 0, false);
     }
 
     /**
@@ -94,12 +94,12 @@ public class BasicKafkaClient {
      */
     public int sendStringMessagesPlain(String topicName, String message, int messageCount, int partition) {
         return sendStringMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount,
-            Collections.EMPTY_LIST, message, partition, true);
+            Collections.emptyList(), message, partition, true);
     }
 
     public int sendStringMessagesPlain(String topicName, String message, int messageCount, int partition, boolean withNullKeyRecord) {
         return sendStringMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount,
-            Collections.EMPTY_LIST, message, partition, withNullKeyRecord);
+            Collections.emptyList(), message, partition, withNullKeyRecord);
     }
 
     /**
@@ -149,7 +149,7 @@ public class BasicKafkaClient {
      * @return sent message count
      */
     public int sendJsonMessagesPlain(String topicName, int messageCount, String message, int partition, boolean withNullKeyRecord) {
-        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.EMPTY_LIST,
+        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.emptyList(),
             message, partition, withNullKeyRecord);
     }
 
@@ -177,7 +177,7 @@ public class BasicKafkaClient {
      * @return sent message count
      */
     public int sendJsonMessagesPlain(String topicName, int messageCount, String message, int partition) {
-        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.EMPTY_LIST,
+        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.emptyList(),
             message, partition, false);
     }
 
@@ -189,7 +189,7 @@ public class BasicKafkaClient {
      * @return sent message count
      */
     public int sendJsonMessagesPlain(String topicName, int messageCount, String message) {
-        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.EMPTY_LIST,
+        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.emptyList(),
             message, 0, false);
     }
 
@@ -200,7 +200,7 @@ public class BasicKafkaClient {
      * @return sent message count
      */
     public int sendJsonMessagesPlain(String topicName, int messageCount) {
-        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.EMPTY_LIST,
+        return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, Collections.emptyList(),
             "{\"Hello\" : \"World\"}", 0, false);
     }
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -250,7 +250,6 @@ public class ProducerIT extends HttpBridgeITAbstract {
         KafkaFuture<Void> future = adminClientFacade.createTopic(topic, 2, 1);
 
         String value = "message-value";
-        String sentBody = "Simple message";
         List<KafkaHeader> headers = new ArrayList<>();
         headers.add(new KafkaHeaderImpl("key1", DatatypeConverter.printBase64Binary("value1".getBytes())));
         headers.add(new KafkaHeaderImpl("key2", DatatypeConverter.printBase64Binary("value2".getBytes())));


### PR DESCRIPTION
Trivial PR to fix an IDE warning about an unchecked cast missing because `EMPTY_LIST` returns just a `List` while it's better using the `emptyList()` method which returns the proper generic expected List type.