### PR TITLE
docs: fix example for POST request to /topics

### DIFF
--- a/documentation/modules/con-requests-kafka-bridge.adoc
+++ b/documentation/modules/con-requests-kafka-bridge.adoc
@@ -95,15 +95,15 @@ curl -X POST \
     "records": [
         {
             "key": "my-key",
-            "value": "sales-lead-0001"
-            "partition": 2
+            "value": "sales-lead-0001",
+            "partition": 2,
             "headers": [
               {
                 "key": "key1",
                 "value": "QXBhY2hlIEthZmthIGlzIHRoZSBib21iIQ==" <1>
               }
             ]
-        },
+        }
     ]
 }'
 ----


### PR DESCRIPTION
Very minor update to the example for POST request to /topics

- Changes the position of the commas so that Bridge does not give errors when the example request is made as is with copy-paste