### PR TITLE
Added missing updates in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.25.0
+
+* Fixed sending messages with headers to the `sendToPartition` endpoint.
+* Added missing validation on the `async` query parameter for sending operations in the OpenAPI v3 specification.
+
 ## 0.24.0
 
 * Fixed regression about producing messages not working when CORS is enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed sending messages with headers to the `sendToPartition` endpoint.
 * Added missing validation on the `async` query parameter for sending operations in the OpenAPI v3 specification.
+* Fixed memory calculation by using JVM so taking cgroupv2 into account.
 
 ## 0.24.0
 


### PR DESCRIPTION
This trivial PR is about updating the CHANGELOG with what was fixed in #757 and #758.
I decided to open a new PR and not including this update in the latest fix to avoid mixing stuff.