### PR TITLE
Fixed OpenAPI 3.0 OffsetRecordSentList component schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Removed "remote" and "local" labels from HTTP server related metrics to avoid a big growth of time series samples.
 * Removed accounting HTTP server metrics for requests on the `/metrics` endpoint.
 * Exposed the `/metrics` endpoint through the OpenAPI specification.
+* Fixed OpenAPI 3.0 `OffsetRecordSentList` component schema returning proper record offsets or error.
 
 ## 0.25.0
 

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1542,7 +1542,14 @@
                     "offsets": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/OffsetRecordSent"
+                            "oneOf": [
+                                {
+                                    "$ref": "#/components/schemas/OffsetRecordSent"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            ]
                         }
                     }
                 },
@@ -1551,6 +1558,10 @@
                         {
                             "partition": 92,
                             "offset": 98
+                        },
+                        {
+                            "error_code": 404,
+                            "message": "Topic my-topic not present in metadata after 60000 ms."
                         },
                         {
                             "partition": 65,


### PR DESCRIPTION
This PR fixes #789
Unluckily it's not possible doing the same with old OpenAPI/Swagger 2.0 (because not supporting something like "oneOf") so we have to live with the current specification.