### PR TITLE
Defer response logging to end handler

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperation.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperation.java
@@ -41,8 +41,8 @@ public abstract class HttpOpenApiOperation implements Handler<RoutingContext> {
     @Override
     public void handle(RoutingContext routingContext) {
         this.logRequest(routingContext);
+        routingContext.addEndHandler(ignoredResult -> this.logResponse(routingContext));
         this.process(routingContext);
-        this.logResponse(routingContext);
     }
 
     protected void logRequest(RoutingContext routingContext) {
@@ -74,4 +74,3 @@ public abstract class HttpOpenApiOperation implements Handler<RoutingContext> {
         return this.operationId;
     }
 }
- 


### PR DESCRIPTION
Defer logging of the HTTP status until after the response is ended.

Fixes #732 