### PR TITLE
Fixed sending headers on the send to partition endpoint

### DIFF
--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -242,7 +242,13 @@ __optional__|< <<_producerrecord,ProducerRecord>> > array
 
 [[_producerrecordtopartition]]
 === ProducerRecordToPartition
-__Type__ : object
+
+[options="header", cols=".^3a,.^4a"]
+|===
+|Name|Schema
+|**headers** +
+__optional__|<<_kafkaheaderlist,KafkaHeaderList>>
+|===
 
 
 [[_producerrecordtopartitionlist]]

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1819,6 +1819,9 @@
                                 "type": "string"
                             }
                         ]
+                    },
+                    "headers": {
+                        "$ref": "#/components/schemas/KafkaHeaderList"
                     }
                 },
                 "additionalProperties": false,

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1671,6 +1671,9 @@
             "object",
             "string"
           ]
+        },
+        "headers": {
+          "$ref": "#/definitions/KafkaHeaderList"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
When sending messages with "headers" to the "sendToPartition" endpoint, we get the following error:

```json
{
    "error_code": 400,
    "message": "Validation error on: /records/0 - Provided object contains unexpected additional property: headers"
}
```

This is wrong, because it should be possible as when using the "send" endpoint.
This PR fixes the bug by adding the missing "headers" declaration in the OpenAPI v2 and v3 specifications on the "sendToPartition" endpoint.