### PR TITLE
Replace Vert.x Kafka client with native Java Kafka client in the source endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,7 @@
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-opentelemetry</artifactId>
 			<version>${vertx.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>

--- a/src/main/java/io/strimzi/kafka/bridge/converter/MessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/converter/MessageConverter.java
@@ -7,7 +7,7 @@ package io.strimzi.kafka.bridge.converter;
 
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
-import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 import java.util.List;
 
@@ -24,7 +24,7 @@ public interface MessageConverter<K, V, M, C> {
      * @param message message to convert
      * @return Kafka record
      */
-    KafkaProducerRecord<K, V> toKafkaRecord(String kafkaTopic, Integer partition, M message);
+    ProducerRecord<K, V> toKafkaRecord(String kafkaTopic, Integer partition, M message);
 
     /**
      * Convert a collection of messages to Kafka records
@@ -34,7 +34,7 @@ public interface MessageConverter<K, V, M, C> {
      * @param messages collection of messages to convert
      * @return Kafka records
      */
-    List<KafkaProducerRecord<K, V>> toKafkaRecords(String kafkaTopic, Integer partition, C messages);
+    List<ProducerRecord<K, V>> toKafkaRecords(String kafkaTopic, Integer partition, C messages);
 
     /**
      * Converts a Kafka record to a message

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -465,8 +465,8 @@ public class HttpBridge extends AbstractVerticle {
 
         try {
             if (source == null) {
-                source = new HttpSourceBridgeEndpoint<>(this.vertx, this.bridgeConfig,
-                        contentTypeToFormat(contentType), new ByteArraySerializer(), new ByteArraySerializer());
+                source = new HttpSourceBridgeEndpoint<>(this.bridgeConfig, contentTypeToFormat(contentType),
+                                                        new ByteArraySerializer(), new ByteArraySerializer());
 
                 source.closeHandler(s -> {
                     this.httpBridgeContext.getHttpSourceEndpoints().remove(httpServerRequest.connection());

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
@@ -12,8 +12,10 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
 import io.vertx.kafka.client.producer.KafkaHeader;
-import io.vertx.kafka.client.producer.KafkaProducerRecord;
-import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
@@ -26,12 +28,12 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
 
 
     @Override
-    public KafkaProducerRecord<byte[], byte[]> toKafkaRecord(String kafkaTopic, Integer partition, Buffer message) {
+    public ProducerRecord<byte[], byte[]> toKafkaRecord(String kafkaTopic, Integer partition, Buffer message) {
 
         Integer partitionFromBody = null;
         byte[] key = null;
         byte[] value = null;
-        List<KafkaHeader> headers = new ArrayList<>();
+        Headers headers = new RecordHeaders();
 
         JsonObject json = message.toJsonObject();
 
@@ -45,10 +47,7 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
             if (json.containsKey("headers")) {
                 for (Object obj: json.getJsonArray("headers")) {
                     JsonObject jsonObject = (JsonObject) obj;
-                    headers.add(new KafkaHeaderImpl(
-                        jsonObject.getString("key"),
-                        Buffer.buffer(
-                            DatatypeConverter.parseBase64Binary(jsonObject.getString("value")))));
+                    headers.add(new RecordHeader(jsonObject.getString("key"), DatatypeConverter.parseBase64Binary(jsonObject.getString("value"))));
                 }
             }
             if (json.containsKey("partition")) {
@@ -61,17 +60,13 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
                 partitionFromBody = partition;
             }
         }
-
-        KafkaProducerRecord<byte[], byte[]> record = KafkaProducerRecord.create(kafkaTopic, key, value, partitionFromBody);
-        record.addHeaders(headers);
-
-        return record;
+        return new ProducerRecord<>(kafkaTopic, partitionFromBody, key, value, headers);
     }
 
     @Override
-    public List<KafkaProducerRecord<byte[], byte[]>> toKafkaRecords(String kafkaTopic, Integer partition, Buffer messages) {
+    public List<ProducerRecord<byte[], byte[]>> toKafkaRecords(String kafkaTopic, Integer partition, Buffer messages) {
 
-        List<KafkaProducerRecord<byte[], byte[]>> records = new ArrayList<>();
+        List<ProducerRecord<byte[], byte[]>> records = new ArrayList<>();
 
         JsonObject json = messages.toJsonObject();
         JsonArray jsonArray = json.getJsonArray("records");

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/BridgeContextStorageProvider.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/BridgeContextStorageProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.tracing;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextStorage;
+import io.opentelemetry.context.ContextStorageProvider;
+import io.opentelemetry.context.Scope;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Provider returning the custom OpenTelemetry context storage
+ */
+public class BridgeContextStorageProvider implements ContextStorageProvider {
+    static final String ACTIVE_CONTEXT = "tracing.context";
+
+    /**
+     * Constructor
+     */
+    public BridgeContextStorageProvider() {
+    }
+
+    @Override
+    public ContextStorage get() {
+        return BridgeContextStorage.INSTANCE;
+    }
+
+    /**
+     * Custom OpenTelemetry context storage
+     * The Vert.x context storage cannot be used anymore having a part of the bridge not using a Vert.x instance (so NPEs around the corner)
+     * This custom implementation provides the same behaviour as the Vert.x one but without the need of a Vert.x instance
+     * It's needed in a transitioning phase with parts of the bridge still handled by Vert.x where the event loop is around,
+     * see for example incoming HTTP requests
+     * In this case the default OpenTelemetry ThreadLocalContextStorage doesn't work because for each new incoming HTTP request
+     * the Context is the same as the previous request because bounded to the thread (Vert.x event loop) while it's should be new
+     * It drives to spans grouped all together under the same trace when they are related to different HTTP requests
+     * We should be able to get rid of this class when Vert.x will be totally out of the picture
+     */
+    // TODO: evaluate to remove this class, back to the default ThreadLocalContextStorage, when Vert.x will be totally removed
+    enum BridgeContextStorage implements ContextStorage {
+        INSTANCE;
+
+        private ConcurrentMap<Object, Object> data = new ConcurrentHashMap();
+
+        @Override
+        public Scope attach(Context toAttach) {
+            Context current = (Context) data.get(ACTIVE_CONTEXT);
+            if (current == toAttach) {
+                return Scope.noop();
+            } else {
+                data.put(ACTIVE_CONTEXT, toAttach);
+                return current == null ? () -> {
+                    data.remove(ACTIVE_CONTEXT);
+                } : () -> {
+                    data.put(ACTIVE_CONTEXT, current);
+                };
+            }
+        }
+
+        @Override
+        public Context current() {
+            return (Context) data.get(ACTIVE_CONTEXT);
+        }
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/NoopTracingHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/NoopTracingHandle.java
@@ -8,7 +8,7 @@ package io.strimzi.kafka.bridge.tracing;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 import java.util.Properties;
 
@@ -42,7 +42,7 @@ final class NoopTracingHandle implements TracingHandle {
 
     private static final class NoopSpanHandle<K, V> implements SpanHandle<K, V> {
         @Override
-        public void inject(KafkaProducerRecord<K, V> record) {
+        public void inject(ProducerRecord<K, V> record) {
         }
 
         @Override

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTracingHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTracingHandle.java
@@ -22,11 +22,12 @@ import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -126,12 +127,12 @@ class OpenTracingHandle implements TracingHandle {
         }
 
         @Override
-        public void inject(KafkaProducerRecord<K, V> record) {
+        public void inject(ProducerRecord<K, V> record) {
             Tracer tracer = GlobalTracer.get();
             tracer.inject(span.context(), Format.Builtin.TEXT_MAP, new TextMap() {
                 @Override
                 public void put(String key, String value) {
-                    record.addHeader(key, value);
+                    record.headers().add(key, value.getBytes(StandardCharsets.UTF_8));
                 }
 
                 @Override

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/SpanHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/SpanHandle.java
@@ -6,7 +6,7 @@
 package io.strimzi.kafka.bridge.tracing;
 
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 /**
  * Span handle, an abstraction over actual span implementation.
@@ -17,7 +17,7 @@ public interface SpanHandle<K, V> {
      *
      * @param record Kafka producer record to extract tracing info
      */
-    void inject(KafkaProducerRecord<K, V> record);
+    void inject(ProducerRecord<K, V> record);
 
     /**
      * Inject tracing info into underlying span from Vert.x routing context.

--- a/src/main/resources/META-INF/services/io.opentelemetry.context.ContextStorageProvider
+++ b/src/main/resources/META-INF/services/io.opentelemetry.context.ContextStorageProvider
@@ -1,0 +1,1 @@
+io.strimzi.kafka.bridge.tracing.BridgeContextStorageProvider


### PR DESCRIPTION
This PR is about replacing the usage of the Vert.x Kafka client on the source endpoint (producer side of the bridge) with the native Java Kafka client (provided by Apache Kafka upstream project).

It provides the following things:

* using `CompletableFuture`(s) based pattern to run producer requests asynchronously (as today it's done by Vert.x)
* removing the Vert.x instance from the sink/producer side
* replacing Vert.x Kafka related classes, i.e. KafkaProducer, KafkaProducerRecord, RecordMetadata, KafkaHeaderImpl and more with the corresponding native ones from the Java Kafka client
* replace the OpenTelemetry Vert.x context storage with a custom one (it could be just a temporary solution before everything will be moved to not using Vert.x)

Anyway, there are still some Vert.x structures in place like the ones handling JSON, Buffer(s) and Handler(s).