### PR TITLE
Updated OAuth to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fixed OpenAPI HTTP status codes returned by `/ready` and `/healthy`:
   * from 200 to 204 because no content in the response in case of success.
   * added 500 in the specification for the failure case, as already returned by the bridge.
-* Dependency updates (Vert.x 4.4.4, Netty 4.1.94.Final to align with Vert.x, Kafka 3.5.0, snakeYAML 2.0, JMX Prometheus Exporter 0.18.0, Jackson 2.14.2)
+* Dependency updates (Vert.x 4.4.4, Netty 4.1.94.Final to align with Vert.x, Kafka 3.5.0, snakeYAML 2.0, JMX Prometheus Exporter 0.18.0, Jackson 2.14.2, OAuth 0.13.0)
 
 ## 0.25.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 		<jackson-databind.version>2.14.2</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
-		<strimzi-oauth.version>0.12.0</strimzi-oauth.version>
+		<strimzi-oauth.version>0.13.0</strimzi-oauth.version>
 		<jaeger.version>1.8.1</jaeger.version>
 		<opentracing.version>0.33.0</opentracing.version>
 		<opentracing-kafka-client.version>0.1.15</opentracing-kafka-client.version>


### PR DESCRIPTION
This PR updates the OAuth dependency to the latest 0.13.0 release.
There is no special bullet point about it in the CHANGELOG (just mention) because AFAICS there are no specific improvements on the client side used by the bridge.