### PR TITLE
Refactoring HTTP endpoints

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
 /**
  * Apache Kafka bridge main application class
  */
-@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class Application {
 
     private static final Logger log = LoggerFactory.getLogger(Application.class);
@@ -55,7 +54,6 @@ public class Application {
      *
      * @param args command line arguments
      */
-    @SuppressWarnings({"checkstyle:NPathComplexity"})
     public static void main(String[] args) {
         log.info("Strimzi Kafka Bridge {} is starting", Application.class.getPackage().getImplementationVersion());
         try {

--- a/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeProducer.java
@@ -5,9 +5,7 @@
 
 package io.strimzi.kafka.bridge;
 
-import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.strimzi.kafka.bridge.config.KafkaConfig;
-import io.strimzi.kafka.bridge.http.HttpBridgeEndpoint;
 import io.strimzi.kafka.bridge.tracing.TracingHandle;
 import io.strimzi.kafka.bridge.tracing.TracingUtil;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -23,57 +21,28 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Base class for source bridge endpoints
+ * Represents a Kafka bridge producer client
  */
-public abstract class SourceBridgeEndpoint<K, V> implements HttpBridgeEndpoint {
+public class KafkaBridgeProducer<K, V> {
 
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    private final Logger log = LoggerFactory.getLogger(KafkaBridgeConsumer.class);
 
-    protected String name;
-    protected final EmbeddedFormat format;
-    protected final Serializer<K> keySerializer;
-    protected final Serializer<V> valueSerializer;
-
-    protected final BridgeConfig bridgeConfig;
-
-    private Handler<HttpBridgeEndpoint> closeHandler;
-
+    private final KafkaConfig kafkaConfig;
+    private final Serializer<K> keySerializer;
+    private final Serializer<V> valueSerializer;
     private Producer<K, V> producer;
 
     /**
      * Constructor
      *
-     * @param bridgeConfig Bridge configuration
-     * @param format embedded format for the key/value in the Kafka message
+     * @param kafkaConfig Kafka configuration
      * @param keySerializer Kafka serializer for the message key
      * @param valueSerializer Kafka serializer for the message value
      */
-    public SourceBridgeEndpoint(BridgeConfig bridgeConfig, EmbeddedFormat format,
-                                Serializer<K> keySerializer, Serializer<V> valueSerializer) {
-        this.bridgeConfig = bridgeConfig;
-        this.format = format;
+    public KafkaBridgeProducer(KafkaConfig kafkaConfig, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+        this.kafkaConfig = kafkaConfig;
         this.keySerializer = keySerializer;
         this.valueSerializer = valueSerializer;
-    }
-
-    @Override
-    public String name() {
-        return this.name;
-    }
-
-    @Override
-    public HttpBridgeEndpoint closeHandler(Handler<HttpBridgeEndpoint> endpointCloseHandler) {
-        this.closeHandler = endpointCloseHandler;
-        return this;
-    }
-
-    /**
-     * Raise close event
-     */
-    protected void handleClose() {
-        if (this.closeHandler != null) {
-            this.closeHandler.handle(this);
-        }
     }
 
     /**
@@ -84,7 +53,7 @@ public abstract class SourceBridgeEndpoint<K, V> implements HttpBridgeEndpoint {
      * @param record Kafka record to send
      * @return a CompletionStage bringing the metadata
      */
-    protected CompletionStage<RecordMetadata> send(ProducerRecord<K, V> record) {
+    public CompletionStage<RecordMetadata> send(ProducerRecord<K, V> record) {
         CompletableFuture<RecordMetadata> promise = new CompletableFuture<>();
         log.trace("Send thread {}", Thread.currentThread());
         log.debug("Sending record {}", record);
@@ -105,18 +74,19 @@ public abstract class SourceBridgeEndpoint<K, V> implements HttpBridgeEndpoint {
      *
      * @param record Kafka record to send
      */
-    protected void sendIgnoreResult(ProducerRecord<K, V> record) {
+    public void sendIgnoreResult(ProducerRecord<K, V> record) {
         log.trace("Send ignore result thread {}", Thread.currentThread());
         log.debug("Sending record {}", record);
         this.producer.send(record);
     }
 
-    @Override
-    public void open() {
-        KafkaConfig kafkaConfig = this.bridgeConfig.getKafkaConfig();
+    /**
+     * Create the internal Kafka Producer client instance with the Kafka producer related configuration.
+     */
+    public void create() {
         Properties props = new Properties();
-        props.putAll(kafkaConfig.getConfig());
-        props.putAll(kafkaConfig.getProducerConfig().getConfig());
+        props.putAll(this.kafkaConfig.getConfig());
+        props.putAll(this.kafkaConfig.getProducerConfig().getConfig());
 
         TracingHandle tracing = TracingUtil.getTracing();
         tracing.addTracingPropsToProducerConfig(props);
@@ -124,11 +94,11 @@ public abstract class SourceBridgeEndpoint<K, V> implements HttpBridgeEndpoint {
         this.producer = new KafkaProducer<>(props, this.keySerializer, this.valueSerializer);
     }
 
-    @Override
+    /**
+     * Close the Kafka Producer client instance
+     */
     public void close() {
         if (this.producer != null)
             this.producer.close();
-
-        this.handleClose();
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeProducer.java
@@ -49,6 +49,7 @@ public class KafkaBridgeProducer<K, V> {
      * Send a record to Kafka, completing the returned CompletionStage when the Kafka producer callback is invoked.
      * The returned CompletionStage can be completed with metadata if the sending operation is successful or
      * it is completed exceptionally if the sending operation fails with any exception.
+     * The internal Kafka Producer send call could block for "max.block.ms" when metadata are not available.
      *
      * @param record Kafka record to send
      * @return a CompletionStage bringing the metadata

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
@@ -39,8 +39,8 @@ import java.util.concurrent.CompletionStage;
  */
 public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
 
-    private HttpBridgeContext httpBridgeContext;
-    private KafkaBridgeAdmin kafkaBridgeAdmin;
+    private final HttpBridgeContext httpBridgeContext;
+    private final KafkaBridgeAdmin kafkaBridgeAdmin;
 
     /**
      * Constructor

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.strimzi.kafka.bridge.AdminClientEndpoint;
+import io.strimzi.kafka.bridge.KafkaBridgeAdmin;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.Handler;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
@@ -35,26 +35,35 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Implementation of the admin client endpoint based on HTTP
+ * Represents an HTTP bridge endpoint for the Kafka administration operations
  */
-public class HttpAdminClientEndpoint extends AdminClientEndpoint {
+public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
 
     private HttpBridgeContext httpBridgeContext;
+    private KafkaBridgeAdmin kafkaBridgeAdmin;
 
     /**
-     * Create a Kafka admin client
+     * Constructor
      *
      * @param bridgeConfig the bridge configuration
      * @param context the HTTP bridge context
      */
-    public HttpAdminClientEndpoint(BridgeConfig bridgeConfig, HttpBridgeContext context) {
-        super(bridgeConfig);
+    public HttpAdminBridgeEndpoint(BridgeConfig bridgeConfig, HttpBridgeContext context) {
+        super(bridgeConfig, null);
+        this.name = "kafka-bridge-admin";
         this.httpBridgeContext = context;
+        this.kafkaBridgeAdmin = new KafkaBridgeAdmin(bridgeConfig.getKafkaConfig());
     }
 
     @Override
     public void open() {
-        super.open();
+        this.kafkaBridgeAdmin.create();
+    }
+
+    @Override
+    public void close() {
+        this.kafkaBridgeAdmin.close();
+        super.close();
     }
 
     @Override
@@ -93,7 +102,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
      * @param routingContext the routing context
      */
     public void doListTopics(RoutingContext routingContext) {
-        this.listTopics()
+        this.kafkaBridgeAdmin.listTopics()
                 .whenComplete((topics, ex) -> {
                     log.trace("List topics handler thread {}", Thread.currentThread());
                     if (ex == null) {
@@ -119,8 +128,8 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
     public void doGetTopic(RoutingContext routingContext) {
         String topicName = routingContext.pathParam("topicname");
 
-        CompletionStage<Map<String, TopicDescription>> describeTopicsPromise = this.describeTopics(List.of(topicName));
-        CompletionStage<Map<ConfigResource, Config>> describeConfigsPromise = this.describeConfigs(List.of(new ConfigResource(ConfigResource.Type.TOPIC, topicName)));
+        CompletionStage<Map<String, TopicDescription>> describeTopicsPromise = this.kafkaBridgeAdmin.describeTopics(List.of(topicName));
+        CompletionStage<Map<ConfigResource, Config>> describeConfigsPromise = this.kafkaBridgeAdmin.describeConfigs(List.of(new ConfigResource(ConfigResource.Type.TOPIC, topicName)));
 
         CompletableFuture.allOf(describeTopicsPromise.toCompletableFuture(), describeConfigsPromise.toCompletableFuture())
                 .whenComplete((v, ex) -> {
@@ -185,7 +194,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
      */
     public void doListPartitions(RoutingContext routingContext) {
         String topicName = routingContext.pathParam("topicname");
-        this.describeTopics(List.of(topicName))
+        this.kafkaBridgeAdmin.describeTopics(List.of(topicName))
                 .whenComplete((topicDescriptions, ex) -> {
                     log.trace("List partitions handler thread {}", Thread.currentThread());
                     if (ex == null) {
@@ -231,7 +240,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                     BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
             return;
         }
-        this.describeTopics(List.of(topicName))
+        this.kafkaBridgeAdmin.describeTopics(List.of(topicName))
                 .whenComplete((topicDescriptions, ex) -> {
                     log.trace("Get partition handler thread {}", Thread.currentThread());
                     if (ex == null) {
@@ -285,7 +294,7 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
         }
         TopicPartition topicPartition = new TopicPartition(topicName, partitionId);
 
-        CompletionStage<Map<String, TopicDescription>> topicExistenceCheckPromise = this.describeTopics(List.of(topicName));
+        CompletionStage<Map<String, TopicDescription>> topicExistenceCheckPromise = this.kafkaBridgeAdmin.describeTopics(List.of(topicName));
         topicExistenceCheckPromise.whenComplete((topicDescriptions, t) -> {
             Throwable e = null;
             if (t != null && t.getCause() instanceof UnknownTopicOrPartitionException) {
@@ -299,9 +308,9 @@ public class HttpAdminClientEndpoint extends AdminClientEndpoint {
                         BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
             } else {
                 Map<TopicPartition, OffsetSpec> topicPartitionBeginOffsets = Map.of(topicPartition, OffsetSpec.earliest());
-                CompletionStage<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> getBeginningOffsetsPromise = this.listOffsets(topicPartitionBeginOffsets);
+                CompletionStage<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> getBeginningOffsetsPromise = this.kafkaBridgeAdmin.listOffsets(topicPartitionBeginOffsets);
                 Map<TopicPartition, OffsetSpec> topicPartitionEndOffsets = Map.of(topicPartition, OffsetSpec.latest());
-                CompletionStage<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> getEndOffsetsPromise = this.listOffsets(topicPartitionEndOffsets);
+                CompletionStage<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> getEndOffsetsPromise = this.kafkaBridgeAdmin.listOffsets(topicPartitionEndOffsets);
 
                 CompletableFuture.allOf(getBeginningOffsetsPromise.toCompletableFuture(), getEndOffsetsPromise.toCompletableFuture())
                         .whenComplete((v, ex) -> {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -58,7 +58,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_ALLOW_M
 /**
  * Main bridge class listening for connections and handling HTTP requests.
  */
-@SuppressWarnings({"checkstyle:MemberName", "checkstyle:ClassFanOutComplexity"})
+@SuppressWarnings({"checkstyle:MemberName"})
 public class HttpBridge extends AbstractVerticle {
 
     private static final Logger log = LoggerFactory.getLogger(HttpBridge.class);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
@@ -5,10 +5,7 @@
 
 package io.strimzi.kafka.bridge.http;
 
-import io.strimzi.kafka.bridge.AdminClientEndpoint;
 import io.strimzi.kafka.bridge.ConsumerInstanceId;
-import io.strimzi.kafka.bridge.SinkBridgeEndpoint;
-import io.strimzi.kafka.bridge.SourceBridgeEndpoint;
 import io.vertx.core.http.HttpConnection;
 
 import java.util.HashMap;
@@ -23,40 +20,39 @@ import java.util.Map;
  */
 public class HttpBridgeContext<K, V> {
 
-    private Map<ConsumerInstanceId, SinkBridgeEndpoint<K, V>> httpSinkEndpoints = new HashMap<>();
-    private Map<HttpConnection, SourceBridgeEndpoint<K, V>> httpSourceEndpoints = new HashMap<>();
-    private AdminClientEndpoint adminClientEndpoint;
-
+    private Map<ConsumerInstanceId, HttpSinkBridgeEndpoint<K, V>> httpSinkEndpoints = new HashMap<>();
+    private Map<HttpConnection, HttpSourceBridgeEndpoint<K, V>> httpSourceEndpoints = new HashMap<>();
+    private HttpAdminBridgeEndpoint httpAdminBridgeEndpoint;
     private HttpOpenApiOperations openApiOperation;
 
     /**
-     * @return map of sink endpoints
+     * @return map of the HTTP sink endpoints
      */
-    public Map<ConsumerInstanceId, SinkBridgeEndpoint<K, V>> getHttpSinkEndpoints() {
+    public Map<ConsumerInstanceId, HttpSinkBridgeEndpoint<K, V>> getHttpSinkEndpoints() {
         return this.httpSinkEndpoints;
     }
 
     /**
-     * @return map of source endpoints
+     * @return map of the HTTP source endpoints
      */
-    public Map<HttpConnection, SourceBridgeEndpoint<K, V>> getHttpSourceEndpoints() {
+    public Map<HttpConnection, HttpSourceBridgeEndpoint<K, V>> getHttpSourceEndpoints() {
         return this.httpSourceEndpoints;
     }
 
     /**
-     * @return the admin endpoint
+     * @return the HTTP admin endpoint
      */
-    public AdminClientEndpoint getAdminClientEndpoint() {
-        return this.adminClientEndpoint;
+    public HttpAdminBridgeEndpoint getHttpAdminEndpoint() {
+        return this.httpAdminBridgeEndpoint;
     }
 
     /**
-     * Sets the admin endpoint
+     * Sets the HTTP admin endpoint
      *
-     * @param adminClientEndpoint the admin endpoint
+     * @param httpAdminBridgeEndpoint the HTTP admin endpoint
      */
-    void setAdminClientEndpoint(AdminClientEndpoint adminClientEndpoint) {
-        this.adminClientEndpoint = adminClientEndpoint;
+    void setHttpAdminEndpoint(HttpAdminBridgeEndpoint httpAdminBridgeEndpoint) {
+        this.httpAdminBridgeEndpoint = httpAdminBridgeEndpoint;
     }
 
     /**
@@ -76,10 +72,10 @@ public class HttpBridgeContext<K, V> {
     }
 
     /**
-     * Close all the sink endpoints
+     * Close all the HTTP sink endpoints
      */
-    public void closeAllSinkBridgeEndpoints() {
-        for (Map.Entry<ConsumerInstanceId, SinkBridgeEndpoint<K, V>> sink: getHttpSinkEndpoints().entrySet()) {
+    public void closeAllHttpSinkBridgeEndpoints() {
+        for (Map.Entry<ConsumerInstanceId, HttpSinkBridgeEndpoint<K, V>> sink: getHttpSinkEndpoints().entrySet()) {
             if (sink.getValue() != null)
                 sink.getValue().close();
         }
@@ -87,10 +83,10 @@ public class HttpBridgeContext<K, V> {
     }
 
     /**
-     * Close all the source endpoints
+     * Close all the HTTP source endpoints
      */
-    public void closeAllSourceBridgeEndpoints() {
-        for (Map.Entry<HttpConnection, SourceBridgeEndpoint<K, V>> source: getHttpSourceEndpoints().entrySet()) {
+    public void closeAllHttpSourceBridgeEndpoints() {
+        for (Map.Entry<HttpConnection, HttpSourceBridgeEndpoint<K, V>> source: getHttpSourceEndpoints().entrySet()) {
             if (source.getValue() != null)
                 source.getValue().close();
         }
@@ -98,10 +94,10 @@ public class HttpBridgeContext<K, V> {
     }
 
     /**
-     * Close the admin client endpoint
+     * Close the HTTP admin client endpoint
      */
-    public void closeAdminClientEndpoint() {
-        if (this.adminClientEndpoint != null)
-            this.adminClientEndpoint.close();
+    public void closeHttpAdminClientEndpoint() {
+        if (this.httpAdminBridgeEndpoint != null)
+            this.httpAdminBridgeEndpoint.close();
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -66,11 +66,11 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
     Pattern hostPortPattern = Pattern.compile("^.*:[0-9]+$");
 
     private MessageConverter<K, V, Buffer, Buffer> messageConverter;
-    private HttpBridgeContext<K, V> httpBridgeContext;
-    private KafkaBridgeConsumer<K, V> kafkaBridgeConsumer;
+    private final HttpBridgeContext<K, V> httpBridgeContext;
+    private final KafkaBridgeConsumer<K, V> kafkaBridgeConsumer;
     private ConsumerInstanceId consumerInstanceId;
     private boolean subscribed;
-    protected boolean assigned;
+    private boolean assigned;
 
     /**
      * Constructor

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -55,7 +55,6 @@ import java.util.stream.StreamSupport;
  * @param <K> type of Kafka message key
  * @param <V> type of Kafka message payload
  */
-@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
 public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
 
     private static final ObjectNode EMPTY_JSON = JsonUtils.createObjectNode();
@@ -116,7 +115,6 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
      * @param bodyAsJson HTTP request body bringing consumer settings
      * @param handler handler for the request
      */
-    @SuppressWarnings("checkstyle:NPathComplexity")
     private void doCreateConsumer(RoutingContext routingContext, JsonNode bodyAsJson, Handler<HttpBridgeEndpoint> handler) {
         // get the consumer group-id
         String groupId = routingContext.pathParam("groupid");
@@ -541,7 +539,6 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
         }
     }
 
-    @SuppressWarnings({"checkstyle:CyclomaticComplexity"})
     @Override
     public void handle(RoutingContext routingContext, Handler<HttpBridgeEndpoint> handler) {
         JsonNode bodyAsJson = EMPTY_JSON;

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -45,7 +45,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
 
     private MessageConverter<K, V, Buffer, Buffer> messageConverter;
     private boolean closing;
-    private KafkaBridgeProducer<K, V> kafkaBridgeProducer;
+    private final KafkaBridgeProducer<K, V> kafkaBridgeProducer;
 
     HttpSourceBridgeEndpoint(BridgeConfig bridgeConfig, EmbeddedFormat format,
                              Serializer<K> keySerializer, Serializer<V> valueSerializer) {


### PR DESCRIPTION
This PR refactors the HTTP sink/source/admin endpoints part.
It moves from using inheritance to composition so that an HTTP endpoint doesn't extend the class containing the Kafka logic but uses it instead:

* the `HttpSinkBridgeEndpoint`, `HttpSourceBridgeEndpoint` and `HttpAdminBridgeEndpoint` derives from `HttpBridgeEndpoint` where most of the common behaviour was moved.
* the above endpoints now use `KafkaBrideConsumer`, `KafkaBridgeProducer` and `KafkaBridgeAdmin` which are the old sink/source/admin base endpoint but still thin wrappers around the Java clients API.


While everything could be still collapsed in one class per endpoint I think that it's still better having more separation of concerns: HTTP endpoint part vs Kafka related communication.
It also avoids to have just one bigger class per endpoint type.
I was able to remove some `@SupperssWarnings` for the checkstyle related to the complexity.