### PR TITLE
Removed useless settled producer

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -905,6 +905,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
                     HttpResponse<JsonObject> response = ar.result();
                     assertThat(response.statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
+                    assertThat(response.body(), nullValue());
                 });
 
         Properties consumerProperties = Consumer.fillDefaultProperties();


### PR DESCRIPTION
This PR fixes #702 by removing the `producerSettledMode` which is not needed with AMQP 1.0 removal.