### PR TITLE
Fix partitions assignment behaviour

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -261,10 +261,7 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
 
         log.info("Assigning to topics partitions {}", this.topicSubscriptions);
         this.assigned = true;
-        this.partitionsAssignment();
-    }
 
-    private void partitionsAssignment() {
         // TODO: maybe we don't need the SinkTopicSubscription class anymore? Removing "offset" field, it's now the same as TopicPartition class?
         Set<TopicPartition> topicPartitions = new HashSet<>();
         for (SinkTopicSubscription topicSubscription : this.topicSubscriptions) {

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -12,7 +12,6 @@ import io.strimzi.kafka.bridge.tracker.OffsetTracker;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.kafka.client.common.PartitionInfo;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
@@ -28,7 +27,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -81,8 +79,6 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     private Handler<AsyncResult<Void>> subscribeHandler;
     // handler called after an unsubscription request
     private Handler<AsyncResult<Void>> unsubscribeHandler;
-    // handler called after a request for a specific partition
-    private Handler<AsyncResult<Optional<PartitionInfo>>> partitionHandler;
     // handler called after a topic partition assign request
     private Handler<AsyncResult<Void>> assignHandler;
     // handler called after a seek request on a topic partition
@@ -400,15 +396,6 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     }
 
     /**
-     * Set the handler called after a request for a specific partition is executed
-     *
-     * @param handler   the handler providing the info about the requested specific partition
-     */
-    protected void setPartitionHandler(Handler<AsyncResult<Optional<PartitionInfo>>> handler) {
-        this.partitionHandler = handler;
-    }
-
-    /**
      * Set the handler called when an assign for a specific partition request is executed
      *
      * @param handler   the handler
@@ -456,14 +443,6 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     private void handleUnsubscribe(AsyncResult<Void> unsubscribeResult) {
         if (this.unsubscribeHandler != null) {
             this.unsubscribeHandler.handle(unsubscribeResult);
-        }
-    }
-
-    // TODO: to remove when figuring out if handlePartition is really not needed anymore
-    @SuppressFBWarnings({"UPM_UNCALLED_PRIVATE_METHOD"})
-    private void handlePartition(AsyncResult<Optional<PartitionInfo>> partitionResult) {
-        if (this.partitionHandler != null) {
-            this.partitionHandler.handle(partitionResult);
         }
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkBridgeEndpoint.java
@@ -10,7 +10,6 @@ import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
 import io.strimzi.kafka.bridge.tracker.OffsetTracker;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.kafka.client.common.PartitionInfo;
@@ -282,40 +281,6 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
     }
 
     /**
-     * Returns the topic partitions to which is possible to ask assignment related to which
-     * partitions are available for the topic subscriptions requested
-     *
-     * @param availablePartitions available topics partitions
-     * @return topic partitions to which is possible to ask assignment
-     */
-    private Set<TopicPartition> topicPartitionsToAssign(List<PartitionInfo> availablePartitions) {
-        Set<TopicPartition> topicPartitions = new HashSet<>();
-
-        for (SinkTopicSubscription topicSubscription : this.topicSubscriptions) {
-
-            // check if a requested partition for a topic exists in the available partitions for that topic
-            Optional<PartitionInfo> requestedPartitionInfo =
-                    availablePartitions.stream()
-                            .filter(p -> p.getTopic().equals(topicSubscription.getTopic()) &&
-                                    topicSubscription.getPartition() != null &&
-                                    p.getPartition() == topicSubscription.getPartition())
-                            .findFirst();
-
-            this.handlePartition(Future.succeededFuture(requestedPartitionInfo));
-
-            if (requestedPartitionInfo.isPresent()) {
-                log.debug("Requested partition {} for topic {} does exist",
-                        topicSubscription.getPartition(), topicSubscription.getTopic());
-                topicPartitions.add(new TopicPartition(topicSubscription.getTopic(), topicSubscription.getPartition()));
-            } else {
-                log.warn("Requested partition {} for topic {} doesn't exist",
-                        topicSubscription.getPartition(), topicSubscription.getTopic());
-            }
-        }
-        return topicPartitions;
-    }
-
-    /**
      * Set up the handlers for automatic revoke and assignment partitions (due to rebalancing) for the consumer
      */
     private void setPartitionsAssignmentHandlers() {
@@ -497,6 +462,8 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         }
     }
 
