### PR TITLE
Bumped Vert.x to 4.3.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed sending messages with headers to the `sendToPartition` endpoint.
 * Added missing validation on the `async` query parameter for sending operations in the OpenAPI v3 specification.
 * Fixed memory calculation by using JVM so taking cgroupv2 into account.
+* Dependency updates (Vert.x 4.3.7)
 
 ## 0.24.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
-		<vertx.version>4.3.5</vertx.version>
+		<vertx.version>4.3.7</vertx.version>
 		<netty.version>4.1.86.Final</netty.version>
 		<kafka.version>3.2.3</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>


### PR DESCRIPTION
Trivial PR to bump Vert.x to the latest 4.3.7 release.