### PR TITLE
Fixed HTTP status code for ready and healthy endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Exposed the `/metrics` endpoint through the OpenAPI specification.
 * Fixed OpenAPI 3.0 `OffsetRecordSentList` component schema returning proper record offsets or error.
 * Fixed OpenAPI `ConsumerRecord` component schema returning key and value not only as (JSON) string but even as object.
+* Fixed OpenAPI HTTP status code returned by `/ready` and `/healthy`, from 200 to 204 because no content in the response.
 
 ## 0.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * Exposed the `/metrics` endpoint through the OpenAPI specification.
 * Fixed OpenAPI 3.0 `OffsetRecordSentList` component schema returning proper record offsets or error.
 * Fixed OpenAPI `ConsumerRecord` component schema returning key and value not only as (JSON) string but even as object.
-* Fixed OpenAPI HTTP status code returned by `/ready` and `/healthy`, from 200 to 204 because no content in the response.
+* Fixed OpenAPI HTTP status codes returned by `/ready` and `/healthy`:
+  * from 200 to 204 because no content in the response in case of success.
+  * added 404 in the specification for the failure case, as already returned by the bridge.
 
 ## 0.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fixed OpenAPI `ConsumerRecord` component schema returning key and value not only as (JSON) string but even as object.
 * Fixed OpenAPI HTTP status codes returned by `/ready` and `/healthy`:
   * from 200 to 204 because no content in the response in case of success.
-  * added 404 in the specification for the failure case, as already returned by the bridge.
+  * added 500 in the specification for the failure case, as already returned by the bridge.
 
 ## 0.25.0
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -912,6 +912,7 @@ Check if the bridge is running. This does not necessarily imply that it is ready
 |===
 |HTTP Code|Description|Schema
 |**200**|The bridge is healthy|No Content
+|**404**|The bridge is not healthy|No Content
 |===
 
 
@@ -970,6 +971,7 @@ Check if the bridge is ready and can accept requests.
 |===
 |HTTP Code|Description|Schema
 |**204**|The bridge is ready|No Content
+|**404**|The bridge is not ready|No Content
 |===
 
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -911,8 +911,8 @@ Check if the bridge is running. This does not necessarily imply that it is ready
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|The bridge is healthy|No Content
-|**404**|The bridge is not healthy|No Content
+|**204**|The bridge is healthy|No Content
+|**500**|The bridge is not healthy|No Content
 |===
 
 
@@ -971,7 +971,7 @@ Check if the bridge is ready and can accept requests.
 |===
 |HTTP Code|Description|Schema
 |**204**|The bridge is ready|No Content
-|**404**|The bridge is not ready|No Content
+|**500**|The bridge is not ready|No Content
 |===
 
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -948,7 +948,7 @@ Retrieves the OpenAPI v2 specification in JSON format.
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|OpenAPI v2 specification in JSON format retrieved successfully.|string
+|**204**|OpenAPI v2 specification in JSON format retrieved successfully.|string
 |===
 
 
@@ -969,7 +969,7 @@ Check if the bridge is ready and can accept requests.
 [options="header", cols=".^2a,.^14a,.^4a"]
 |===
 |HTTP Code|Description|Schema
