### PR TITLE
Fixed closing Kafka producer on dropping HTTP connection (regression)

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -61,12 +61,17 @@ public class HttpSourceBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
         this.kafkaBridgeProducer.create();
     }
 
+    @Override
+    public void close() {
+        this.kafkaBridgeProducer.close();
+        super.close();
+    }
+
     /**
      * Close the source endpoint
      */
     public void maybeClose() {
         if (this.closing) {
-            this.kafkaBridgeProducer.close();
             this.close();
         }
     }


### PR DESCRIPTION
The latest https://github.com/strimzi/strimzi-kafka-bridge/pull/754 added a regression, with the Kafka producer not properly closed when the corresponding HTTP client producer drop the connection.
This PR fixes it.