### PR TITLE
Fixed Stanislav Knot reference

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,24 @@
 			<organization>CN Group</organization>
 			<organizationUrl>https://www.cngroup.dk/</organizationUrl>
 		</developer>
+		<developer>
+			<name>Paul Mellor</name>
+			<email>pmellor@redhat.com</email>
+			<organization>Red Hat</organization>
+			<organizationUrl>https://www.redhat.com</organizationUrl>
+		</developer>
+		<developer>
+			<name>Lukáš Král</name>
+			<email>l.kral@outlook.com</email>
+			<organization>Red Hat</organization>
+			<organizationUrl>https://www.redhat.com</organizationUrl>
+		</developer>
+		<developer>
+			<name>Maroš Orsák</name>
+			<email>maros.orsak159@gmail.com</email>
+			<organization>Red Hat</organization>
+			<organizationUrl>https://www.redhat.com</organizationUrl>
+		</developer>
 	</developers>
 
         <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
 		</developer>
 		<developer>
 			<name>Stanislav Knot</name>
-			<email>sknot@redhat.com</email>
-			<organization>Red Hat</organization>
-			<organizationUrl>https://www.redhat.com</organizationUrl>
+			<email>knot@cngroup.dk</email>
+			<organization>CN Group</organization>
+			<organizationUrl>https://www.cngroup.dk/</organizationUrl>
 		</developer>
 	</developers>
 


### PR DESCRIPTION
Fixing information about Stanislav Knot maintainer in the pom.xml as they are in the Strimzi operator https://github.com/strimzi/strimzi-kafka-operator/blob/main/pom.xml#L65