### PR TITLE
Updated snakeYAML 2.0 and JMX Prometheus Exporter 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fixed OpenAPI HTTP status codes returned by `/ready` and `/healthy`:
   * from 200 to 204 because no content in the response in case of success.
   * added 500 in the specification for the failure case, as already returned by the bridge.
-* Dependency updates (Vert.x 4.4.3, Netty 4.1.93.Final to align with Vert.x, Kafka 3.5.0)
+* Dependency updates (Vert.x 4.4.3, Netty 4.1.93.Final to align with Vert.x, Kafka 3.5.0, snakeYAML 2.0, JMX Prometheus Exporter 0.18.0)
 
 ## 0.25.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,12 +131,12 @@
 		<opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
 		<opentelemetry.version>1.19.0</opentelemetry.version>
 		<micrometer.version>1.9.5</micrometer.version>
-		<jmx-prometheus-collector.version>0.17.2</jmx-prometheus-collector.version>
+		<jmx-prometheus-collector.version>0.18.0</jmx-prometheus-collector.version>
 		<prometheus-simpleclient.version>0.16.0</prometheus-simpleclient.version>
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.103.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
-		<snakeyaml.version>1.33</snakeyaml.version>
+		<snakeyaml.version>2.0</snakeyaml.version>
 		<!-- property to skip surefire tests during failsafe execution -->
 		<!--suppress UnresolvedMavenProperty -->
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -354,8 +354,11 @@
 			<artifactId>kafka-env-var-config-provider</artifactId>
 			<version>${kafka-env-var-config-provider.version}</version>
 		</dependency>
-		<!-- Transitive dependency version overrides for Vulnerabilities: -->
-		<!-- overriding version of snakeyaml for prometheus.jmx.collector 0.12.0: Vulnerability: DOS and CVE-2022-41854 -->
+		<!--
+			snakeyaml is brought by prometheus.jmx.collector and vertx-web-openapi.
+			Having this transitive dependency override helps to take full control on it when we need a new release
+			because of CVEs but the above-mentioned components don't bring the fixed version yet
+		-->
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>


### PR DESCRIPTION
In the previous versions, we were dealing with Vert.x and the JMX Prometheus Exporter bringing different versions of snakeYAML and it was not possible to align to a common 2.0 because Vert.x couldn't work properly.
With newer version of Vert.x 4.4.3 we are finally able to get snakeYAML 2.0 which is brought by the newer JMX Prometheus Exporter as well.