### PR TITLE
Updated JMeter doc for installing plugins manager

### DIFF
--- a/perftest/README.md
+++ b/perftest/README.md
@@ -1,12 +1,12 @@
 # Performance tests
 
-This folder contains a [JMeter](https://jmeter.apache.org/) JMX configuration file describing a test plan with:
+This folder contains a [JMeter](https://jmeter.apache.org/) JMX configuration file describing a test plan with the following operations:
 
 * consumers creation, topics subscription, polling for getting records in a loop, and final consumers deletion
 * producers sending records to topics in a loop
 
-The test plan is configurable changing the number of consumers/producers (JMeter threads) and the number of loop cycles for sending/receiving records.
+The test plan is configurable. You can change the number of consumers/producers (JMeter threads) and the number of loop cycles for sending/receiving records.
 
 It needs a set of plugins in order to show some graphs.
-For this reason, you need to download the JMeter Plugins Manager from [here](https://jmeter-plugins.org/get/) and put it into the `lib/ext` folder.
-When opening the JMX configuration file for the first time, JMeter will ask to install such plugins for running the test plan. 
+For this reason, you need to download the JMeter Plugins Manager from the [jmeter-plugins.org](https://jmeter-plugins.org/get/) website and put it into the `lib/ext` folder.
+When opening the JMX configuration file for the first time, JMeter will ask to install the plugins to run the test plan.

--- a/perftest/README.md
+++ b/perftest/README.md
@@ -1,8 +1,12 @@
 # Performance tests
 
-This folder contains a [JMeter](https://jmeter.apache.org/) configuration file decribing a test plan with:
+This folder contains a [JMeter](https://jmeter.apache.org/) JMX configuration file describing a test plan with:
 
 * consumers creation, topics subscription, polling for getting records in a loop, and final consumers deletion
 * producers sending records to topics in a loop
 
 The test plan is configurable changing the number of consumers/producers (JMeter threads) and the number of loop cycles for sending/receiving records.
+
+It needs a set of plugins in order to show some graphs.
+For this reason, you need to download the JMeter Plugins Manager from [here](https://jmeter-plugins.org/get/) and put it into the `lib/ext` folder.
+When opening the JMX configuration file for the first time, JMeter will ask to install such plugins for running the test plan. 

--- a/perftest/strimzi-kafka-bridge.jmx
+++ b/perftest/strimzi-kafka-bridge.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Strimzi HTTP Bridge Test Plan" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -23,6 +23,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
@@ -335,6 +336,7 @@
             </value>
           </objProp>
           <stringProp name="filename"></stringProp>
+          <boolProp name="useGroupName">true</boolProp>
         </ResultCollector>
         <hashTree/>
         <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.TransactionsPerSecondGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Transactions per Second" enabled="true">
@@ -394,6 +396,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
@@ -556,6 +559,7 @@
               </value>
             </objProp>
             <stringProp name="filename"></stringProp>
+            <boolProp name="useGroupName">true</boolProp>
           </ResultCollector>
           <hashTree/>
           <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.TransactionsPerSecondGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Transactions per Second" enabled="true">


### PR DESCRIPTION
Trivial PR to update a needed step for using JMeter configuration file if the plugins manager is not installed already.