### PR TITLE
Update GitHub actions to newer versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     
     # Setup OpenJDK 11
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: '11'


### PR DESCRIPTION
This PR updates some of the GitHub actions we use for CodeQL.
It aligns the versions with what we are already using in the operator repository.