### PR TITLE
Some clean and deprecated method replaced

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
@@ -144,7 +144,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                         if (configEntries.size() > 0) {
                             ObjectNode configs = JsonUtils.createObjectNode();
                             configEntries.forEach(configEntry -> configs.put(configEntry.name(), configEntry.value()));
-                            root.put("configs", configs);
+                            root.set("configs", configs);
                         }
                         TopicDescription description = topicDescriptions.get(topicName);
                         if (description != null) {
@@ -152,7 +152,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
                                 partitionsArray.add(createPartitionMetadata(partitionInfo));
                             });
                         }
-                        root.put("partitions", partitionsArray);
+                        root.set("partitions", partitionsArray);
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                     } else if (ex.getCause() instanceof UnknownTopicOrPartitionException) {
                         HttpBridgeError error = new HttpBridgeError(
@@ -339,7 +339,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
             replica.put("in_sync", insyncSet.contains(node.id()));
             replicasArray.add(replica);
         });
-        root.put("replicas", replicasArray);
+        root.set("replicas", replicasArray);
         return root;
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -481,12 +481,12 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
                         }
                         for (Map.Entry<String, ArrayNode> part: partitions.entrySet()) {
                             ObjectNode topic = JsonUtils.createObjectNode();
-                            topic.put(part.getKey(), part.getValue());
+                            topic.set(part.getKey(), part.getValue());
                             partitionsArray.add(topic);
                         }
                         ArrayNode topicsArray = JsonUtils.createArrayNode(topics);
-                        root.put("topics", topicsArray);
-                        root.put("partitions", partitionsArray);
+                        root.set("topics", topicsArray);
+                        root.set("partitions", partitionsArray);
 
                         HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(root));
                     } else {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -196,7 +196,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
             }
             offsets.add(offset);
         }
-        jsonResponse.put("offsets", offsets);
+        jsonResponse.set("offsets", offsets);
         return jsonResponse;
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
@@ -110,7 +110,7 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
                 headers.add(header);
             }
             if (!headers.isEmpty()) {
-                jsonObject.put("headers", headers);
+                jsonObject.set("headers", headers);
             }
             jsonArray.add(jsonObject);
         }

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
@@ -91,9 +91,9 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
             ObjectNode jsonObject = JsonUtils.createObjectNode();
 
             jsonObject.put("topic", record.topic());
-            jsonObject.put("key", record.key() != null ?
+            jsonObject.set("key", record.key() != null ?
                     JsonUtils.bytesToJson(record.key()) : null);
-            jsonObject.put("value", record.value() != null ?
+            jsonObject.set("value", record.value() != null ?
                     JsonUtils.bytesToJson(record.value()) : null);
             jsonObject.put("partition", record.partition());
             jsonObject.put("offset", record.offset());
@@ -109,7 +109,7 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
                 headers.add(header);
             }
             if (!headers.isEmpty()) {
-                jsonObject.put("headers", headers);
+                jsonObject.set("headers", headers);
             }
             jsonArray.add(jsonObject);
         }

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
@@ -111,7 +111,7 @@ class OpenTelemetryHandle implements TracingHandle {
         return GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
     }
 
-    private static final TextMapGetter<RoutingContext> ROUTING_CONTEXT_GETTER = new TextMapGetter<RoutingContext>() {
+    private static final TextMapGetter<RoutingContext> ROUTING_CONTEXT_GETTER = new TextMapGetter<>() {
         @Override
         public Iterable<String> keys(RoutingContext rc) {
             return rc.request().headers().names();
@@ -126,7 +126,7 @@ class OpenTelemetryHandle implements TracingHandle {
         }
     };
 
-    private static final TextMapGetter<Map<String, String>> MG = new TextMapGetter<Map<String, String>>() {
+    private static final TextMapGetter<Map<String, String>> MG = new TextMapGetter<>() {
         @Override
         public Iterable<String> keys(Map<String, String> map) {
             return map.keySet();


### PR DESCRIPTION
Trivial PR to do a little bit of cleaning and deprecated method replacement (in Jackson databind when putting a JsonNode).