### PR TITLE
bump up 0.103.0 test container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 		<jmx-prometheus-collector.version>0.17.2</jmx-prometheus-collector.version>
 		<prometheus-simpleclient.version>0.16.0</prometheus-simpleclient.version>
 		<commons-cli.version>1.4</commons-cli.version>
-		<test-container.version>0.102.0</test-container.version>
+		<test-container.version>0.103.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>1.33</snakeyaml.version>
 		<!-- property to skip surefire tests during failsafe execution -->


### PR DESCRIPTION
This PR updates the latest version of the Strimzi test container used by tests.