### PR TITLE
Updated Vert.x 4.4.4 and Netty 4.1.94.Final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fixed OpenAPI HTTP status codes returned by `/ready` and `/healthy`:
   * from 200 to 204 because no content in the response in case of success.
   * added 500 in the specification for the failure case, as already returned by the bridge.
-* Dependency updates (Vert.x 4.4.3, Netty 4.1.93.Final to align with Vert.x, Kafka 3.5.0, snakeYAML 2.0, JMX Prometheus Exporter 0.18.0, Jackson 2.14.2)
+* Dependency updates (Vert.x 4.4.4, Netty 4.1.94.Final to align with Vert.x, Kafka 3.5.0, snakeYAML 2.0, JMX Prometheus Exporter 0.18.0, Jackson 2.14.2)
 
 ## 0.25.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
-		<vertx.version>4.4.3</vertx.version>
-		<netty.version>4.1.93.Final</netty.version>
+		<vertx.version>4.4.4</vertx.version>
+		<netty.version>4.1.94.Final</netty.version>
 		<kafka.version>3.5.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
Trivial PR to update Vert.x 4.4.4 and also direct Netty dependencies to 4.1.94.Final to align with what Vert.x 4.4.4 is bringing.