### PR TITLE
Added async query parameter on send/sentToPartition in OpenAPI v3 and v2

### DIFF
--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -734,6 +734,15 @@
                     "schema": {
                         "type": "string"
                     }
+                },
+                {
+                    "name": "async",
+                    "in": "query",
+                    "description": "Ignore metadata as result of the sending operation, not returning them to the client. If not specified it is false, metadata returned.",
+                    "required": false,
+                    "schema": {
+                        "type": "boolean"
+                    }
                 }
             ]
         },
@@ -1120,6 +1129,15 @@
                     "required": true,
                     "schema": {
                         "type": "integer"
+                    }
+                },
+                {
+                    "name": "async",
+                    "in": "query",
+                    "description": "Whether to return immediately upon sending records, instead of waiting for metadata. No offsets will be returned if specified. Defaults to false.",
+                    "required": false,
+                    "schema": {
+                        "type": "boolean"
                     }
                 }
             ]

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -949,6 +949,13 @@
             "schema": {
               "$ref": "#/definitions/ProducerRecordToPartitionList"
             }
+          },
+          {
+            "name": "async",
+            "in": "query",
+            "description": "Whether to return immediately upon sending records, instead of waiting for metadata. No offsets will be returned if specified. Defaults to false.",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -941,6 +941,40 @@ public class ProducerIT extends HttpBridgeITAbstract {
     }
 
     @Test
+    void sendWithWrongAsync(VertxTestContext context) throws InterruptedException, ExecutionException {
+        KafkaFuture<Void> future = adminClientFacade.createTopic(topic);
+
+        String value = "message-value";
+
+        JsonArray records = new JsonArray();
+        JsonObject json = new JsonObject();
+        json.put("value", value);
+        records.add(json);
+
+        JsonObject root = new JsonObject();
+        root.put("records", records);
+
+        future.get();
+
+        producerService()
+                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
+                .addQueryParam("async", "wrong")
+                .sendJsonObject(root, ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        HttpBridgeError error = HttpBridgeError.fromJson(response.body());
+                        assertThat(response.statusCode(), is(HttpResponseStatus.BAD_REQUEST.code()));
+                        assertThat(error.getCode(), is(HttpResponseStatus.BAD_REQUEST.code()));
+                        assertThat(error.getMessage(), containsString("Value wrong should be true or false"));
+                    });
+                    context.completeNow();
+                });
+
+        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+    }
+
+    @Test
     void sendSimpleMessageWithWrongContentType(VertxTestContext context) throws InterruptedException, ExecutionException {
         KafkaFuture<Void> future = adminClientFacade.createTopic(topic);
 


### PR DESCRIPTION
The `async` query parameter was totally missing in the OpenAPI v3 specification and missing in the `sentToPartition` operation for v2.
Because the bridge uses v3 to validate, there was no validation on the boolean value for that query parameter.
This PR fixes it and add a test as well.