+    // TODO: to remove when figuring out if handlePartition is really not needed anymore
+    @SuppressFBWarnings({"UPM_UNCALLED_PRIVATE_METHOD"})
     private void handlePartition(AsyncResult<Optional<PartitionInfo>> partitionResult) {
         if (this.partitionHandler != null) {
             this.partitionHandler.handle(partitionResult);
@@ -509,6 +476,8 @@ public abstract class SinkBridgeEndpoint<K, V> implements BridgeEndpoint {
         }
     }
 
+    // TODO: to remove when figuring out if handleSeek is really not needed anymore
+    @SuppressFBWarnings({"UPM_UNCALLED_PRIVATE_METHOD"})
     private void handleSeek(AsyncResult<Void> seekResult) {
         if (this.seekHandler != null) {
             this.seekHandler.handle(seekResult);

--- a/src/main/java/io/strimzi/kafka/bridge/SinkTopicSubscription.java
+++ b/src/main/java/io/strimzi/kafka/bridge/SinkTopicSubscription.java
@@ -13,19 +13,16 @@ public class SinkTopicSubscription {
 
     private String topic;
     private Integer partition;
-    private Long offset;
 
     /**
      * Constructor
      *
      * @param topic topic to subscribe/assign
      * @param partition partition requested as assignment (null if no specific assignment)
-     * @param offset offset to seek on partition (null if from the beginning)
      */
-    public SinkTopicSubscription(String topic, Integer partition, Long offset) {
+    public SinkTopicSubscription(String topic, Integer partition) {
         this.topic = topic;
         this.partition = partition;
-        this.offset = offset;
     }
 
     /**
@@ -34,7 +31,7 @@ public class SinkTopicSubscription {
      * @param topic topic to subscribe
      */
     public SinkTopicSubscription(String topic) {
-        this(topic, null, null);
+        this(topic, null);
     }
 
     /**
@@ -69,28 +66,11 @@ public class SinkTopicSubscription {
         this.partition = partition;
     }
 
-    /**
-     * @return offset to seek on partition (null if from the beginning)
-     */
-    public Long getOffset() {
-        return offset;
-    }
-
-    /**
-     * Set the offset to seek on partition (null if from the beginning)
-     *
-     * @param offset offset to seek on partition (null if from the beginning)
-     */
-    public void setOffset(Long offset) {
-        this.offset = offset;
-    }
-
     @Override
     public String toString() {
         return "SinkTopicSubscription(" +
                 "topic=" + this.topic +
                 ",partition=" + this.partition +
-                ",offset=" + this.offset +
                 ")";
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -355,10 +355,12 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
             return;
         }
         JsonArray partitionsList = bodyAsJson.getJsonArray("partitions");
+        // clear current subscriptions because assign works by replacing them in the native Kafka client
+        this.topicSubscriptions.clear();
         this.topicSubscriptions.addAll(
                 partitionsList.stream()
                         .map(JsonObject.class::cast)
-                        .map(json -> new SinkTopicSubscription(json.getString("topic"), json.getInteger("partition"), json.getLong("offset")))
+                        .map(json -> new SinkTopicSubscription(json.getString("topic"), json.getInteger("partition")))
                         .collect(Collectors.toList())
         );
 


### PR DESCRIPTION
This PR fixes #707.
As explained in the issue, the current assignment behaviour is wrong and it doesn't leverage the native Java Kafka client one. With this fix, it's able to get assigned partitions and receiving messages as soon as missing topic and/or partitions are created. Tests are added as well.

It also remove the "seek" operation after the assignment that was used by the AMQP 1.0 protocol support now removed.
The OpenAPI definition doesn't allow to specify an "offset" field when the HTTP client asks for partition assignment on the `/assignments` endpoint.
