### PR TITLE
Removed jna dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,9 +566,6 @@
 									<ignoredUnusedDeclaredDependency>org.apache.tomcat.embed:tomcat-embed-core</ignoredUnusedDeclaredDependency>  <!-- CVE override -->
 									<!-- OpenTelemetry - used via classpath configuration -->
 									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-otlp</ignoredUnusedDeclaredDependency>
-									<!-- Required to be able to use the Test Container on different platforms such as Arm based Macs -->
-									<!-- Can be removed once the Strimzi Test Container is using new Test Container version (should be in Strimzi Test Container 0.103) -->
-									<ignoredUnusedDeclaredDependency>net.java.dev.jna:jna</ignoredUnusedDeclaredDependency>
 									<!-- OpenTelemetry - Vert.x using old version and OpenTelemetry breaking API compatibility. See dependency declaration for details. -->
 									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-sdk-trace</ignoredUnusedDeclaredDependency>
 								</ignoredUnusedDeclaredDependencies>


### PR DESCRIPTION
As commented in the pom file, this PR removes the `jna` dependency because we already moved to use test-container 0.104.0.
To confirm that the removal is safe, the mvn dependency tree reports the following:

```shell
[INFO] \- io.strimzi:strimzi-test-container:jar:0.104.0:test
[INFO]    +- org.testcontainers:testcontainers:jar:1.17.4:test
[INFO]    |  +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:test
[INFO]    |  |  \- org.jetbrains:annotations:jar:17.0.0:compile
[INFO]    |  \- com.github.docker-java:docker-java-transport-zerodep:jar:3.2.13:test
[INFO]    |     +- com.github.docker-java:docker-java-transport:jar:3.2.13:test
[INFO]    |     \- net.java.dev.jna:jna:jar:5.8.0:test
```

The `jna` dependency is the same as we had declared directly so it will work fine.