### PR TITLE
Bumped Netty and Kafka dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 * Fixed sending messages with headers to the `sendToPartition` endpoint.
 * Added missing validation on the `async` query parameter for sending operations in the OpenAPI v3 specification.
 * Fixed memory calculation by using JVM so taking cgroupv2 into account.
-* Dependency updates (Vert.x 4.3.8)
-* OpenTelemetry updated to 1.19.0
+* Dependency updates (Vert.x 4.3.8, Netty 4.1.87 to align with Vert.x, Kafka 3.4.0, OpenTelemetry 1.19.0)
 * Added feature to unsubscribe topics by executing a subscribe or assign request with an empty topics list.
 
 ## 0.24.0

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<vertx.version>4.3.8</vertx.version>
-		<netty.version>4.1.86.Final</netty.version>
-		<kafka.version>3.2.3</kafka.version>
+		<netty.version>4.1.87.Final</netty.version>
+		<kafka.version>3.4.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<maven.checkstyle.version>3.2.0</maven.checkstyle.version>


### PR DESCRIPTION
Bumped Netty to align with what Vert.x brings for other Netty components.
Bumped Kafka to latest release.