### PR TITLE
Fixed wrong logger class

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeProducer.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletionStage;
  */
 public class KafkaBridgeProducer<K, V> {
 
-    private final Logger log = LoggerFactory.getLogger(KafkaBridgeConsumer.class);
+    private final Logger log = LoggerFactory.getLogger(KafkaBridgeProducer.class);
 
     private final KafkaConfig kafkaConfig;
     private final Serializer<K> keySerializer;


### PR DESCRIPTION
Trivial PR to fix a wrong logger class in the `KafkaBridgeProducer`.
This fixes #813 