### PR TITLE
Update the Java setup step used in CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,10 +38,11 @@ jobs:
       uses: actions/checkout@v2
     
     # Setup OpenJDK 11
-    - name: Setup java
-      uses: joschi/setup-jdk@v2
+    - uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'temurin'
+        java-version: '11'
+        cache: 'maven'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
This PR updates the CodeQL step which installs and configures Java from `joschi/setup-jdk@v2` which is deprecated to the official `actions/setup-java@v2` step.