### PR TITLE
Removed usage of Vert.x Buffer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,11 +176,6 @@
 			<version>${netty.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-buffer</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminClientEndpoint.java
@@ -101,14 +101,14 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                     if (ex == null) {
                         ArrayNode root = JsonUtils.createArrayNode();
                         topics.forEach(topic -> root.add(topic));
-                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                     } else {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     }
                 });
     }
@@ -161,21 +161,21 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                             });
                         }
                         root.put("partitions", partitionsArray);
-                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                     } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.NOT_FOUND.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     } else {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     }
                 });
     }
@@ -196,21 +196,21 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                         if (description != null) {
                             description.partitions().forEach(partitionInfo -> root.add(createPartitionMetadata(partitionInfo)));
                         }
-                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                     } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.NOT_FOUND.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     } else {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     }
                 });
     }
@@ -230,7 +230,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                     HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
                     "Specified partition is not a valid number");
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             return;
         }
         this.describeTopics(List.of(topicName))
@@ -240,14 +240,14 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                         TopicDescription description = topicDescriptions.get(topicName);
                         if (description != null && partitionId < description.partitions().size()) {
                             JsonNode root = createPartitionMetadata(description.partitions().get(partitionId));
-                            HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                            HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                         } else {
                             HttpBridgeError error = new HttpBridgeError(
                                     HttpResponseStatus.NOT_FOUND.code(),
                                     "Specified partition does not exist."
                             );
                             HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                         }
                     } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
                         HttpBridgeError error = new HttpBridgeError(
@@ -255,14 +255,14 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     } else {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     }
                 });
     }
@@ -282,7 +282,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                     HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
                     "Specified partition is not a valid number");
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             return;
         }
         TopicPartition topicPartition = new TopicPartition(topicName, partitionId);
@@ -298,7 +298,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
             if (e != null) {
                 HttpBridgeError error = new HttpBridgeError(HttpResponseStatus.NOT_FOUND.code(), e.getMessage());
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                        BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                        BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             } else {
                 Map<TopicPartition, OffsetSpec> topicPartitionBeginOffsets = Map.of(topicPartition, OffsetSpec.earliest());
                 CompletionStage<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> getBeginningOffsetsPromise = this.listOffsets(topicPartitionBeginOffsets);
@@ -318,14 +318,14 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                                 if (endOffset != null) {
                                     root.put("end_offset", endOffset.offset());
                                 }
-                                HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                                HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                             } else {
                                 HttpBridgeError error = new HttpBridgeError(
                                         HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                         ex.getMessage()
                                 );
                                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                        BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                        BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                             }
                         });
             }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -281,14 +281,14 @@ public class HttpBridge extends AbstractVerticle {
                     "Consumer is disabled in config. To enable consumer update http.consumer.enabled to true"
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.SERVICE_UNAVAILABLE.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             return;
         }
 
         this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.CREATE_CONSUMER);
 
         // check for an empty body
-        JsonNode body = !routingContext.body().isEmpty() ? JsonUtils.bufferToJson(routingContext.body().buffer()) : JsonUtils.createObjectNode();
+        JsonNode body = !routingContext.body().isEmpty() ? JsonUtils.bytesToJson(routingContext.body().buffer().getBytes()) : JsonUtils.createObjectNode();
         SinkBridgeEndpoint<byte[], byte[]> sink = null;
 
         try {
@@ -321,7 +321,7 @@ public class HttpBridge extends AbstractVerticle {
                 ex.getMessage()
             );
             HttpUtils.sendResponse(routingContext, error.getCode(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -344,7 +344,7 @@ public class HttpBridge extends AbstractVerticle {
                     "The specified consumer instance was not found."
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -439,7 +439,7 @@ public class HttpBridge extends AbstractVerticle {
                     "The specified consumer instance was not found."
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -455,7 +455,7 @@ public class HttpBridge extends AbstractVerticle {
                     "Producer is disabled in config. To enable producer update http.producer.enabled to true"
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.SERVICE_UNAVAILABLE.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             return;
         }
         HttpServerRequest httpServerRequest = routingContext.request();
@@ -486,7 +486,7 @@ public class HttpBridge extends AbstractVerticle {
                     ex.getMessage()
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -500,7 +500,7 @@ public class HttpBridge extends AbstractVerticle {
                     "The AdminClient was not found."
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -530,9 +530,9 @@ public class HttpBridge extends AbstractVerticle {
                     if (xForwardedPath != null) {
                         path = xForwardedPath;
                     }
-                    ObjectNode json = (ObjectNode) JsonUtils.bufferToJson(readFile.result());
+                    ObjectNode json = (ObjectNode) JsonUtils.bytesToJson(readFile.result().getBytes());
                     json.put("basePath", path);
-                    HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, JsonUtils.jsonToBuffer(json));
+                    HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, JsonUtils.jsonToBytes(json));
                 }
             } else {
                 log.error("Failed to read OpenAPI JSON file", readFile.cause());
@@ -540,7 +540,7 @@ public class HttpBridge extends AbstractVerticle {
                     HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                     readFile.cause().getMessage());
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        BridgeContentType.JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                        BridgeContentType.JSON, JsonUtils.jsonToBytes(error.toJson()));
             }
         });
     }
