### PR TITLE
Decouple Vert.x version used for testing vs runtime components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<vertx.version>4.4.4</vertx.version>
+		<vertx-testing.version>4.4.4</vertx-testing.version>
 		<netty.version>4.1.94.Final</netty.version>
 		<kafka.version>3.5.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
@@ -380,37 +381,37 @@
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-kafka-client</artifactId>
-			<version>${vertx.version}</version>
+			<version>${vertx-testing.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-web-client</artifactId>
-			<version>${vertx.version}</version>
+			<version>${vertx-testing.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-junit5</artifactId>
-			<version>${vertx.version}</version>
+			<version>${vertx-testing.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-opentracing</artifactId>
-			<version>${vertx.version}</version>
+			<version>${vertx-testing.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-opentelemetry</artifactId>
-			<version>${vertx.version}</version>
+			<version>${vertx-testing.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-web-common</artifactId>
-			<version>${vertx.version}</version>
+			<version>${vertx-testing.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This trivial PR just adds a different property to specify the Vert.x version for dependencies used just for testing.
It helps if we need any differentiation and align with what we already have in the operator.