### PR TITLE
Remove un-necessary encoding parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,6 @@
 							<headerLocation>.checkstyle/java.header</headerLocation>
 							<suppressionsLocation>.checkstyle/suppressions.xml</suppressionsLocation>
 							<includeTestSourceDirectory>true</includeTestSourceDirectory>
-							<encoding>UTF-8</encoding>
 							<consoleOutput>true</consoleOutput>
 							<failsOnError>true</failsOnError>
 						</configuration>


### PR DESCRIPTION
Copy of [1] but applies to the Strimzi Kafka Bridge project. 

[1] - https://github.com/strimzi/strimzi-kafka-operator/pull/9072