### PR TITLE
Updated CHANGELOG with 0.26.1 release and latest fix for future 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.27.0
+
+* Fixed logging Kafka TLS related password for trust/key stores on startup.
+
+## 0.26.1
+
+* Dependency updates (Kafka 3.5.1 [CVE-2023-34455](https://nvd.nist.gov/vuln/detail/CVE-2023-34455))
+
 ## 0.26.0
 
 * Removed "remote" and "local" labels from HTTP server related metrics to avoid a big growth of time series samples.


### PR DESCRIPTION
Trivial PR to reflect in the CHANGELOG what was done with 0.26.1 patch release and first fix for future 0.27.0.