### PR TITLE
Replaced Vert.x JSON handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,18 @@
 		<test-container.version>0.102.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
+		<gson.version>2.9.1</gson.version>
 		<!-- property to skip surefire tests during failsafe execution -->
 		<!--suppress UnresolvedMavenProperty -->
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>${gson.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-core</artifactId>
@@ -173,6 +179,11 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-common</artifactId>
+			<version>${netty.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-buffer</artifactId>
 			<version>${netty.version}</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,18 +119,12 @@
 		<test-container.version>0.102.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
-		<gson.version>2.9.1</gson.version>
 		<!-- property to skip surefire tests during failsafe execution -->
 		<!--suppress UnresolvedMavenProperty -->
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>${gson.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-core</artifactId>

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -5,7 +5,6 @@
 
 package io.strimzi.kafka.bridge.http;
 
-import com.google.gson.JsonSyntaxException;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.ConsumerInstanceId;
@@ -17,6 +16,7 @@ import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.converter.MessageConverter;
 import io.strimzi.kafka.bridge.http.converter.HttpBinaryMessageConverter;
 import io.strimzi.kafka.bridge.http.converter.HttpJsonMessageConverter;
+import io.strimzi.kafka.bridge.http.converter.JsonDecodeException;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
 import io.strimzi.kafka.bridge.tracing.SpanHandle;
 import io.strimzi.kafka.bridge.tracing.TracingHandle;
@@ -277,7 +277,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
                             this.format == EmbeddedFormat.BINARY ? BridgeContentType.KAFKA_JSON_BINARY : BridgeContentType.KAFKA_JSON_JSON,
                             buffer);
                 }
-            } catch (DecodeException | JsonSyntaxException e) {
+            } catch (JsonDecodeException e) {
                 log.error("Error decoding records as JSON", e);
                 responseStatus = HttpResponseStatus.NOT_ACCEPTABLE;
                 HttpBridgeError error = new HttpBridgeError(

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -5,6 +5,7 @@
 
 package io.strimzi.kafka.bridge.http;
 
+import com.google.gson.JsonSyntaxException;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.ConsumerInstanceId;
@@ -276,7 +277,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
                             this.format == EmbeddedFormat.BINARY ? BridgeContentType.KAFKA_JSON_BINARY : BridgeContentType.KAFKA_JSON_JSON,
                             buffer);
                 }
