### PR TITLE
Using common creation metadata logic in the admin get topic

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
@@ -149,22 +149,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                         TopicDescription description = topicDescriptions.get(topicName);
                         if (description != null) {
                             description.partitions().forEach(partitionInfo -> {
-                                int leaderId = partitionInfo.leader().id();
-                                ObjectNode partition = JsonUtils.createObjectNode();
-                                partition.put("partition", partitionInfo.partition());
-                                partition.put("leader", leaderId);
-                                ArrayNode replicasArray = JsonUtils.createArrayNode();
-                                Set<Integer> insyncSet = new HashSet<Integer>();
-                                partitionInfo.isr().forEach(node -> insyncSet.add(node.id()));
-                                partitionInfo.replicas().forEach(node -> {
-                                    ObjectNode replica = JsonUtils.createObjectNode();
-                                    replica.put("broker", node.id());
-                                    replica.put("leader", leaderId == node.id());
-                                    replica.put("in_sync", insyncSet.contains(node.id()));
-                                    replicasArray.add(replica);
-                                });
-                                partition.put("replicas", replicasArray);
-                                partitionsArray.add(partition);
+                                partitionsArray.add(createPartitionMetadata(partitionInfo));
                             });
                         }
                         root.put("partitions", partitionsArray);


### PR DESCRIPTION
Trivial PR to reuse the logic for creating the partition metadata (in the admin get topic operation) instead of having duplicated code.