### PR TITLE
Fixed key and value definition of OpenAPI ConsumerRecord component schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Removed accounting HTTP server metrics for requests on the `/metrics` endpoint.
 * Exposed the `/metrics` endpoint through the OpenAPI specification.
 * Fixed OpenAPI 3.0 `OffsetRecordSentList` component schema returning proper record offsets or error.
+* Fixed OpenAPI `ConsumerRecord` component schema returning key and value not only as (JSON) string but even as object.
 
 ## 0.25.0
 

--- a/documentation/book/api/definitions.adoc
+++ b/documentation/book/api/definitions.adoc
@@ -51,15 +51,11 @@ __optional__|The unique name for the consumer instance. The name is unique withi
 |Name|Schema
 |**headers** +
 __optional__|<<_kafkaheaderlist,KafkaHeaderList>>
-|**key** +
-__optional__|string
 |**offset** +
 __optional__|integer (int64)
 |**partition** +
 __optional__|integer (int32)
 |**topic** +
-__optional__|string
-|**value** +
 __optional__|string
 |===
 

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1457,7 +1457,14 @@
                 },
                 "properties": {
                     "key": {
-                        "type": "string"
+                        "oneOf": [
+                            {
+                                "type": "object"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     },
                     "offset": {
                         "format": "int64",
@@ -1471,7 +1478,16 @@
                         "type": "string"
                     },
                     "value": {
-                        "type": "string"
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "nullable": true
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "nullable" : true
                     },
                     "headers": {
                         "$ref": "#/components/schemas/KafkaHeaderList"

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1321,7 +1321,10 @@
       },
       "properties": {
         "key": {
-          "type": "string"
+          "type": [
+            "object",
+            "string"
+          ]
         },
         "offset": {
           "format": "int64",
@@ -1335,7 +1338,11 @@
           "type": "string"
         },
         "value": {
-          "type": "string"
+          "type": [
+            "object",
+            "string",
+            "null"
+          ]
         },
         "headers": {
           "$ref": "#/definitions/KafkaHeaderList"


### PR DESCRIPTION
The current OpenAPI `ConsumerRecord` component schema definition has `key` and `value` just as string(s) while they can bring (JSON) object as well (it is already this way for the `ProducerRecord`).
This PR fixes this issue.