### PR TITLE
Removed the usage of Vert.x Buffer

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
@@ -108,14 +108,14 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                     if (ex == null) {
                         ArrayNode root = JsonUtils.createArrayNode();
                         topics.forEach(topic -> root.add(topic));
-                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                     } else {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     }
                 });
     }
@@ -168,21 +168,21 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                             });
                         }
                         root.put("partitions", partitionsArray);
-                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                     } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.NOT_FOUND.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     } else {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     }
                 });
     }
@@ -203,21 +203,21 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                         if (description != null) {
                             description.partitions().forEach(partitionInfo -> root.add(createPartitionMetadata(partitionInfo)));
                         }
-                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                     } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.NOT_FOUND.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     } else {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     }
                 });
     }
@@ -237,7 +237,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                     HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
                     "Specified partition is not a valid number");
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             return;
         }
         this.kafkaBridgeAdmin.describeTopics(List.of(topicName))
@@ -247,14 +247,14 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                         TopicDescription description = topicDescriptions.get(topicName);
                         if (description != null && partitionId < description.partitions().size()) {
                             JsonNode root = createPartitionMetadata(description.partitions().get(partitionId));
-                            HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                            HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                         } else {
                             HttpBridgeError error = new HttpBridgeError(
                                     HttpResponseStatus.NOT_FOUND.code(),
                                     "Specified partition does not exist."
                             );
                             HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                         }
                     } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
                         HttpBridgeError error = new HttpBridgeError(
@@ -262,14 +262,14 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     } else {
                         HttpBridgeError error = new HttpBridgeError(
                                 HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                 ex.getMessage()
                         );
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                     }
                 });
     }
@@ -289,7 +289,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                     HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
                     "Specified partition is not a valid number");
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.UNPROCESSABLE_ENTITY.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             return;
         }
         TopicPartition topicPartition = new TopicPartition(topicName, partitionId);
@@ -305,7 +305,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
             if (e != null) {
                 HttpBridgeError error = new HttpBridgeError(HttpResponseStatus.NOT_FOUND.code(), e.getMessage());
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                        BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                        BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             } else {
                 Map<TopicPartition, OffsetSpec> topicPartitionBeginOffsets = Map.of(topicPartition, OffsetSpec.earliest());
                 CompletionStage<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> getBeginningOffsetsPromise = this.kafkaBridgeAdmin.listOffsets(topicPartitionBeginOffsets);
@@ -325,14 +325,14 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                                 if (endOffset != null) {
                                     root.put("end_offset", endOffset.offset());
                                 }
-                                HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(root));
+                                HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                             } else {
                                 HttpBridgeError error = new HttpBridgeError(
                                         HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                                         ex.getMessage()
                                 );
                                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                        BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                                        BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
                             }
                         });
             }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -278,14 +278,14 @@ public class HttpBridge extends AbstractVerticle {
                     "Consumer is disabled in config. To enable consumer update http.consumer.enabled to true"
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.SERVICE_UNAVAILABLE.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             return;
         }
 
         this.httpBridgeContext.setOpenApiOperation(HttpOpenApiOperations.CREATE_CONSUMER);
 
         // check for an empty body
-        JsonNode body = !routingContext.body().isEmpty() ? JsonUtils.bufferToJson(routingContext.body().buffer()) : JsonUtils.createObjectNode();
+        JsonNode body = !routingContext.body().isEmpty() ? JsonUtils.bytesToJson(routingContext.body().buffer().getByteBuf().array()) : JsonUtils.createObjectNode();
         HttpSinkBridgeEndpoint<byte[], byte[]> sink = null;
 
         try {
@@ -318,7 +318,7 @@ public class HttpBridge extends AbstractVerticle {
                 ex.getMessage()
             );
             HttpUtils.sendResponse(routingContext, error.getCode(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -341,7 +341,7 @@ public class HttpBridge extends AbstractVerticle {
                     "The specified consumer instance was not found."
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -436,7 +436,7 @@ public class HttpBridge extends AbstractVerticle {
                     "The specified consumer instance was not found."
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.NOT_FOUND.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -452,7 +452,7 @@ public class HttpBridge extends AbstractVerticle {
                     "Producer is disabled in config. To enable producer update http.producer.enabled to true"
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.SERVICE_UNAVAILABLE.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
             return;
         }
         HttpServerRequest httpServerRequest = routingContext.request();
@@ -483,7 +483,7 @@ public class HttpBridge extends AbstractVerticle {
                     ex.getMessage()
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -497,7 +497,7 @@ public class HttpBridge extends AbstractVerticle {
                     "The AdminClient was not found."
             );
             HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
         }
     }
 
@@ -527,9 +527,9 @@ public class HttpBridge extends AbstractVerticle {
                     if (xForwardedPath != null) {
                         path = xForwardedPath;
                     }
-                    ObjectNode json = (ObjectNode) JsonUtils.bufferToJson(readFile.result());
+                    ObjectNode json = (ObjectNode) JsonUtils.bytesToJson(readFile.result().getByteBuf().array());
                     json.put("basePath", path);
-                    HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, JsonUtils.jsonToBuffer(json));
+                    HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, JsonUtils.jsonToBytes(json));
                 }
             } else {
                 log.error("Failed to read OpenAPI JSON file", readFile.cause());
@@ -537,7 +537,7 @@ public class HttpBridge extends AbstractVerticle {
                     HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
                     readFile.cause().getMessage());
                 HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        BridgeContentType.JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                        BridgeContentType.JSON, JsonUtils.jsonToBytes(error.toJson()));
             }
         });
     }
