### PR TITLE
Removed metrics counters for the /metrics endpoint itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.26.0
 
 * Removed "remote" and "local" labels from HTTP server related metrics to avoid a big growth of time series samples.
+* Removed accounting HTTP server metrics for requests on the `/metrics` endpoint.
 
 ## 0.25.0
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -8,7 +8,6 @@ package io.strimzi.kafka.bridge.http;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.Application;
@@ -38,7 +37,6 @@ import io.vertx.ext.web.validation.BodyProcessorException;
 import io.vertx.ext.web.validation.ParameterProcessorException;
 import io.vertx.json.schema.ValidationException;
 import io.vertx.micrometer.Label;
-import io.vertx.micrometer.backends.BackendRegistries;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -182,10 +180,9 @@ public class HttpBridge extends AbstractVerticle {
                 this.router.errorHandler(HttpResponseStatus.NOT_FOUND.code(), this::errorHandler);
 
                 this.router.route("/metrics").handler(this::metricsHandler);
-                MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
-                if (meterRegistry != null) {
+                if (this.metricsReporter.getMeterRegistry() != null) {
                     // exclude to report the HTTP server metrics for the /metrics endpoint itself
-                    meterRegistry.config().meterFilter(
+                    this.metricsReporter.getMeterRegistry().config().meterFilter(
                             MeterFilter.deny(meter -> "/metrics".equals(meter.getTag(Label.HTTP_PATH.toString())))
                     );
                 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -186,8 +186,8 @@ public class HttpBridge extends AbstractVerticle {
                 if (meterRegistry != null) {
                     // exclude to report the HTTP server metrics for the /metrics endpoint itself
                     meterRegistry.config().meterFilter(
-                            MeterFilter.deny(meter -> meter.getTag(Label.HTTP_PATH.toString()) != null &&
-                                    meter.getTag(Label.HTTP_PATH.toString()).equals("/metrics")));
+                            MeterFilter.deny(meter -> "/metrics".equals(meter.getTag(Label.HTTP_PATH.toString())))
+                    );
                 }
 
                 log.info("Starting HTTP-Kafka bridge verticle...");


### PR DESCRIPTION
The bridge provides metrics counters (related to HTTP requests) for all the HTTP endpoints including the `/metrics` endpoint which will be scraped by Prometheus to get the ...  metrics.
Imho having metrics for the `/metrics` endpoint isn't that useful.
This PR use a `MeterFilter` to not expose such counters.
In relation to getting rid of Vert.x and moving to use Quarkus, this is what the metrics support in Quarkus does as well. Metrics on the default `/q/metrics` endpoint are not exposed.