### PR TITLE
Remove "remote" and "local" labels from HTTP server related metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.26.0
+
+* Removed "remote" and "local" labels from HTTP server related metrics to avoid a big growth of time series samples.
+
 ## 0.25.0
 
 * Fixed printing operation log at the proper logging level.

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -101,7 +101,7 @@ public class Application {
         return new MicrometerMetricsOptions()
                 .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
                 // define the labels on the HTTP server related metrics
-                .setLabels(EnumSet.of(Label.REMOTE, Label.LOCAL, Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE))
+                .setLabels(EnumSet.of(Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE))
                 // disable metrics about pool and verticles
                 .setDisabledMetricsCategories(set)
                 .setJvmMetricsEnabled(true)


### PR DESCRIPTION
This PR fixes #459 by removing "remote" and "local" labels from HTTP server related metrics.
It avoids a huge growth in the related time series samples on scraping.
I also tested this change on the Grafana dashboard we provide in Strimzi and there is no impact on it.