### PR TITLE
Exposed metrics endpoint through the OpenAPI specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Removed "remote" and "local" labels from HTTP server related metrics to avoid a big growth of time series samples.
 * Removed accounting HTTP server metrics for requests on the `/metrics` endpoint.
+* Exposed the `/metrics` endpoint through the OpenAPI specification.
 
 ## 0.25.0
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -915,6 +915,27 @@ Check if the bridge is running. This does not necessarily imply that it is ready
 |===
 
 
+[[_metrics]]
+=== GET /metrics
+
+==== Description
+Retrieves the bridge metrics in Prometheus format.
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**200**|Metrics in Prometheus format retrieved successfully.|string
+|===
+
+
+==== Produces
+
+* `text/plain`
+
+
 [[_openapi]]
 === GET /openapi
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -53,7 +53,9 @@ public enum HttpOpenApiOperations {
     /** get the OpenAPI specification */
     OPENAPI("openapi"),
     /** get general information (i.e. version) about the bridge */
-    INFO("info");
+    INFO("info"),
+    /** get metrics (if enabled) in Prometheus format */
+    METRICS("metrics");
 
     private final String text;
 

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1355,6 +1355,24 @@
                 "description": "Retrieves the OpenAPI v2 specification in JSON format."
             }
         },
+        "/metrics": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Metrics in Prometheus format retrieved successfully."
+                    }
+                },
+                "operationId": "metrics",
+                "description": "Retrieves the bridge metrics in Prometheus format."
+            }
+        },
         "/": {
             "get": {
                 "responses": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1226,6 +1226,23 @@
         "description": "Retrieves the OpenAPI v2 specification in JSON format."
       }
     },
+    "/metrics": {
+      "get": {
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Metrics in Prometheus format retrieved successfully.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "operationId": "metrics",
+        "description": "Retrieves the bridge metrics in Prometheus format."
+      }
+    },
     "/": {
       "get": {
         "produces": [


### PR DESCRIPTION
The OpenAPI specification was missing the `/metrics` endpoint definition.
This PR fixes this issue.