### PR TITLE
Clean-up /tmp folder when starting the container

### DIFF
--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set +x
 
+# Clean-up /tmp directory from files which might have remained from previous container restart
+# We ignore any errors which might be caused by files injected by different agents which we do not have the rights to delete
+rm -rfv /tmp/* || true
+
 MYPATH="$(dirname "$0")"
 
 # Generate temporary keystore password


### PR DESCRIPTION
This small PR adds removal of the everything inside the `/tmp` folder.
It should fix the issue with crash looping Pod due to OOM (when the OOM was again caused because of full `/tmp` directory)

Fixes #753 