@@ -548,7 +548,7 @@ public class HttpBridge extends AbstractVerticle {
         ObjectNode versionJson = JsonUtils.createObjectNode();
         versionJson.put("bridge_version", version == null ? "null" : version);
         HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(),
-                BridgeContentType.JSON, JsonUtils.jsonToBuffer(versionJson));
+                BridgeContentType.JSON, JsonUtils.jsonToBytes(versionJson));
     }
 
     @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
@@ -592,7 +592,7 @@ public class HttpBridge extends AbstractVerticle {
 
         HttpBridgeError error = new HttpBridgeError(routingContext.statusCode(), message);
         HttpUtils.sendResponse(routingContext, routingContext.statusCode(),
-                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBuffer(error.toJson()));
+                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
 
         log.error("[{}] Response: statusCode = {}, message = {} ", 
             requestId,

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
@@ -27,14 +27,14 @@ public class HttpUtils {
      * @param contentType the content-type to set in the HTTP response
      * @param body the body to set in the HTTP response
      */
-    public static void sendResponse(RoutingContext routingContext, int statusCode, String contentType, Buffer body) {
+    public static void sendResponse(RoutingContext routingContext, int statusCode, String contentType, byte[] body) {
         if (!routingContext.response().closed() && !routingContext.response().ended()) {
             routingContext.response().setStatusCode(statusCode);
             if (body != null) {
-                log.debug("[{}] Response: body = {}", routingContext.get("request-id"), JsonUtils.bufferToJson(body));
+                log.debug("[{}] Response: body = {}", routingContext.get("request-id"), JsonUtils.bytesToJson(body));
                 routingContext.response().putHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
-                routingContext.response().putHeader(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(body.length()));
-                routingContext.response().write(body);
+                routingContext.response().putHeader(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(body.length));
+                routingContext.response().write(Buffer.buffer(body));
             }
             routingContext.response().end();
         } else if (routingContext.response().ended()) {

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -25,28 +24,28 @@ public class JsonUtils {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
-     * Get the JSON representation of the provided buffer content
+     * Get the JSON representation of the provided bytes array
      *
-     * @param buffer buffer containing JSON data
-     * @return JSON representation of the buffer data
+     * @param bytes bytes array containing JSON data
+     * @return JSON representation of the bytes array
      */
-    public static JsonNode bufferToJson(Buffer buffer) {
+    public static JsonNode bytesToJson(byte[] bytes) {
         try {
-            return MAPPER.readTree(buffer.getByteBuf().array());
+            return MAPPER.readTree(bytes);
         } catch (IOException e) {
             throw new JsonDecodeException("Failed to decode:" + e.getMessage(), e);
         }
     }
 
     /**
-     * Get the bytes representation within a buffer of the provided JSON
+     * Get the bytes array representation of the provided JSON
      *
      * @param json JSON representation
-     * @return bytes buffer representing the JSON data
+     * @return bytes array representing the JSON data
      */
-    public static Buffer jsonToBuffer(JsonNode json) {
+    public static byte[] jsonToBytes(JsonNode json) {
         try {
-            return Buffer.buffer(MAPPER.writeValueAsBytes(json));
+            return MAPPER.writeValueAsBytes(json);
         } catch (Exception e) {
             throw new JsonEncodeException("Failed to encode as JSON: " + e.getMessage());
         }


### PR DESCRIPTION
With the goal of removing Vert.x, this PR removes the usage of the `Buffer` class by centralising in a couple of place instead of using it all across the converters moving from `Buffer` to bytes and back.
The `Buffer` is used only where HTTP request and response are handled because the Vert.x routing system works this way.
The last pieces will be removed when Vert.x will be totally out of the picture.