### PR TITLE
Add oauth metrics into the `jmx_metrics_config.yaml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed bug about missing OAuth password grants configuration   
 * Dependency updates (Vert.x 4.3.5)
 * Dependency updates (snakeYAML [CVE-2022-41854](https://nvd.nist.gov/vuln/detail/CVE-2022-41854))
+* Add Oauth metrics into the `jmx_metrics_config.yaml`
 
 ### Changes, deprecations and removals
 

--- a/src/main/resources/jmx_metrics_config.yaml
+++ b/src/main/resources/jmx_metrics_config.yaml
@@ -23,3 +23,65 @@ rules:
     labels:
       type: "$2"
       clientId: "$3"
+  # OAuth Metrics
+  # WARNING: Make sure that the ordering of the attributes is the same as in MBean names
+  - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(count|totalTimeMs):"
+    name: "strimzi_oauth_$1_$12"
+    type: COUNTER
+    labels:
+      context: "$2"
+      kind: "$3"
+      host: "$4"
+      path: "$5"
+      "$6": "$7"
+      "$8": "$9"
+      "$10": "$11"
+  - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+), (.+)=(.+)><>(count|totalTimeMs):"
+    name: "strimzi_oauth_$1_$10"
+    type: COUNTER
+    labels:
+      context: "$2"
+      kind: "$3"
+      host: "$4"
+      path: "$5"
+      "$6": "$7"
+      "$8": "$9"
+  - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+)><>(count|totalTimeMs):"
+    name: "strimzi_oauth_$1_$8"
+    type: COUNTER
+    labels:
+      context: "$2"
+      kind: "$3"
+      host: "$4"
+      path: "$5"
+      "$6": "$7"
+  - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(.+):"
+    name: "strimzi_oauth_$1_$12"
+    type: GAUGE
+    labels:
+      context: "$2"
+      kind: "$3"
+      host: "$4"
+      path: "$5"
+      "$6": "$7"
+      "$8": "$9"
+      "$10": "$11"
+  - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+), (.+)=(.+)><>(.+):"
+    name: "strimzi_oauth_$1_$10"
+    type: GAUGE
+    labels:
+      context: "$2"
+      kind: "$3"
+      host: "$4"
+      path: "$5"
+      "$6": "$7"
+      "$8": "$9"
+  - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+)><>(.+):"
+    name: "strimzi_oauth_$1_$8"
+    type: GAUGE
+    labels:
+      context: "$2"
+      kind: "$3"
+      host: "$4"
+      path: "$5"
+      "$6": "$7"


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

In Oauth 0.11.0, the oauth metrics were introduced.
But, to scrape these Oauth metrics from Bridge, we need to add the correct patterns into the `jmx_metrics_config.yaml`.

This PR does it.