### PR TITLE
Updated to Ubuntu 22.04 and using pre-installed JDK version

### DIFF
--- a/.azure/templates/jobs/build_container.yaml
+++ b/.azure/templates/jobs/build_container.yaml
@@ -11,7 +11,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       - template: '../steps/setup_docker.yaml'

--- a/.azure/templates/jobs/build_docs.yaml
+++ b/.azure/templates/jobs/build_docs.yaml
@@ -17,7 +17,7 @@ jobs:
       - template: "../steps/maven_cache.yaml"
       - template: '../steps/setup_java.yaml'
         parameters:
-          JDK_VERSION: '11'
+          JDK_VERSION: 11
       - template: '../steps/setup_asciidoc.yaml'
       - bash: "make docu_html docu_htmlnoheader"
         displayName: "Build docs"

--- a/.azure/templates/jobs/build_docs.yaml
+++ b/.azure/templates/jobs/build_docs.yaml
@@ -6,7 +6,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Variables
     variables:
       MVN_CACHE_FOLDER: $(HOME)/.m2/repository
@@ -17,7 +17,6 @@ jobs:
       - template: "../steps/maven_cache.yaml"
       - template: '../steps/setup_java.yaml'
         parameters:
-          JDK_PATH: '/usr/lib/jvm/java-11-openjdk-amd64'
           JDK_VERSION: '11'
       - template: '../steps/setup_asciidoc.yaml'
       - bash: "make docu_html docu_htmlnoheader"

--- a/.azure/templates/jobs/build_docs.yaml
+++ b/.azure/templates/jobs/build_docs.yaml
@@ -1,12 +1,17 @@
 jobs:
   - job: 'build_docs'
     displayName: 'Build Docs'
+    strategy:
+      matrix:
+        'java-11':
+          image: 'Ubuntu-22.04'
+          jdk_version: '11'
     # Strategy for the job
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-22.04'
+      vmImage: $(image)
     # Variables
     variables:
       MVN_CACHE_FOLDER: $(HOME)/.m2/repository
@@ -16,6 +21,8 @@ jobs:
       # Get cached Maven repository
       - template: "../steps/maven_cache.yaml"
       - template: '../steps/setup_java.yaml'
+        parameters:
+          JDK_VERSION: $(jdk_version)
       - template: '../steps/setup_asciidoc.yaml'
       - bash: "make docu_html docu_htmlnoheader"
         displayName: "Build docs"

--- a/.azure/templates/jobs/build_docs.yaml
+++ b/.azure/templates/jobs/build_docs.yaml
@@ -16,8 +16,6 @@ jobs:
       # Get cached Maven repository
       - template: "../steps/maven_cache.yaml"
       - template: '../steps/setup_java.yaml'
-        parameters:
-          JDK_VERSION: 11
       - template: '../steps/setup_asciidoc.yaml'
       - bash: "make docu_html docu_htmlnoheader"
         displayName: "Build docs"

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -5,14 +5,12 @@ jobs:
     strategy:
       matrix:
         'java-11':
-          image: 'Ubuntu-20.04'
+          image: 'Ubuntu-22.04'
           jdk_version: '11'
-          jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
           main_build: 'true'
         'java-17':
-          image: 'Ubuntu-20.04'
+          image: 'Ubuntu-22.04'
           jdk_version: '17'
-          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
           main_build: 'false'
     # Set timeout for jobs
     timeoutInMinutes: 60
@@ -29,7 +27,6 @@ jobs:
       - template: "../steps/maven_cache.yaml"
       - template: '../steps/setup_java.yaml'
         parameters:
-          JDK_PATH: $(jdk_path)
           JDK_VERSION: $(jdk_version)
       - bash: "make spotbugs"
         displayName: "Spotbugs"

--- a/.azure/templates/jobs/deploy_java.yaml
+++ b/.azure/templates/jobs/deploy_java.yaml
@@ -5,7 +5,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       - task: DownloadPipelineArtifact@2

--- a/.azure/templates/jobs/publish_docs.yaml
+++ b/.azure/templates/jobs/publish_docs.yaml
@@ -5,7 +5,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       - task: DownloadPipelineArtifact@2

--- a/.azure/templates/jobs/push_container.yaml
+++ b/.azure/templates/jobs/push_container.yaml
@@ -5,7 +5,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-20.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       - template: '../steps/setup_docker.yaml'

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -9,4 +9,4 @@ steps:
       versionSpec: $(JDK_VERSION)
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
-      displayName: 'Configure Java'
+    displayName: 'Configure Java'

--- a/.azure/templates/steps/setup_java.yaml
+++ b/.azure/templates/steps/setup_java.yaml
@@ -1,35 +1,12 @@
 # Step to setup JAVA on the agent
-# We use openjdkX, where X is Java version (e.g. 11 for OpenJDK 11).
 parameters:
-  - name: JDK_PATH
-    default: '/usr/lib/jvm/java-11-openjdk-amd64'
   - name: JDK_VERSION
     default: '11'
 
 steps:
-  - bash: |
-      sudo apt-get update
-    displayName: 'Update package list'
-  - bash: |
-      sudo apt-get install openjdk-11-jdk
-    displayName: 'Install openjdk11'
-    condition: eq(variables['JDK_VERSION'], '11')
-  - bash: |
-      sudo apt-get install openjdk-17-jdk
-    displayName: 'Install openjdk17'
-    condition: eq(variables['JDK_VERSION'], '17')
-  - bash: |
-      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]11"
-      echo "##vso[task.setvariable variable=JAVA_VERSION]11"
-    displayName: 'Setup JAVA_VERSION=11'
-    condition: eq(variables['JDK_VERSION'], '11')
-  - bash: |
-      echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]17"
-      echo "##vso[task.setvariable variable=JAVA_VERSION]17"
-    displayName: 'Setup JAVA_VERSION=17'
-    condition: eq(variables['JDK_VERSION'], '17')
-  - bash: |
-      echo "##vso[task.setvariable variable=JAVA_HOME]$(JDK_PATH)"
-      echo "##vso[task.setvariable variable=JAVA_HOME__X64]$(JDK_PATH)"
-      echo "##vso[task.setvariable variable=PATH]$(jdk_path)/bin:$(PATH)"
-    displayName: 'Setup JAVA_HOME'
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: $(JDK_VERSION)
+      jdkArchitectureOption: 'x64'
+      jdkSourceOption: 'PreInstalled'
+      displayName: 'Configure Java'


### PR DESCRIPTION
As it's already in place for the operator repository, this PR updates Ubuntu and use pre-installed JDK version (for both Java 11 and 17 in the matrix).