@@ -551,7 +551,7 @@ public class HttpBridge extends AbstractVerticle {
         ObjectNode versionJson = JsonUtils.createObjectNode();
         versionJson.put("bridge_version", version == null ? "null" : version);
         HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(),
-                BridgeContentType.JSON, JsonUtils.jsonToBuffer(versionJson));
+                BridgeContentType.JSON, JsonUtils.jsonToBytes(versionJson));
     }
 
     @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
@@ -595,7 +595,7 @@ public class HttpBridge extends AbstractVerticle {
 
         HttpBridgeError error = new HttpBridgeError(routingContext.statusCode(), message);
         HttpUtils.sendResponse(routingContext, routingContext.statusCode(),
-                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
 
         log.error("[{}] Response: statusCode = {}, message = {} ", 
             requestId,

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
@@ -27,14 +27,14 @@ public class HttpUtils {
      * @param contentType the content-type to set in the HTTP response
      * @param body the body to set in the HTTP response
      */
-    public static void sendResponse(RoutingContext routingContext, int statusCode, String contentType, Buffer body) {
+    public static void sendResponse(RoutingContext routingContext, int statusCode, String contentType, byte[] body) {
         if (!routingContext.response().closed() && !routingContext.response().ended()) {
             routingContext.response().setStatusCode(statusCode);
             if (body != null) {
-                log.debug("[{}] Response: body = {}", routingContext.get("request-id"), JsonUtils.bufferToJson(body));
+                log.debug("[{}] Response: body = {}", routingContext.get("request-id"), JsonUtils.bytesToJson(body));
                 routingContext.response().putHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
-                routingContext.response().putHeader(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(body.length()));
-                routingContext.response().write(body);
+                routingContext.response().putHeader(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(body.length));
+                routingContext.response().write(Buffer.buffer(body));
             }
             routingContext.response().end();
         } else if (routingContext.response().ended()) {

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -25,28 +24,28 @@ public class JsonUtils {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
-     * Get the JSON representation of the provided buffer content
+     * Get the JSON representation of the provided bytes array
      *
-     * @param buffer buffer containing JSON data
-     * @return JSON representation of the buffer data
+     * @param bytes bytes array containing JSON data
+     * @return JSON representation of the bytes array
      */
-    public static JsonNode bufferToJson(Buffer buffer) {
+    public static JsonNode bytesToJson(byte[] bytes) {
         try {
-            return MAPPER.readTree(buffer.getByteBuf().array());
+            return MAPPER.readTree(bytes);
         } catch (IOException e) {
             throw new JsonDecodeException("Failed to decode:" + e.getMessage(), e);
         }
     }
 
     /**
-     * Get the bytes representation within a buffer of the provided JSON
+     * Get the bytes representation of the provided JSON
      *
      * @param json JSON representation
-     * @return bytes buffer representing the JSON data
+     * @return bytes representing the JSON data
      */
-    public static Buffer jsonToBuffer(JsonNode json) {
+    public static byte[] jsonToBytes(JsonNode json) {
         try {
-            return Buffer.buffer(MAPPER.writeValueAsBytes(json));
+            return MAPPER.writeValueAsBytes(json);
         } catch (Exception e) {
             throw new JsonEncodeException("Failed to encode as JSON: " + e.getMessage());
         }


### PR DESCRIPTION
This PR removes the usage of the Vert.x `Buffer` class, just moving bytes around.
It's still used: 

1. when writing on the HTTP routing context response
2. in the tests.

The above will be fixed in future PRs when we are not going to use the Vert.x HTTP server features anymore and rewriting tests without Vert.x
