### PR TITLE
Bumped OpenTelemetry to 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added missing validation on the `async` query parameter for sending operations in the OpenAPI v3 specification.
 * Fixed memory calculation by using JVM so taking cgroupv2 into account.
 * Dependency updates (Vert.x 4.3.8)
+* OpenTelemetry updated to 1.19.0
 
 ## 0.24.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,8 @@
 		<jaeger.version>1.8.1</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.15</opentracing-kafka-client.version>
-		<opentelemetry.alpha-version>1.18.0-alpha</opentelemetry.alpha-version>
-		<opentelemetry.version>1.18.0</opentelemetry.version>
+		<opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
+		<opentelemetry.version>1.19.0</opentelemetry.version>
 		<micrometer.version>1.9.5</micrometer.version>
 		<jmx-prometheus-collector.version>0.17.2</jmx-prometheus-collector.version>
 		<prometheus-simpleclient.version>0.16.0</prometheus-simpleclient.version>


### PR DESCRIPTION
While working on moving to use Quarkus, upgrading to a newer OpenTelemetry 1.19.0 is useful to stay aligned with the version that OpenTelemetry Quarkus support is using.