### PR TITLE
Added the catch of wrong content-type returning meaningful message

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -33,6 +33,7 @@ import io.vertx.ext.web.RoutingContext;
 
 import io.vertx.ext.web.handler.CorsHandler;
 import io.vertx.ext.web.openapi.RouterBuilder;
+import io.vertx.ext.web.validation.BodyProcessorException;
 import io.vertx.ext.web.validation.ParameterProcessorException;
 import io.vertx.json.schema.ValidationException;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -574,13 +575,20 @@ public class HttpBridge extends AbstractVerticle {
             }
 
             if (routingContext.failure() != null && routingContext.failure() instanceof ParameterProcessorException) {
-                ParameterProcessorException validationException = (ParameterProcessorException) routingContext.failure();
+                ParameterProcessorException parameterException = (ParameterProcessorException) routingContext.failure();
                 StringBuilder sb = new StringBuilder();
-                if (validationException.getParameterName() != null) {
-                    sb.append("Validation error on: ").append(validationException.getParameterName()).append(" - ");
+                if (parameterException.getParameterName() != null) {
+                    sb.append("Parameter error on: ").append(parameterException.getParameterName()).append(" - ");
                 }
-                sb.append(validationException.getMessage());
+                sb.append(parameterException.getMessage());
                 message = sb.toString();
+            }
+
+            if (routingContext.failure() != null && routingContext.failure() instanceof BodyProcessorException) {
+                BodyProcessorException bodyProcessorException = (BodyProcessorException) routingContext.failure();
+                if (bodyProcessorException.getMessage() != null) {
+                    message = bodyProcessorException.getMessage();
+                }
             }
         } else if (routingContext.statusCode() == HttpResponseStatus.NOT_FOUND.code()) {
             message = HttpResponseStatus.NOT_FOUND.reasonPhrase();

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -564,31 +564,25 @@ public class HttpBridge extends AbstractVerticle {
         if (routingContext.statusCode() == HttpResponseStatus.BAD_REQUEST.code()) {
             message = HttpResponseStatus.BAD_REQUEST.reasonPhrase();
             // in case of validation exception, building a meaningful error message
-            if (routingContext.failure() != null && routingContext.failure().getCause() instanceof ValidationException) {
-                ValidationException validationException = (ValidationException) routingContext.failure().getCause();
+            if (routingContext.failure() != null) {
                 StringBuilder sb = new StringBuilder();
-                if (validationException.inputScope() != null) {
-                    sb.append("Validation error on: ").append(validationException.inputScope()).append(" - ");
+                if (routingContext.failure().getCause() instanceof ValidationException) {
+                    ValidationException validationException = (ValidationException) routingContext.failure().getCause();
+                    if (validationException.inputScope() != null) {
+                        sb.append("Validation error on: ").append(validationException.inputScope()).append(" - ");
+                    }
+                    sb.append(validationException.getMessage());
+                } else if (routingContext.failure() instanceof ParameterProcessorException) {
+                    ParameterProcessorException parameterException = (ParameterProcessorException) routingContext.failure();
+                    if (parameterException.getParameterName() != null) {
+                        sb.append("Parameter error on: ").append(parameterException.getParameterName()).append(" - ");
+                    }
+                    sb.append(parameterException.getMessage());
+                } else if (routingContext.failure() instanceof BodyProcessorException) {
+                    BodyProcessorException bodyProcessorException = (BodyProcessorException) routingContext.failure();
+                    sb.append(bodyProcessorException.getMessage());
                 }
-                sb.append(validationException.getMessage());
                 message = sb.toString();
-            }
-
-            if (routingContext.failure() != null && routingContext.failure() instanceof ParameterProcessorException) {
-                ParameterProcessorException parameterException = (ParameterProcessorException) routingContext.failure();
-                StringBuilder sb = new StringBuilder();
-                if (parameterException.getParameterName() != null) {
-                    sb.append("Parameter error on: ").append(parameterException.getParameterName()).append(" - ");
-                }
-                sb.append(parameterException.getMessage());
-                message = sb.toString();
-            }
-
-            if (routingContext.failure() != null && routingContext.failure() instanceof BodyProcessorException) {
-                BodyProcessorException bodyProcessorException = (BodyProcessorException) routingContext.failure();
-                if (bodyProcessorException.getMessage() != null) {
-                    message = bodyProcessorException.getMessage();
-                }
             }
         } else if (routingContext.statusCode() == HttpResponseStatus.NOT_FOUND.code()) {
             message = HttpResponseStatus.NOT_FOUND.reasonPhrase();

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -647,7 +647,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsToPartitionRequest(topic, partition, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: partitionid - [Bad Request] Parsing error for parameter partitionid in location PATH: java.lang.NumberFormatException: For input string: \"" + partition + "\""));
+            .sendJsonObject(root, verifyBadRequest(context, "Parameter error on: partitionid - [Bad Request] Parsing error for parameter partitionid in location PATH: java.lang.NumberFormatException: For input string: \"" + partition + "\""));
     }
 
     @Test


### PR DESCRIPTION
This PR fixes #598 
The bridge is now handling requests on sending messages which come with a bad content-type and returning a more meaningful error like the following:

```json
{
   "error_code":400,
   "message":"[Bad Request] Cannot find body processor for content type application/x-www-form-urlencoded"
}
```
