### PR TITLE
Replace Vert.x Kafka client with native Java Kafka client in the admin endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,11 +132,6 @@
 		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
-			<artifactId>vertx-kafka-client</artifactId>
-			<version>${vertx.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.vertx</groupId>
 			<artifactId>vertx-web</artifactId>
 			<version>${vertx.version}</version>
 		</dependency>
@@ -375,6 +370,12 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.vertx</groupId>
+			<artifactId>vertx-kafka-client</artifactId>
+			<version>${vertx.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
@@ -59,7 +59,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
     @Override
     public void handle(Endpoint<?> endpoint, Handler<?> handler) {
         RoutingContext routingContext = (RoutingContext) endpoint.get();
-        log.info("HttpAdminClientEndpoint handle thread {}", Thread.currentThread());
+        log.trace("HttpAdminClientEndpoint handle thread {}", Thread.currentThread());
         switch (this.httpBridgeContext.getOpenApiOperation()) {
             case LIST_TOPICS:
                 doListTopics(routingContext);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
@@ -11,29 +11,27 @@ import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.Endpoint;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.kafka.admin.Config;
-import io.vertx.kafka.admin.ConfigEntry;
-import io.vertx.kafka.admin.ListOffsetsResultInfo;
-import io.vertx.kafka.admin.OffsetSpec;
-import io.vertx.kafka.admin.TopicDescription;
-import io.vertx.kafka.client.common.ConfigResource;
-import io.vertx.kafka.client.common.TopicPartition;
-import io.vertx.kafka.client.common.TopicPartitionInfo;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Implementation of the admin client endpoint based on HTTP
@@ -43,13 +41,13 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
     private HttpBridgeContext httpBridgeContext;
 
     /**
+     * Create a Kafka admin client
      *
-     * @param vertx the Vert.x instance
      * @param bridgeConfig the bridge configuration
      * @param context the HTTP bridge context
      */
-    public HttpAdminClientEndpoint(Vertx vertx, BridgeConfig bridgeConfig, HttpBridgeContext context) {
-        super(vertx, bridgeConfig);
+    public HttpAdminClientEndpoint(BridgeConfig bridgeConfig, HttpBridgeContext context) {
+        super(bridgeConfig);
         this.httpBridgeContext = context;
     }
 
@@ -61,6 +59,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
     @Override
     public void handle(Endpoint<?> endpoint, Handler<?> handler) {
         RoutingContext routingContext = (RoutingContext) endpoint.get();
+        log.info("HttpAdminClientEndpoint handle thread {}", Thread.currentThread());
         switch (this.httpBridgeContext.getOpenApiOperation()) {
             case LIST_TOPICS:
                 doListTopics(routingContext);
@@ -94,23 +93,22 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
      * @param routingContext the routing context
      */
     public void doListTopics(RoutingContext routingContext) {
-        listTopics(listTopicsResult -> {
-            if (listTopicsResult.succeeded()) {
-                JsonArray root = new JsonArray();
-                Set<String> topics = listTopicsResult.result();
-                topics.forEach(topic -> {
-                    root.add(topic);
+        this.listTopics()
+                .whenComplete((topics, ex) -> {
+                    log.trace("List topics handler thread {}", Thread.currentThread());
+                    if (ex == null) {
+                        JsonArray root = new JsonArray();
+                        topics.forEach(topic -> root.add(topic));
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
+                    } else {
+                        HttpBridgeError error = new HttpBridgeError(
+                                HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                ex.getMessage()
+                        );
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                    }
                 });
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
-            } else {
-                HttpBridgeError error = new HttpBridgeError(
-                        HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        listTopicsResult.cause().getMessage()
-                );
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-            }
-        });
     }
 
     /**
@@ -121,71 +119,63 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
     public void doGetTopic(RoutingContext routingContext) {
         String topicName = routingContext.pathParam("topicname");
 
-        Promise<Map<String, TopicDescription>> describeTopicsPromise = Promise.promise();
-        this.describeTopics(Collections.singletonList(topicName), describeTopicsPromise);
-        Promise<Map<ConfigResource, Config>> describeConfigsPromise = Promise.promise();
-        this.describeConfigs(Collections.singletonList(new ConfigResource(org.apache.kafka.common.config.ConfigResource.Type.TOPIC,
-                topicName)), describeConfigsPromise);
-        Future<Map<String, TopicDescription>> describeTopicsFuture = describeTopicsPromise.future();
-        Future<Map<ConfigResource, Config>> describeConfigsFuture = describeConfigsPromise.future();
+        CompletionStage<Map<String, TopicDescription>> describeTopicsPromise = this.describeTopics(List.of(topicName));
+        CompletionStage<Map<ConfigResource, Config>> describeConfigsPromise = this.describeConfigs(List.of(new ConfigResource(ConfigResource.Type.TOPIC, topicName)));
 
-        CompositeFuture.join(describeTopicsFuture, describeConfigsFuture).onComplete(done -> {
-            if (done.succeeded() && describeTopicsFuture.result() != null && describeConfigsFuture.result() != null) {
-                Map<String, TopicDescription> topicDescriptions = describeTopicsFuture.result();
-                Map<ConfigResource, Config> configDescriptions = describeConfigsFuture.result();
-                JsonObject root = new JsonObject();
-                JsonArray partitionsArray = new JsonArray();
-                root.put("name", topicName);
-                List<ConfigEntry> configEntries = configDescriptions.values().iterator().next().getEntries();
-                if (configEntries.size() > 0) {
-                    JsonObject configs = new JsonObject();
-                    configEntries.forEach(configEntry -> {
-                        configs.put(configEntry.getName(), configEntry.getValue());
-                    });
-                    root.put("configs", configs);
-                }
-                TopicDescription description = topicDescriptions.get(topicName);
-                if (description != null) {
-                    description.getPartitions().forEach(partitionInfo -> {
-                        int leaderId = partitionInfo.getLeader().getId();
-                        JsonObject partition = new JsonObject();
-                        partition.put("partition", partitionInfo.getPartition());
-                        partition.put("leader", leaderId);
-                        JsonArray replicasArray = new JsonArray();
-                        Set<Integer> insyncSet = new HashSet<Integer>();
-                        partitionInfo.getIsr().forEach(node -> {
-                            insyncSet.add(node.getId());
-                        });
-                        partitionInfo.getReplicas().forEach(node -> {
-                            JsonObject replica = new JsonObject();
-                            replica.put("broker", node.getId());
-                            replica.put("leader", leaderId == node.getId());
-                            replica.put("in_sync", insyncSet.contains(node.getId()));
-                            replicasArray.add(replica);
-                        });
-                        partition.put("replicas", replicasArray);
-                        partitionsArray.add(partition);
-                    });
-                }
-                root.put("partitions", partitionsArray);
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
-
-            } else if (done.cause() != null && done.cause().getCause() instanceof UnknownTopicOrPartitionException) {
-                HttpBridgeError error = new HttpBridgeError(
-                        HttpResponseStatus.NOT_FOUND.code(),
-                        done.cause().getMessage()
-                );
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-            } else {
-                HttpBridgeError error = new HttpBridgeError(
-                        HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        done.cause().getMessage()
-                );
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-            }
-        });
+        CompletableFuture.allOf(describeTopicsPromise.toCompletableFuture(), describeConfigsPromise.toCompletableFuture())
+                .whenComplete((v, ex) -> {
+                    log.trace("Get topic handler thread {}", Thread.currentThread());
+                    if (ex == null) {
+                        Map<String, TopicDescription> topicDescriptions = describeTopicsPromise.toCompletableFuture().getNow(Map.of());
+                        Map<ConfigResource, Config> configDescriptions = describeConfigsPromise.toCompletableFuture().getNow(Map.of());
+                        JsonObject root = new JsonObject();
+                        JsonArray partitionsArray = new JsonArray();
+                        root.put("name", topicName);
+                        Collection<ConfigEntry> configEntries = configDescriptions.values().iterator().next().entries();
+                        if (configEntries.size() > 0) {
+                            JsonObject configs = new JsonObject();
+                            configEntries.forEach(configEntry -> configs.put(configEntry.name(), configEntry.value()));
+                            root.put("configs", configs);
+                        }
+                        TopicDescription description = topicDescriptions.get(topicName);
+                        if (description != null) {
+                            description.partitions().forEach(partitionInfo -> {
+                                int leaderId = partitionInfo.leader().id();
+                                JsonObject partition = new JsonObject();
+                                partition.put("partition", partitionInfo.partition());
+                                partition.put("leader", leaderId);
+                                JsonArray replicasArray = new JsonArray();
+                                Set<Integer> insyncSet = new HashSet<Integer>();
+                                partitionInfo.isr().forEach(node -> insyncSet.add(node.id()));
+                                partitionInfo.replicas().forEach(node -> {
+                                    JsonObject replica = new JsonObject();
+                                    replica.put("broker", node.id());
+                                    replica.put("leader", leaderId == node.id());
+                                    replica.put("in_sync", insyncSet.contains(node.id()));
+                                    replicasArray.add(replica);
+                                });
+                                partition.put("replicas", replicasArray);
+                                partitionsArray.add(partition);
+                            });
+                        }
+                        root.put("partitions", partitionsArray);
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
+                    } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
+                        HttpBridgeError error = new HttpBridgeError(
+                                HttpResponseStatus.NOT_FOUND.code(),
+                                ex.getMessage()
+                        );
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
+                                BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                    } else {
+                        HttpBridgeError error = new HttpBridgeError(
+                                HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                ex.getMessage()
+                        );
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                    }
+                });
     }
 
     /**
@@ -195,33 +185,32 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
      */
     public void doListPartitions(RoutingContext routingContext) {
         String topicName = routingContext.pathParam("topicname");
-        describeTopics(Collections.singletonList(topicName), describeTopicsResult -> {
-            if (describeTopicsResult.succeeded()) {
-                Map<String, TopicDescription> topicDescriptions = describeTopicsResult.result();
-                JsonArray root = new JsonArray();
-                TopicDescription description = topicDescriptions.get(topicName);
-                if (description != null) {
-                    description.getPartitions().forEach(partitionInfo -> {
-                        root.add(createPartitionMetadata(partitionInfo));
-                    });
-                }
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
-            } else if (describeTopicsResult.cause() != null && describeTopicsResult.cause().getCause() instanceof UnknownTopicOrPartitionException) {
-                HttpBridgeError error = new HttpBridgeError(
-                        HttpResponseStatus.NOT_FOUND.code(),
-                        describeTopicsResult.cause().getMessage()
-                );
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-            } else {
-                HttpBridgeError error = new HttpBridgeError(
-                        HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        describeTopicsResult.cause().getMessage()
-                );
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-            }
-        });
+        this.describeTopics(List.of(topicName))
+                .whenComplete((topicDescriptions, ex) -> {
+                    log.trace("List partitions handler thread {}", Thread.currentThread());
+                    if (ex == null) {
+                        JsonArray root = new JsonArray();
+                        TopicDescription description = topicDescriptions.get(topicName);
+                        if (description != null) {
+                            description.partitions().forEach(partitionInfo -> root.add(createPartitionMetadata(partitionInfo)));
+                        }
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
+                    } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
+                        HttpBridgeError error = new HttpBridgeError(
+                                HttpResponseStatus.NOT_FOUND.code(),
+                                ex.getMessage()
+                        );
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
+                                BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                    } else {
+                        HttpBridgeError error = new HttpBridgeError(
+                                HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                ex.getMessage()
+                        );
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                    }
+                });
     }
 
     /**
@@ -242,37 +231,38 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                     BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
             return;
         }
-        describeTopics(Collections.singletonList(topicName), describeTopicsResult -> {
-            if (describeTopicsResult.succeeded()) {
-                Map<String, TopicDescription> topicDescriptions = describeTopicsResult.result();
-                TopicDescription description = topicDescriptions.get(topicName);
-                if (description != null && partitionId < description.getPartitions().size()) {
-                    JsonObject root = createPartitionMetadata(description.getPartitions().get(partitionId));
-                    HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
-                } else {
-                    HttpBridgeError error = new HttpBridgeError(
-                            HttpResponseStatus.NOT_FOUND.code(),
-                            "Specified partition does not exist."
-                    );
-                    HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                            BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-                }
-            } else if (describeTopicsResult.cause() != null && describeTopicsResult.cause().getCause() instanceof UnknownTopicOrPartitionException) {
-                HttpBridgeError error = new HttpBridgeError(
-                        HttpResponseStatus.NOT_FOUND.code(),
-                        describeTopicsResult.cause().getMessage()
-                );
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-            } else {
-                HttpBridgeError error = new HttpBridgeError(
-                        HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        describeTopicsResult.cause().getMessage()
-                );
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-            }
-        });
+        this.describeTopics(List.of(topicName))
+                .whenComplete((topicDescriptions, ex) -> {
+                    log.trace("Get partition handler thread {}", Thread.currentThread());
+                    if (ex == null) {
+                        TopicDescription description = topicDescriptions.get(topicName);
+                        if (description != null && partitionId < description.partitions().size()) {
+                            JsonObject root = createPartitionMetadata(description.partitions().get(partitionId));
+                            HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
+                        } else {
+                            HttpBridgeError error = new HttpBridgeError(
+                                    HttpResponseStatus.NOT_FOUND.code(),
+                                    "Specified partition does not exist."
+                            );
+                            HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
+                                    BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                        }
+                    } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
+                        HttpBridgeError error = new HttpBridgeError(
+                                HttpResponseStatus.NOT_FOUND.code(),
+                                ex.getMessage()
+                        );
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
+                                BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                    } else {
+                        HttpBridgeError error = new HttpBridgeError(
+                                HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                ex.getMessage()
+                        );
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                    }
+                });
     }
 
     /**
@@ -294,69 +284,65 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
             return;
         }
         TopicPartition topicPartition = new TopicPartition(topicName, partitionId);
-        Promise<Map<TopicPartition, ListOffsetsResultInfo>> getBeginningOffsetsPromise = Promise.promise();
-        Map<TopicPartition, OffsetSpec> topicPartitionBeginOffsets = Collections.singletonMap(topicPartition, OffsetSpec.EARLIEST);
-        this.listOffsets(topicPartitionBeginOffsets, getBeginningOffsetsPromise);
-        Promise<Map<TopicPartition, ListOffsetsResultInfo>> getEndOffsetsPromise = Promise.promise();
-        Map<TopicPartition, OffsetSpec> topicPartitionEndOffsets = Collections.singletonMap(topicPartition, OffsetSpec.LATEST);
-        this.listOffsets(topicPartitionEndOffsets, getEndOffsetsPromise);
-        Future<Map<TopicPartition, ListOffsetsResultInfo>> getBeginningOffsetsFuture = getBeginningOffsetsPromise.future();
-        Future<Map<TopicPartition, ListOffsetsResultInfo>> getEndOffsetsFuture = getEndOffsetsPromise.future();
-        Promise<Map<String, TopicDescription>> topicExistenceCheck = Promise.promise();
-        this.describeTopics(Collections.singletonList(topicName), topicExistenceCheck);
-        topicExistenceCheck.future().onComplete(t -> {
+
+        CompletionStage<Map<String, TopicDescription>> topicExistenceCheckPromise = this.describeTopics(List.of(topicName));
+        topicExistenceCheckPromise.whenComplete((topicDescriptions, t) -> {
             Throwable e = null;
-            if (t.cause() != null && t.cause().getCause() instanceof UnknownTopicOrPartitionException) {
-                e = t.cause();
-            } else if (t.result().get(topicName).getPartitions().size() <= partitionId) {
+            if (t != null && t.getCause() instanceof UnknownTopicOrPartitionException) {
+                e = t;
+            } else if (topicDescriptions.get(topicName).partitions().size() <= partitionId) {
                 e = new UnknownTopicOrPartitionException("Topic '" + topicName + "' does not have partition with id " + partitionId);
             }
             if (e != null) {
                 HttpBridgeError error = new HttpBridgeError(HttpResponseStatus.NOT_FOUND.code(), e.getMessage());
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
                         BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-                return;
             } else {
-                CompositeFuture.join(getBeginningOffsetsFuture, getEndOffsetsFuture).onComplete(done -> {
-                    if (done.succeeded() && getBeginningOffsetsFuture.result() != null && getEndOffsetsFuture.result() != null) {
-                        JsonObject root = new JsonObject();
-                        ListOffsetsResultInfo beginningOffset = getBeginningOffsetsFuture.result().get(topicPartition);
-                        if (beginningOffset != null) {
-                            root.put("beginning_offset", beginningOffset.getOffset());
-                        }
-                        ListOffsetsResultInfo endOffset = getEndOffsetsFuture.result().get(topicPartition);
-                        if (endOffset != null) {
-                            root.put("end_offset", endOffset.getOffset());
-                        }
-                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
-                    } else {
-                        HttpBridgeError error = new HttpBridgeError(
-                                HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                done.cause().getMessage()
-                        );
-                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
-                    }
-                });
+                Map<TopicPartition, OffsetSpec> topicPartitionBeginOffsets = Map.of(topicPartition, OffsetSpec.earliest());
+                CompletionStage<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> getBeginningOffsetsPromise = this.listOffsets(topicPartitionBeginOffsets);
+                Map<TopicPartition, OffsetSpec> topicPartitionEndOffsets = Map.of(topicPartition, OffsetSpec.latest());
+                CompletionStage<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> getEndOffsetsPromise = this.listOffsets(topicPartitionEndOffsets);
+
+                CompletableFuture.allOf(getBeginningOffsetsPromise.toCompletableFuture(), getEndOffsetsPromise.toCompletableFuture())
+                        .whenComplete((v, ex) -> {
+                            log.trace("Get offsets handler thread {}", Thread.currentThread());
+                            if (ex == null) {
+                                JsonObject root = new JsonObject();
+                                ListOffsetsResult.ListOffsetsResultInfo beginningOffset = getBeginningOffsetsPromise.toCompletableFuture().getNow(Map.of()).get(topicPartition);
+                                if (beginningOffset != null) {
+                                    root.put("beginning_offset", beginningOffset.offset());
+                                }
+                                ListOffsetsResult.ListOffsetsResultInfo endOffset = getEndOffsetsPromise.toCompletableFuture().getNow(Map.of()).get(topicPartition);
+                                if (endOffset != null) {
+                                    root.put("end_offset", endOffset.offset());
+                                }
+                                HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, root.toBuffer());
+                            } else {
+                                HttpBridgeError error = new HttpBridgeError(
+                                        HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                        ex.getMessage()
+                                );
+                                HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                        BridgeContentType.KAFKA_JSON, error.toJson().toBuffer());
+                            }
+                        });
             }
         });
     }
 
     private static JsonObject createPartitionMetadata(TopicPartitionInfo partitionInfo) {
-        int leaderId = partitionInfo.getLeader().getId();
+        int leaderId = partitionInfo.leader().id();
         JsonObject root = new JsonObject();
-        root.put("partition", partitionInfo.getPartition());
+        root.put("partition", partitionInfo.partition());
         root.put("leader", leaderId);
         JsonArray replicasArray = new JsonArray();
-        Set<Integer> insyncSet = new HashSet<Integer>();
-        partitionInfo.getIsr().forEach(node -> {
-            insyncSet.add(node.getId());
-        });
-        partitionInfo.getReplicas().forEach(node -> {
+        Set<Integer> insyncSet = new HashSet<>();
+        partitionInfo.isr().forEach(node -> insyncSet.add(node.id()));
+        partitionInfo.replicas().forEach(node -> {
             JsonObject replica = new JsonObject();
-            replica.put("broker", node.getId());
-            replica.put("leader", leaderId == node.getId());
-            replica.put("in_sync", insyncSet.contains(node.getId()));
+            replica.put("broker", node.id());
+            replica.put("leader", leaderId == node.id());
+            replica.put("in_sync", insyncSet.contains(node.id()));
             replicasArray.add(replica);
         });
         root.put("replicas", replicasArray);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -183,7 +183,7 @@ public class HttpBridge extends AbstractVerticle {
 
                 log.info("Starting HTTP-Kafka bridge verticle...");
                 this.httpBridgeContext = new HttpBridgeContext<>();
-                AdminClientEndpoint adminClientEndpoint = new HttpAdminClientEndpoint(this.vertx, this.bridgeConfig, this.httpBridgeContext);
+                AdminClientEndpoint adminClientEndpoint = new HttpAdminClientEndpoint(this.bridgeConfig, this.httpBridgeContext);
                 this.httpBridgeContext.setAdminClientEndpoint(adminClientEndpoint);
                 adminClientEndpoint.open();
                 this.bindHttpServer(startPromise);

--- a/src/main/java/io/strimzi/kafka/bridge/http/model/HttpBridgeResult.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/model/HttpBridgeResult.java
@@ -8,7 +8,7 @@ package io.strimzi.kafka.bridge.http.model;
 /**
  * This class represents a result of an HTTP bridging operation
  *
- * @param <T> the class bringing the actual result as {@link HttpBridgeError} or {@link io.vertx.kafka.client.producer.RecordMetadata}
+ * @param <T> the class bringing the actual result as {@link HttpBridgeError} or {@link org.apache.kafka.clients.producer.RecordMetadata}
  */
 public class HttpBridgeResult<T> {
 


### PR DESCRIPTION
This PR is about replacing the usage of the Vert.x Kafka client on the admin endpoint with the native Java Kafka client (provided by Apache Kafka upstream project).

It provides the following things:

* using CompletableFuture(s) based pattern to run consumer requests asynchronously (as today it's done by Vert.x)
* removing the Vert.x instance from the admin side
* replacing Vert.x Kafka related classes, i.e. TopicPartition, TopicPartitionInfo, TopicDescription and more with the corresponding native ones from the Java Kafka client

With this last PR, the `vertx-kafka-client` dependency is not needed anymore in the bridge but I had to keep it but moving to `test` scope because the Vert.x Kafka client is still used in the tests (which should be re-written from scratch, but it's a different bigger work to do not in this PR).

Anyway, there are still some Vert.x structures in place like the ones handling JSON, Buffer(s) and Handler(s).