### PR TITLE
Removed compiling code on spotbugs check

### DIFF
--- a/Makefile.maven
+++ b/Makefile.maven
@@ -27,5 +27,5 @@ java_clean:
 	mvn clean
 
 .PHONY: spotbugs
-spotbugs: java_compile
+spotbugs:
 	mvn $(MVN_ARGS) spotbugs:check


### PR DESCRIPTION
Trivial PR to avoid recompiling code everytime the spotbugs make target is executed.