### PR TITLE
Updated CHANGELOG to latest Vert.x 4.3.8 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Fixed sending messages with headers to the `sendToPartition` endpoint.
 * Added missing validation on the `async` query parameter for sending operations in the OpenAPI v3 specification.
 * Fixed memory calculation by using JVM so taking cgroupv2 into account.
-* Dependency updates (Vert.x 4.3.7)
+* Dependency updates (Vert.x 4.3.8)
 
 ## 0.24.0
 


### PR DESCRIPTION
After Vert.x bumped by the bot, updating the CHANGELOG for 0.25.0.