### PR TITLE
Update Kafka to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 		<vertx.version>4.4.4</vertx.version>
 		<vertx-testing.version>4.4.4</vertx-testing.version>
 		<netty.version>4.1.94.Final</netty.version>
-		<kafka.version>3.5.1</kafka.version>
+		<kafka.version>3.6.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<maven.checkstyle.version>3.3.0</maven.checkstyle.version>


### PR DESCRIPTION
This PR updates the Kafka version used by the Bridge to 3.6.0.