### PR TITLE
Fixed wrong oauth version in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Fixed logging Kafka TLS related password for trust/key stores on startup.
 * Sign containers using cosign
 * Generate and publish Software Bill of Materials (SBOMs) of Strimzi containers
-* Dependency updates (Kafka 3.6.0, OAuth 0.13.0)
+* Dependency updates (Kafka 3.6.0, OAuth 0.14.0)
 
 ## 0.26.1
 


### PR DESCRIPTION
Cherry picking from what we already had on the release-0.27.x branch about wrong OAuth version in the CHANGELOG.