### PR TITLE
Use JVM in `dynamic_resources.sh` for calculating memory

### DIFF
--- a/bin/docker/dynamic_resources.sh
+++ b/bin/docker/dynamic_resources.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 
+mem_file_cgroups_v1="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+mem_file_cgroups_v2="/sys/fs/cgroup/memory.max"
+
 function get_heap_size {
-  CONTAINER_MEMORY_IN_BYTES=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`
+  CONTAINER_MEMORY_IN_BYTES=""
+
+  if [ -f "$mem_file_cgroups_v1" ]; then
+    CONTAINER_MEMORY_IN_BYTES = $(cat "$mem_file_cgroups_v1")
+  else
+    CONTAINER_MEMORY_IN_BYTES = $(cat "$mem_file_cgroups_v2")
+  fi
+
    # use max of 31G memory, java performs much better with Compressed Ordinary Object Pointers
   DEFAULT_MEMORY_CEILING=$((31 * 2**30))
   if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then

--- a/bin/docker/dynamic_resources.sh
+++ b/bin/docker/dynamic_resources.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
+MYPATH="$(dirname "$0")"
+
 function get_heap_size {
   # Get the max heap used by a jvm which used all the ram available to the container
   CONTAINER_MEMORY_IN_BYTES=$(java -XshowSettings:vm -version \
     |& awk '/Max\. Heap Size \(Estimated\): [0-9KMG]+/{ print $5}' \
-    | gawk -f to_bytes.gawk)
+    | gawk -f "${MYPATH}"/to_bytes.gawk)
 
   # use max of 31G memory, java performs much better with Compressed Ordinary Object Pointers
   DEFAULT_MEMORY_CEILING=$((31 * 2**30))

--- a/bin/docker/to_bytes.gawk
+++ b/bin/docker/to_bytes.gawk
@@ -1,0 +1,11 @@
+# Use gawk because gnu awk can't extract regexp groups; gawk has `match`
+BEGIN {
+  suffixes[""]=1
+  suffixes["K"]=1024
+  suffixes["M"]=1024**2
+  suffixes["G"]=1024**3
+}
+
+match($0, /([0-9.]*)([kKmMgG]?)/, a) {
+  printf("%d", a[1] * suffixes[toupper(a[2])])
+}


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

This PR changes the approach, which was used in `dynamic_resources.sh` until now. The script now uses JVM for calculating the memory - so it also covers cgroups v2.

Fixes #731