### PR TITLE
Bumped SnakeYAML 1.33 to fix CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Moved from using the Jaeger exporter to OTLP exporter by default
 * Moved to Java 11 at language level, dropped Java 8 and use Java 17 as the runtime for all containers
 * Dependency updates (Vert.x 4.3.5)
+* Dependency updates (snakeYAML [CVE-2022-41854](https://nvd.nist.gov/vuln/detail/CVE-2022-41854))
 
 ### Changes, deprecations and removals
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.102.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
+		<snakeyaml.version>1.33</snakeyaml.version>
 		<!-- property to skip surefire tests during failsafe execution -->
 		<!--suppress UnresolvedMavenProperty -->
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -356,11 +357,11 @@
 			<version>${kafka-env-var-config-provider.version}</version>
 		</dependency>
 		<!-- Transitive dependency version overrides for Vulnerabilities: -->
-		<!-- overriding version of snakeyaml for prometheus.jmx.collector 0.12.0: Vulnerability: DOS -->
+		<!-- overriding version of snakeyaml for prometheus.jmx.collector 0.12.0: Vulnerability: DOS and CVE-2022-41854 -->
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.32</version>
+			<version>${snakeyaml.version}</version>
 		</dependency>
 		<!-- Testing -->
 		<dependency>


### PR DESCRIPTION
This PR updates SnakeYAML to 1.33 to address the dependabot reports.