### PR TITLE
Bump Jackson to 2.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,8 @@
 		<sonatype.nexus.staging>1.6.7</sonatype.nexus.staging>
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
-		<jackson-core.version>2.14.2</jackson-core.version>
-		<jackson-databind.version>2.14.2</jackson-databind.version>
+		<jackson-core.version>2.15.2</jackson-core.version>
+		<jackson-databind.version>2.15.2</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
 		<strimzi-oauth.version>0.13.0</strimzi-oauth.version>


### PR DESCRIPTION
Trivial PR to bump Jackson deps to 2.15.2 to avoid potential vulnerabilities and align with latest update in the Strimzi operator https://github.com/strimzi/strimzi-kafka-operator/pull/8856