### PR TITLE
Replaced Vert.x Config component with plain Java config retriever

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,6 @@
 		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
-			<artifactId>vertx-config</artifactId>
-			<version>${vertx.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.vertx</groupId>
 			<artifactId>vertx-micrometer-metrics</artifactId>
 			<version>${vertx.version}</version>
 		</dependency>

--- a/src/main/java/io/strimzi/kafka/bridge/config/ConfigRetriever.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/ConfigRetriever.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge.config;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+/**
+ * Retrieve the bridge configuration from properties file and environment variables
+ */
+public class ConfigRetriever {
+
+    /**
+     * Retrieve the bridge configuration from the properties file provided as parameter
+     * and adding environment variables
+     * If a parameter is defined in both properties file and environment variables, the latter wins
+     *
+     * @param path path to the properties file
+     * @return configuration as key-value pairs
+     * @throws IOException when not possible to get the properties file
+     */
+    public static Map<String, Object> getConfig(String path) throws IOException {
+        Map<String, Object> configuration;
+        try (InputStream is = new FileInputStream(path)) {
+            Properties props = new Properties();
+            props.load(is);
+            configuration =
+                    props.entrySet().stream().collect(
+                            Collectors.toMap(
+                                    e -> String.valueOf(e.getKey()),
+                                    e -> String.valueOf(e.getValue()),
+                                    (prev, next) -> next, HashMap::new
+                            ));
+        }
+        configuration.putAll(System.getenv());
+        return configuration;
+    }
+}

--- a/src/main/java/io/strimzi/kafka/bridge/config/ConfigRetriever.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/ConfigRetriever.java
@@ -6,6 +6,7 @@
 package io.strimzi.kafka.bridge.config;
 
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -28,6 +29,20 @@ public class ConfigRetriever {
      * @throws IOException when not possible to get the properties file
      */
     public static Map<String, Object> getConfig(String path) throws IOException {
+        return getConfig(path, System.getenv());
+    }
+
+    /**
+     * Retrieve the bridge configuration from the properties file provided as parameter
+     * and adding the additional configuration parameter provided as well
+     * If a parameter is defined in both properties file and additional configuration, the latter wins
+     *
+     * @param path path to the properties file
+     * @param additionalConfig additional configuration to add
+     * @return configuration as key-value pairs
+     * @throws IOException when not possible to get the properties file
+     */
+    public static Map<String, Object> getConfig(String path, Map<String, String> additionalConfig) throws IOException {
         Map<String, Object> configuration;
         try (InputStream is = new FileInputStream(path)) {
             Properties props = new Properties();
@@ -40,7 +55,7 @@ public class ConfigRetriever {
                                     (prev, next) -> next, HashMap::new
                             ));
         }
-        configuration.putAll(System.getenv());
+        configuration.putAll(additionalConfig);
         return configuration;
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/config/ConfigRetriever.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/ConfigRetriever.java
@@ -6,7 +6,6 @@
 package io.strimzi.kafka.bridge.config;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;

--- a/src/test/java/io/strimzi/kafka/bridge/ConfigRetrieverTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/ConfigRetrieverTest.java
@@ -18,11 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.strimzi.kafka.bridge.config.BridgeConfig.BRIDGE_ID;
-import static io.strimzi.kafka.bridge.config.KafkaConfig.KAFKA_CONFIG_PREFIX;
-import static io.strimzi.kafka.bridge.config.KafkaConsumerConfig.KAFKA_CONSUMER_CONFIG_PREFIX;
-import static io.strimzi.kafka.bridge.config.KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX;
-import static io.strimzi.kafka.bridge.http.HttpConfig.HTTP_HOST;
-import static io.strimzi.kafka.bridge.http.HttpConfig.HTTP_PORT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -37,27 +32,23 @@ public class ConfigRetrieverTest {
         String path = getClass().getClassLoader().getResource("application.properties").getPath();
         Map<String, Object> config = ConfigRetriever.getConfig(path);
         BridgeConfig bridgeConfig = BridgeConfig.fromMap(config);
-        assertThat(bridgeConfig.getBridgeID(), is(config.get(BRIDGE_ID)));
+
+        assertThat(bridgeConfig.getBridgeID(), is("my-bridge"));
 
         assertThat(bridgeConfig.getKafkaConfig().getConfig().size(), is(1));
-        assertThat(bridgeConfig.getKafkaConfig().getConfig().get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
-                is(config.get(KAFKA_CONFIG_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG)));
+        assertThat(bridgeConfig.getKafkaConfig().getConfig().get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG), is("localhost:9092"));
 
         assertThat(bridgeConfig.getKafkaConfig().getAdminConfig().getConfig().size(), is(0));
-        assertThat(bridgeConfig.getKafkaConfig().getConfig().get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
-                is(config.get(KAFKA_CONFIG_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG)));
 
         assertThat(bridgeConfig.getKafkaConfig().getProducerConfig().getConfig().size(), is(1));
-        assertThat(bridgeConfig.getKafkaConfig().getProducerConfig().getConfig().get(ProducerConfig.ACKS_CONFIG),
-                is(config.get(KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.ACKS_CONFIG)));
+        assertThat(bridgeConfig.getKafkaConfig().getProducerConfig().getConfig().get(ProducerConfig.ACKS_CONFIG), is("1"));
 
         assertThat(bridgeConfig.getKafkaConfig().getConsumerConfig().getConfig().size(), is(1));
-        assertThat(bridgeConfig.getKafkaConfig().getConsumerConfig().getConfig().get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG),
-                is(config.get(KAFKA_CONSUMER_CONFIG_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)));
+        assertThat(bridgeConfig.getKafkaConfig().getConsumerConfig().getConfig().get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), is("earliest"));
 
         assertThat(bridgeConfig.getHttpConfig().getConfig().size(), is(2));
