### PR TITLE
Update Config Providers to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
 		<vertx.version>4.3.5</vertx.version>
 		<netty.version>4.1.78.Final</netty.version>
 		<kafka.version>3.2.3</kafka.version>
-		<kafka-kubernetes-config-provider.version>1.0.1</kafka-kubernetes-config-provider.version>
-		<kafka-env-var-config-provider.version>1.0.0</kafka-env-var-config-provider.version>
+		<kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>
+		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<maven.checkstyle.version>3.2.0</maven.checkstyle.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<junit.version>5.8.2</junit.version>


### PR DESCRIPTION
This PR updates the Kubernetes Config Provider and Env Var Config Provider to their new release 1.1.0 which brings Java 17 support and dependency updates.