-            } catch (DecodeException e) {
+            } catch (DecodeException | JsonSyntaxException e) {
                 log.error("Error decoding records as JSON", e);
                 responseStatus = HttpResponseStatus.NOT_ACCEPTABLE;
                 HttpBridgeError error = new HttpBridgeError(

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -28,7 +28,6 @@ import io.strimzi.kafka.bridge.tracing.TracingHandle;
 import io.strimzi.kafka.bridge.tracing.TracingUtil;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.DecodeException;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -526,7 +525,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
                 bodyAsJson = JsonUtils.bufferToJson(routingContext.body().buffer());
             }
             log.debug("[{}] Request: body = {}", routingContext.get("request-id"), bodyAsJson);
-        } catch (DecodeException ex) {
+        } catch (JsonDecodeException ex) {
             HttpBridgeError error = handleError(ex);
             HttpUtils.sendResponse(routingContext, error.getCode(),
                     BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
@@ -673,7 +672,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends SinkBridgeEndpoint<K, V> {
         if (ex instanceof IllegalStateException && ex.getMessage() != null &&
             ex.getMessage().contains("No current assignment for partition")) {
             code = HttpResponseStatus.NOT_FOUND.code();
-        } else if (ex instanceof DecodeException) {
+        } else if (ex instanceof JsonDecodeException) {
             code = HttpResponseStatus.UNPROCESSABLE_ENTITY.code();
         }
         return new HttpBridgeError(code, ex.getMessage());

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
@@ -6,8 +6,8 @@
 package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.strimzi.kafka.bridge.http.converter.JsonUtils;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +31,7 @@ public class HttpUtils {
         if (!routingContext.response().closed() && !routingContext.response().ended()) {
             routingContext.response().setStatusCode(statusCode);
             if (body != null) {
-                log.debug("[{}] Response: body = {}", routingContext.get("request-id"), Json.decodeValue(body));
+                log.debug("[{}] Response: body = {}", routingContext.get("request-id"), JsonUtils.bufferToJson(body));
                 routingContext.response().putHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
                 routingContext.response().putHeader(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(body.length()));
                 routingContext.response().write(body);

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.strimzi.kafka.bridge.converter.MessageConverter;
 import io.vertx.core.buffer.Buffer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -123,6 +124,8 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
         return Buffer.buffer(GSON.toJson(jsonArray).getBytes(StandardCharsets.UTF_8));
     }
 
+    // suppressing this warning, because for the JSON serialization null is needed here
+    @SuppressFBWarnings("PZLA_PREFER_ZERO_LENGTH_ARRAYS")
     private byte[] jsonToBytes(JsonElement json) {
         if (json.isJsonNull())
             return null;

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonDecodeException.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonDecodeException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.http.converter;
+
+/**
+ * Represents and exception during JSON decoding operations
+ */
+public class JsonDecodeException extends RuntimeException {
+
+    /**
+     * Default constrctor
+     */
+    public JsonDecodeException() {
+    }
+
+    /**
+     * Constructor
+     *
+     * @param message Exception message
+     */
+    public JsonDecodeException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param message Exception message
+     * @param cause Inner cause of the exception
+     */
+    public JsonDecodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonEncodeException.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonEncodeException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.http.converter;
+
+/**
+ * Represents and exception during JSON encoding operations
+ */
+public class JsonEncodeException extends RuntimeException {
+
+    /**
+     * Default constrctor
+     */
+    public JsonEncodeException() {
+    }
+
+    /**
+     * Constructor
+     *
+     * @param message Exception message
+     */
+    public JsonEncodeException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param message Exception message
+     * @param cause Inner cause of the exception
+     */
+    public JsonEncodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
@@ -21,7 +21,7 @@ public class JsonUtils {
     /**
      * ObjectMapper instance used for JSON encoding/decoding
      */
-    public static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Get the JSON representation of the provided buffer content

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
@@ -110,7 +110,7 @@ public class JsonUtils {
      * @param field name of the field representing the child node
      * @return int value of the child node or null if it doesn't exist
      */
-    public static int getInt(JsonNode json, String field) {
+    public static Integer getInt(JsonNode json, String field) {
         return json.path(field).isMissingNode() ? null : json.get(field).asInt();
     }
 
@@ -122,7 +122,7 @@ public class JsonUtils {
      * @param field name of the field representing the child node
      * @return long value of the child node or null if it doesn't exist
      */
-    public static long getLong(JsonNode json, String field) {
+    public static Long getLong(JsonNode json, String field) {
         return json.path(field).isMissingNode() ? null : json.get(field).asLong();
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.http.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.buffer.Buffer;
+
+import java.io.IOException;
+
+/**
+ * Provides some utility methods for JSON encoding/decoding
+ */
+public class JsonUtils {
+
+    /**
+     * ObjectMapper instance used for JSON encoding/decoding
+     */
+    public static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Get the JSON representation of the provided buffer content
+     *
+     * @param buffer buffer containing JSON data
+     * @return JSON representation of the buffer data
+     */
+    public static JsonNode bufferToJson(Buffer buffer) {
+        try {
+            return MAPPER.readTree(buffer.getByteBuf().array());
+        } catch (IOException e) {
+            throw new JsonDecodeException("Failed to decode:" + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Get the bytes representation within a buffer of the provided JSON
+     *
+     * @param json JSON representation
+     * @return bytes buffer representing the JSON data
+     */
+    public static Buffer jsonToBuffer(JsonNode json) {
+        try {
+            return Buffer.buffer(MAPPER.writeValueAsBytes(json));
+        } catch (Exception e) {
+            throw new JsonEncodeException("Failed to encode as JSON: " + e.getMessage());
+        }
+    }
+
+    /**
+     * @return an empty JSON array node to be filled with elements
+     */
+    public static ArrayNode createArrayNode() {
+        return MAPPER.createArrayNode();
+    }
+
+    /**
+     * @return an empty JSON Object node to be filled with data
+     */
+    public static ObjectNode createObjectNode() {
+        return MAPPER.createObjectNode();
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * Provides some utility methods for JSON encoding/decoding
@@ -63,5 +64,65 @@ public class JsonUtils {
      */
     public static ObjectNode createObjectNode() {
         return MAPPER.createObjectNode();
+    }
+
+    /**
+     * Create an array node filled with the items in the provided collection
+     *
+     * @param collection collection used to initialize the array node
+     * @return a JSON array node already filled with the provided collection items
+     * @param <T> the type of the collection items
+     */
+    public static <T> ArrayNode createArrayNode(Collection<T> collection) {
+        return MAPPER.valueToTree(collection);
+    }
+
+    /**
+     * Return the String value for the child node of the provided JSON node
+     * or null if it doesn't exist
+     *
+     * @param json JSON node on which accessing the child node
+     * @param field name of the field representing the child node
+     * @return String value of the child node or null if it doesn't exist
+     */
+    public static String getString(JsonNode json, String field) {
+        return json.path(field).isMissingNode() ? null : json.get(field).asText();
+    }
+
+    /**
+     * Return the String value for the child node of the provided JSON node
+     * or the provided default value if it doesn't exist
+     *
+     * @param json JSON node on which accessing the child node
+     * @param field name of the field representing the child node
+     * @param def default value to return if the child node doesn't exist
+     * @return String value of the child node or the default value if it doesn't exist
+     */
+    public static String getString(JsonNode json, String field, String def) {
+        return json.path(field).isMissingNode() ? def : json.get(field).asText();
+    }
+
+    /**
+     * Return the Integer value for the child node of the provided JSON node
+     * or null if it doesn't exist
+     *
+     * @param json JSON node on which accessing the child node
+     * @param field name of the field representing the child node
+     * @return int value of the child node or null if it doesn't exist
+     */
+    public static int getInt(JsonNode json, String field) {
+        return json.path(field).isMissingNode() ? null : json.get(field).asInt();
+    }
+
+    /**
+     * Return the Long value for the child node of the provided JSON node
+     * or null if it doesn't exist
+     *
+     * @param json JSON node on which accessing the child node
+     * @param field name of the field representing the child node
+     * @return long value of the child node or null if it doesn't exist
+     */
+    public static long getLong(JsonNode json, String field) {
+        return json.path(field).isMissingNode() ? null : json.get(field).asLong();
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/model/HttpBridgeError.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/model/HttpBridgeError.java
@@ -5,6 +5,8 @@
 
 package io.strimzi.kafka.bridge.http.model;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.strimzi.kafka.bridge.http.converter.JsonUtils;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -43,8 +45,8 @@ public class HttpBridgeError {
     /**
      * @return a JSON representation of the error with code and message
      */
-    public JsonObject toJson() {
-        JsonObject json = new JsonObject();
+    public ObjectNode toJson() {
+        ObjectNode json = JsonUtils.createObjectNode();
         json.put("error_code", this.code);
         json.put("message", this.message);
         return json;

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -1475,7 +1475,7 @@ public class ConsumerIT extends HttpBridgeITAbstract {
                         HttpBridgeError error = HttpBridgeError.fromJson(response.body());
                         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_ACCEPTABLE.code()));
                         assertThat(error.getCode(), is(HttpResponseStatus.NOT_ACCEPTABLE.code()));
-                        assertThat(error.getMessage().startsWith("Failed to decode"), is(true));
+                        assertThat(error.getMessage().contains("malformed JSON"), is(true));
                     });
                     consume.complete(true);
                 });

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -1475,7 +1475,7 @@ public class ConsumerIT extends HttpBridgeITAbstract {
                         HttpBridgeError error = HttpBridgeError.fromJson(response.body());
                         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_ACCEPTABLE.code()));
                         assertThat(error.getCode(), is(HttpResponseStatus.NOT_ACCEPTABLE.code()));
-                        assertThat(error.getMessage().contains("malformed JSON"), is(true));
+                        assertThat(error.getMessage().startsWith("Failed to decode"), is(true));
                     });
                     consume.complete(true);
                 });

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -10,7 +10,6 @@ import io.strimzi.kafka.bridge.clients.Consumer;
 import io.strimzi.kafka.bridge.config.KafkaProducerConfig;
 import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
-import io.strimzi.kafka.bridge.utils.KafkaJsonDeserializer;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
@@ -74,7 +73,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new KafkaJsonDeserializer<>(String.class));
+                new StringDeserializer(), new StringDeserializer());
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(value));
@@ -124,7 +123,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new KafkaJsonDeserializer<>(String.class));
+                new StringDeserializer(), new StringDeserializer());
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(value));
@@ -174,7 +173,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new KafkaJsonDeserializer<>(String.class), new KafkaJsonDeserializer<>(String.class));
+                new StringDeserializer(), new StringDeserializer());
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(value));
@@ -281,7 +280,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-            new KafkaJsonDeserializer<>(String.class), new KafkaJsonDeserializer<>(String.class));
+                new StringDeserializer(), new StringDeserializer());
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(value));
@@ -411,7 +410,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new KafkaJsonDeserializer<String>(String.class));
+                new StringDeserializer(), new StringDeserializer());
         this.count = 0;
         consumer.handler(record -> {
             context.verify(() -> {
@@ -488,7 +487,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new KafkaJsonDeserializer<>(String.class), new KafkaJsonDeserializer<>(String.class));
+                new StringDeserializer(), new StringDeserializer());
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(nullValue()));
@@ -911,7 +910,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new KafkaJsonDeserializer<String>(String.class));
+                new StringDeserializer(), new StringDeserializer());
         this.count = 0;
         consumer.handler(record -> {
             context.verify(() -> {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -10,6 +10,7 @@ import io.strimzi.kafka.bridge.clients.Consumer;
 import io.strimzi.kafka.bridge.config.KafkaProducerConfig;
 import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
+import io.strimzi.kafka.bridge.utils.KafkaJsonDeserializer;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
@@ -73,7 +74,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new StringDeserializer());
+                new StringDeserializer(), new KafkaJsonDeserializer<>(String.class));
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(value));
@@ -123,7 +124,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new StringDeserializer());
+                new StringDeserializer(), new KafkaJsonDeserializer<>(String.class));
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(value));
@@ -173,7 +174,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new StringDeserializer());
+                new KafkaJsonDeserializer<>(String.class), new KafkaJsonDeserializer<>(String.class));
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(value));
@@ -280,7 +281,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new StringDeserializer());
+            new KafkaJsonDeserializer<>(String.class), new KafkaJsonDeserializer<>(String.class));
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(value));
@@ -410,7 +411,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new StringDeserializer());
+                new StringDeserializer(), new KafkaJsonDeserializer<>(String.class));
         this.count = 0;
         consumer.handler(record -> {
             context.verify(() -> {
@@ -487,7 +488,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new StringDeserializer());
+                new KafkaJsonDeserializer<>(String.class), new KafkaJsonDeserializer<>(String.class));
         consumer.handler(record -> {
             context.verify(() -> {
                 assertThat(record.value(), is(nullValue()));
@@ -910,7 +911,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
 
         KafkaConsumer<String, String> consumer = KafkaConsumer.create(vertx, consumerProperties,
-                new StringDeserializer(), new StringDeserializer());
+                new StringDeserializer(), new KafkaJsonDeserializer<>(String.class));
         this.count = 0;
         consumer.handler(record -> {
             context.verify(() -> {


### PR DESCRIPTION
This PR is about replacing the JSON handling happening inside the bridge with Vert.x classes by using GSON library instead.
It doesn't remove the usage of the Vert.x `Buffer` class which is still in place. That removal will happen in a different PR.

The PR fixes #410 as well. It is able to handle simple strings (in key or value) as pure strings and not JSON strings but at same time it is able to handle JSON object used as key or value in the messages.
This different strings handling is also the reason why some fixes in the tests, where the simple strings are not JSON strings anymore.