-        assertThat(bridgeConfig.getHttpConfig().getConfig().get(HTTP_HOST), is(config.get(HTTP_HOST)));
-        assertThat(bridgeConfig.getHttpConfig().getConfig().get(HTTP_PORT), is(config.get(HTTP_PORT)));
+        assertThat(bridgeConfig.getHttpConfig().getHost(), is("0.0.0.0"));
+        assertThat(bridgeConfig.getHttpConfig().getPort(), is(8080));
     }
 
     @Test

--- a/src/test/java/io/strimzi/kafka/bridge/ConfigRetrieverTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/ConfigRetrieverTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+
+package io.strimzi.kafka.bridge;
+
+import io.strimzi.kafka.bridge.config.BridgeConfig;
+import io.strimzi.kafka.bridge.config.ConfigRetriever;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.strimzi.kafka.bridge.config.BridgeConfig.BRIDGE_ID;
+import static io.strimzi.kafka.bridge.config.KafkaConfig.KAFKA_CONFIG_PREFIX;
+import static io.strimzi.kafka.bridge.config.KafkaConsumerConfig.KAFKA_CONSUMER_CONFIG_PREFIX;
+import static io.strimzi.kafka.bridge.config.KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX;
+import static io.strimzi.kafka.bridge.http.HttpConfig.HTTP_HOST;
+import static io.strimzi.kafka.bridge.http.HttpConfig.HTTP_PORT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for the ConfigRetriever class
+ */
+public class ConfigRetrieverTest {
+
+    @Test
+    public void testApplicationPropertiesFile() throws IOException {
+        String path = getClass().getClassLoader().getResource("application.properties").getPath();
+        Map<String, Object> config = ConfigRetriever.getConfig(path);
+        BridgeConfig bridgeConfig = BridgeConfig.fromMap(config);
+        assertThat(bridgeConfig.getBridgeID(), is(config.get(BRIDGE_ID)));
+
+        assertThat(bridgeConfig.getKafkaConfig().getConfig().size(), is(1));
+        assertThat(bridgeConfig.getKafkaConfig().getConfig().get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
+                is(config.get(KAFKA_CONFIG_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG)));
+
+        assertThat(bridgeConfig.getKafkaConfig().getAdminConfig().getConfig().size(), is(0));
+        assertThat(bridgeConfig.getKafkaConfig().getConfig().get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG),
+                is(config.get(KAFKA_CONFIG_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG)));
+
+        assertThat(bridgeConfig.getKafkaConfig().getProducerConfig().getConfig().size(), is(1));
+        assertThat(bridgeConfig.getKafkaConfig().getProducerConfig().getConfig().get(ProducerConfig.ACKS_CONFIG),
+                is(config.get(KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.ACKS_CONFIG)));
+
+        assertThat(bridgeConfig.getKafkaConfig().getConsumerConfig().getConfig().size(), is(1));
+        assertThat(bridgeConfig.getKafkaConfig().getConsumerConfig().getConfig().get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG),
+                is(config.get(KAFKA_CONSUMER_CONFIG_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)));
+
+        assertThat(bridgeConfig.getHttpConfig().getConfig().size(), is(2));
+        assertThat(bridgeConfig.getHttpConfig().getConfig().get(HTTP_HOST), is(config.get(HTTP_HOST)));
+        assertThat(bridgeConfig.getHttpConfig().getConfig().get(HTTP_PORT), is(config.get(HTTP_PORT)));
+    }
+
+    @Test
+    public void testEnvVarOverride() throws IOException {
+        // "simulating" an addition to the current environment variables
+        Map<String, String> env = new HashMap<>();
+        env.putAll(System.getenv());
+        env.put(BRIDGE_ID, "different-bridge-id");
+
+        String path = getClass().getClassLoader().getResource("application.properties").getPath();
+        Map<String, Object> config = ConfigRetriever.getConfig(path, env);
+        BridgeConfig bridgeConfig = BridgeConfig.fromMap(config);
+
+        assertThat(bridgeConfig.getBridgeID(), is(env.get(BRIDGE_ID)));
+    }
+
+    @Test
+    public void testNoApplicationPropertiesFile() throws IOException {
+        assertThrows(FileNotFoundException.class, () -> ConfigRetriever.getConfig("no-existing.properties"));
+    }
+
+    @Test
+    public void testWrongApplicationPropertiesFile() throws IOException {
+        String path = getClass().getClassLoader().getResource("wrong.properties").getPath();
+        Map<String, Object> config = ConfigRetriever.getConfig(path);
+        BridgeConfig bridgeConfig = BridgeConfig.fromMap(config);
+
+        assertThat(bridgeConfig.getConfig().size(), is(0));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,15 @@
+#Bridge related settings
+bridge.id=my-bridge
+
+#Apache Kafka common
+kafka.bootstrap.servers=localhost:9092
+
+#Apache Kafka producer
+kafka.producer.acks=1
+
+#Apache Kafka consumer
+kafka.consumer.auto.offset.reset=earliest
+
+#HTTP related settings
+http.host=0.0.0.0
+http.port=8080

--- a/src/test/resources/wrong.properties
+++ b/src/test/resources/wrong.properties
@@ -1,0 +1,1 @@
+no.meaningful.parameter=its-value


### PR DESCRIPTION
This trivial PR replaces the Vert.x Config component with a simple `ConfigRetriever` class for getting bridge configuration from both properties file and environment variables.