### PR TITLE
Added HTTP 204 as OK status in OpenTelemetry span

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
@@ -176,7 +176,7 @@ class OpenTelemetryHandle implements TracingHandle {
         public void finish(int code) {
             try {
                 span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, code);
-                span.setStatus(code == HttpResponseStatus.OK.code() ? StatusCode.OK : StatusCode.ERROR);
+                span.setStatus(code == HttpResponseStatus.OK.code() || code == HttpResponseStatus.NO_CONTENT.code() ? StatusCode.OK : StatusCode.ERROR);
                 scope.close();
             } finally {
                 span.end();

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
@@ -176,7 +176,8 @@ class OpenTelemetryHandle implements TracingHandle {
         public void finish(int code) {
             try {
                 span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, code);
-                span.setStatus(code == HttpResponseStatus.OK.code() || code == HttpResponseStatus.NO_CONTENT.code() ? StatusCode.OK : StatusCode.ERROR);
+                // OK status is fine for all 2xx HTTP status codes
+                span.setStatus(code >= 200 && code < 300 ? StatusCode.OK : StatusCode.ERROR);
                 scope.close();
             } finally {
                 span.end();


### PR DESCRIPTION
When the HTTP client produces messages by adding the `?async=true` as query parameter, there is no content got back from the bridge so `204` code is returned.
When OpenTelemetry is active, in this case, the span gets an ERROR status code because the source code is checking only for HTTP `200` and not `204` as ok outcome.
This trivial PR fixes the issue.