### PR TITLE
Bumped Netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<vertx.version>4.3.5</vertx.version>
-		<netty.version>4.1.78.Final</netty.version>
+		<netty.version>4.1.85.Final</netty.version>
 		<kafka.version>3.2.3</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
This PR bumps netty version which is needed by new Vert.x 4.3.5 to work properly with HTTP 2 protocol upgrade.