### PR TITLE
Update subscribe and assign method to follow same processing logic as apache kafka

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeConsumer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeConsumer.java
@@ -99,6 +99,7 @@ public class KafkaBridgeConsumer<K, V> {
 
         if (topicSubscriptions.isEmpty()) {
             this.unsubscribe();
+            return;
         }
 
         log.info("Subscribe to topics {}", topicSubscriptions);
@@ -157,6 +158,7 @@ public class KafkaBridgeConsumer<K, V> {
 
         if (topicPartitions.isEmpty()) {
             this.unsubscribe();
+            return;
         }
 
         log.trace("Assign thread {}", Thread.currentThread());

--- a/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeConsumer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeConsumer.java
@@ -93,8 +93,12 @@ public class KafkaBridgeConsumer<K, V> {
      * @param topicSubscriptions topics to subscribe to
      */
     public void subscribe(List<SinkTopicSubscription> topicSubscriptions) {
+        if (topicSubscriptions == null) {
+            throw new IllegalArgumentException("Topic subscriptions cannot be null");
+        }
+
         if (topicSubscriptions.isEmpty()) {
-            throw new IllegalArgumentException("At least one topic to subscribe has to be specified!");
+            this.unsubscribe();
         }
 
         log.info("Subscribe to topics {}", topicSubscriptions);
@@ -140,8 +144,8 @@ public class KafkaBridgeConsumer<K, V> {
      * @param topicSubscriptions topics to be assigned
      */
     public void assign(List<SinkTopicSubscription> topicSubscriptions) {
-        if (topicSubscriptions.isEmpty()) {
-            throw new IllegalArgumentException("At least one topic to subscribe has to be specified!");
+        if (topicSubscriptions == null) {
+            throw new IllegalArgumentException("Topic subscriptions cannot be null");
         }
 
         log.info("Assigning to topics partitions {}", topicSubscriptions);
@@ -149,6 +153,10 @@ public class KafkaBridgeConsumer<K, V> {
         Set<TopicPartition> topicPartitions = new HashSet<>();
         for (SinkTopicSubscription topicSubscription : topicSubscriptions) {
             topicPartitions.add(new TopicPartition(topicSubscription.getTopic(), topicSubscription.getPartition()));
+        }
+
+        if (topicPartitions.isEmpty()) {
+            this.unsubscribe();
         }
 
         log.trace("Assign thread {}", Thread.currentThread());

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -49,7 +49,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
 
         CompletableFuture<Boolean> unsubscribe = new CompletableFuture<>();
         consumerService()
-                .deleteRequest(Urls.consumerInstanceSubscription(groupId, name + "consumer-invalidation"))
+            .deleteRequest(Urls.consumerInstanceSubscription(groupId, name + "consumer-invalidation"))
                 .putHeader("Content-length", String.valueOf(topicsRoot.toBuffer().length()))
                 .as(BodyCodec.jsonObject())
                 .sendJsonObject(topicsRoot, ar -> {
@@ -78,7 +78,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
 
         // create consumer
         consumerService()
-                .createConsumer(context, groupId, json);
+            .createConsumer(context, groupId, json);
 
         // cannot subscribe setting both topics list and topic_pattern
         JsonArray topics = new JsonArray();
@@ -90,7 +90,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
 
         CompletableFuture<Boolean> subscribeConflict = new CompletableFuture<>();
         consumerService()
-                .subscribeConsumerRequest(groupId, name, topicsRoot)
+            .subscribeConsumerRequest(groupId, name, topicsRoot)
                 .sendJsonObject(topicsRoot, ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
@@ -110,7 +110,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         topicsRoot = new JsonObject();
         CompletableFuture<Boolean> subscribeEmpty = new CompletableFuture<>();
         consumerService()
-                .subscribeConsumerRequest(groupId, name, topicsRoot)
+            .subscribeConsumerRequest(groupId, name, topicsRoot)
                 .sendJsonObject(topicsRoot, ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
@@ -129,7 +129,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         context.completeNow();
         assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
         consumerService()
-                .deleteConsumer(context, groupId, name);
+            .deleteConsumer(context, groupId, name);
     }
 
     @Test
@@ -145,7 +145,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
 
         CompletableFuture<Boolean> subscribe = new CompletableFuture<>();
         consumerService()
-                .subscribeConsumerRequest(groupId, name, topicsRoot)
+            .subscribeConsumerRequest(groupId, name, topicsRoot)
                 .sendJsonObject(topicsRoot, ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
@@ -285,7 +285,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         subscribe.get(TEST_TIMEOUT, TimeUnit.SECONDS);
 
         consumerService()
-                .deleteConsumer(context, groupId, name);
+            .deleteConsumer(context, groupId, name);
 
         context.completeNow();
     }
@@ -353,7 +353,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         listSubscriptions.get(TEST_TIMEOUT, TimeUnit.SECONDS);
 
         consumerService()
-                .deleteConsumer(context, groupId, name);
+            .deleteConsumer(context, groupId, name);
         context.completeNow();
     }
 
@@ -385,7 +385,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
                 });
         consume.get(TEST_TIMEOUT, TimeUnit.SECONDS);
         consumerService()
-                .deleteConsumer(context, groupId, name);
+            .deleteConsumer(context, groupId, name);
         context.completeNow();
     }
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -193,8 +193,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
                     }
                 });
         consume.get(TEST_TIMEOUT, TimeUnit.SECONDS);
-
-        CompletableFuture<Boolean> subscribe = new CompletableFuture<>();
+        
         // Validate the existing consumer list
         CompletableFuture<Boolean> listSubscriptions = new CompletableFuture<>();
         consumerService()
@@ -214,6 +213,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         // Subscribe to an empty topic list, expect return null response body
         JsonObject unsubscribeTopicRoot = new JsonObject();
         unsubscribeTopicRoot.put("topics", new JsonArray());
+        CompletableFuture<Boolean> subscribe = new CompletableFuture<>();
         consumerService()
                 .subscribeConsumerRequest(groupId, name, unsubscribeTopicRoot)
                 .sendJsonObject(unsubscribeTopicRoot, ar -> {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -413,12 +413,12 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
 
     @Test
     void assignEmptyAfterSubscriptionTest(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        String topic = "subscribe-and-assign-topic";
+        String topic = "subscribe-and-assign-empty-topic";
 
         KafkaFuture<Void> future = adminClientFacade.createTopic(topic, 4, 1);
         future.get();
 
-        String consumerName = "my-kafka-consumer-assign";
+        String consumerName = "my-kafka-consumer-assign-empty";
 
         JsonObject consumerJson = new JsonObject();
         consumerJson.put("name", consumerName);

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -196,6 +196,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
                     subscribe.complete(true);
                 });
 
+        subscribe.get(TEST_TIMEOUT, TimeUnit.SECONDS);            
         // Validate the existing consumer list
         CompletableFuture<Boolean> listSubscriptions = new CompletableFuture<>();
         consumerService()
@@ -444,6 +445,7 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
                     assignCF.complete(true);
                 });
 
+        assignCF.get(TEST_TIMEOUT, TimeUnit.SECONDS);
         // Validate the existing consumer list
         CompletableFuture<Boolean> listSubscriptions = new CompletableFuture<>();
         consumerService()


### PR DESCRIPTION
This PR fixed the bug described in issue https://github.com/strimzi/strimzi-kafka-bridge/issues/756

it update subscribe and assign method to follow same processing logic as apache kafka.