-|**200**|The bridge is ready|No Content
+|**204**|The bridge is ready|No Content
 |===
 
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -510,12 +510,12 @@ public class HttpBridge extends AbstractVerticle {
     }
 
     private void healthy(RoutingContext routingContext) {
-        HttpResponseStatus httpResponseStatus = this.isAlive() ? HttpResponseStatus.NO_CONTENT : HttpResponseStatus.NOT_FOUND;
+        HttpResponseStatus httpResponseStatus = this.isAlive() ? HttpResponseStatus.NO_CONTENT : HttpResponseStatus.INTERNAL_SERVER_ERROR;
         HttpUtils.sendResponse(routingContext, httpResponseStatus.code(), null, null);
     }
 
     private void ready(RoutingContext routingContext) {
-        HttpResponseStatus httpResponseStatus = this.isReady() ? HttpResponseStatus.NO_CONTENT : HttpResponseStatus.NOT_FOUND;
+        HttpResponseStatus httpResponseStatus = this.isReady() ? HttpResponseStatus.NO_CONTENT : HttpResponseStatus.INTERNAL_SERVER_ERROR;
         HttpUtils.sendResponse(routingContext, httpResponseStatus.code(), null, null);
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -510,12 +510,12 @@ public class HttpBridge extends AbstractVerticle {
     }
 
     private void healthy(RoutingContext routingContext) {
-        HttpResponseStatus httpResponseStatus = this.isAlive() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
+        HttpResponseStatus httpResponseStatus = this.isAlive() ? HttpResponseStatus.NO_CONTENT : HttpResponseStatus.NOT_FOUND;
         HttpUtils.sendResponse(routingContext, httpResponseStatus.code(), null, null);
     }
 
     private void ready(RoutingContext routingContext) {
-        HttpResponseStatus httpResponseStatus = this.isReady() ? HttpResponseStatus.OK : HttpResponseStatus.NOT_FOUND;
+        HttpResponseStatus httpResponseStatus = this.isReady() ? HttpResponseStatus.NO_CONTENT : HttpResponseStatus.NOT_FOUND;
         HttpUtils.sendResponse(routingContext, httpResponseStatus.code(), null, null);
     }
 

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1324,6 +1324,9 @@
                 "responses": {
                     "204": {
                         "description": "The bridge is healthy"
+                    },
+                    "404": {
+                        "description": "The bridge is not healthy"
                     }
                 },
                 "operationId": "healthy",
@@ -1335,6 +1338,9 @@
                 "responses": {
                     "204": {
                         "description": "The bridge is ready"
+                    },
+                    "404": {
+                        "description": "The bridge is not ready"
                     }
                 },
                 "operationId": "ready",

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1325,7 +1325,7 @@
                     "204": {
                         "description": "The bridge is healthy"
                     },
-                    "404": {
+                    "500": {
                         "description": "The bridge is not healthy"
                     }
                 },
@@ -1339,7 +1339,7 @@
                     "204": {
                         "description": "The bridge is ready"
                     },
-                    "404": {
+                    "500": {
                         "description": "The bridge is not ready"
                     }
                 },

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1322,7 +1322,7 @@
         "/healthy": {
             "get": {
                 "responses": {
-                    "200": {
+                    "204": {
                         "description": "The bridge is healthy"
                     }
                 },
@@ -1333,7 +1333,7 @@
         "/ready": {
             "get": {
                 "responses": {
-                    "200": {
+                    "204": {
                         "description": "The bridge is ready"
                     }
                 },

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1192,6 +1192,9 @@
         "responses": {
           "200": {
             "description": "The bridge is healthy"
+          },
+          "404": {
+            "description": "The bridge is not healthy"
           }
         },
         "operationId": "healthy",
@@ -1203,6 +1206,9 @@
         "responses": {
           "204": {
             "description": "The bridge is ready"
+          },
+          "404": {
+            "description": "The bridge is not ready"
           }
         },
         "operationId": "ready",

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1201,7 +1201,7 @@
     "/ready": {
       "get": {
         "responses": {
-          "200": {
+          "204": {
             "description": "The bridge is ready"
           }
         },
@@ -1215,7 +1215,7 @@
           "application/json"
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": "OpenAPI v2 specification in JSON format retrieved successfully.",
             "schema": {
               "type": "string"

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1190,10 +1190,10 @@
     "/healthy": {
       "get": {
         "responses": {
-          "200": {
+          "204": {
             "description": "The bridge is healthy"
           },
-          "404": {
+          "500": {
             "description": "The bridge is not healthy"
           }
         },
@@ -1207,7 +1207,7 @@
           "204": {
             "description": "The bridge is ready"
           },
-          "404": {
+          "500": {
             "description": "The bridge is not ready"
           }
         },

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
@@ -34,7 +34,7 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
                     .send(ar -> {
                         context.verify(() -> {
                             assertThat(ar.succeeded(), is(true));
-                            assertThat(ar.result().statusCode(), is(HttpResponseStatus.OK.code()));
+                            assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
                         });
                         if (l == iterations) {
                             context.completeNow();
@@ -56,7 +56,7 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
                             LOGGER.info("Verifying that endpoint /healthy is ready " + ar.succeeded() + " for "
                                 + l + " time with status code " + ar.result().statusCode());
                             assertThat(ar.succeeded(), is(true));
-                            assertThat(ar.result().statusCode(), is(HttpResponseStatus.OK.code()));
+                            assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
                         });
                         if (l == iterations) {
                             LOGGER.info("Successfully completing the context");


### PR DESCRIPTION
The you hit the `/ready` and `/healthy` endpoints, no content is returned and the body is empty.
This mean that the more appropriate HTTP status code has to be `204` and not `200` as we have today.
This PR fixes this issue.
It also adds the `404` code in the OpenAPI specification, already returned by the bridge (but missing in the spec).