### PR TITLE
Fixed async query parameter on POST only method

### DIFF
--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -656,6 +656,17 @@
                     },
                     "required": true
                 },
+                "parameters": [
+                    {
+                        "name": "async",
+                        "in": "query",
+                        "description": "Ignore metadata as result of the sending operation, not returning them to the client. If not specified it is false, metadata returned.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Records sent successfully.",
@@ -733,15 +744,6 @@
                     "required": true,
                     "schema": {
                         "type": "string"
-                    }
-                },
-                {
-                    "name": "async",
-                    "in": "query",
-                    "description": "Ignore metadata as result of the sending operation, not returning them to the client. If not specified it is false, metadata returned.",
-                    "required": false,
-                    "schema": {
-                        "type": "boolean"
                     }
                 }
             ]
@@ -1043,6 +1045,17 @@
                     },
                     "required": true
                 },
+                "parameters": [
+                    {
+                        "name": "async",
+                        "in": "query",
+                        "description": "Whether to return immediately upon sending records, instead of waiting for metadata. No offsets will be returned if specified. Defaults to false.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Records sent successfully.",
@@ -1129,15 +1142,6 @@
                     "required": true,
                     "schema": {
                         "type": "integer"
-                    }
-                },
-                {
-                    "name": "async",
-                    "in": "query",
-                    "description": "Whether to return immediately upon sending records, instead of waiting for metadata. No offsets will be returned if specified. Defaults to false.",
-                    "required": false,
-                    "schema": {
-                        "type": "boolean"
                     }
                 }
             ]


### PR DESCRIPTION
Both the `/topics/{topicname}` and `/topics/{topicname}/partitions/{partitionid}` paths allows `GET` and `POST` HTTP methods with a different meaning (retrieving topic/partition info, sending to topic/partition).
Anyway, the `async` query parameter is meaningful for `POST` method only.
This PR moves the `async` query parameter declaration, in the OpenAPI specification, to the POST method definition directly to make it clearer.
It also helps auto-generation tools which would generate a corresponding client code having a REST API method (in whatever programming language), without adding the `async` parameter when it's not really supported.