### PR TITLE
Fixed logging layout pattern

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -6,7 +6,7 @@ name = BridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -6,7 +6,7 @@ name = BridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -6,7 +6,7 @@ name = BridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d] %-5p <%-12.12c{1}:%L> [%-12.12t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console


### PR DESCRIPTION
The current layout pattern doesn't seem to show stuff good but cut words ... for example

```shell
[2023-07-11 18:00:24,989] INFO  <ppInfoParser:119> [oop-thread-0] Kafka version: 3.4.0
[2023-07-11 18:00:24,990] INFO  <ppInfoParser:120> [oop-thread-0] Kafka commitId: 2e1947d240607d53
[2023-07-11 18:00:24,990] INFO  <ppInfoParser:121> [oop-thread-0] Kafka startTimeMs: 1689091224985
[2023-07-11 18:00:25,052] INFO  <HttpBridge  :100> [oop-thread-0] HTTP-Kafka Bridge started and listening on port 8080
[2023-07-11 18:00:25,052] INFO  <HttpBridge  :101> [oop-thread-0] HTTP-Kafka Bridge bootstrap servers localhost:9092
[2023-07-11 18:00:25,053] INFO  <Application :125> [oop-thread-2] HTTP verticle instance deployed [202fb118-4226-4c83-aa96-a3892fa43e9d]
```

This PR gets the same layout pattern used by the Strimzi cluster operator which provides a much better format:

```shell
2023-07-11 18:00:42 INFO  [vert.x-eventloop-thread-0] AppInfoParser:119 - Kafka version: 3.5.0
2023-07-11 18:00:42 INFO  [vert.x-eventloop-thread-0] AppInfoParser:120 - Kafka commitId: c97b88d5db4de28d
2023-07-11 18:00:42 INFO  [vert.x-eventloop-thread-0] AppInfoParser:121 - Kafka startTimeMs: 1689091242812
2023-07-11 18:00:42 INFO  [vert.x-eventloop-thread-0] HttpBridge:102 - HTTP-Kafka Bridge started and listening on port 8080
2023-07-11 18:00:42 INFO  [vert.x-eventloop-thread-0] HttpBridge:103 - HTTP-Kafka Bridge bootstrap servers localhost:9092
2023-07-11 18:00:42 INFO  [vert.x-eventloop-thread-2] Application:125 - HTTP verticle instance deployed [4631cb80-bbbe-4f5a-ae70-0b45b4090265]
```