### PR TITLE
Bumped Vert.x 4.4.6 and Netty 4.1.100.Final for CVE-2023-44487 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Sign containers using cosign
 * Generate and publish Software Bill of Materials (SBOMs) of Strimzi containers
 * Dependency updates (Kafka 3.6.0, OAuth 0.14.0)
+* Dependency updates (Vert.x 4.4.6, Netty 4.1.100.Final [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487))
 
 ## 0.26.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,9 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
-		<vertx.version>4.4.4</vertx.version>
-		<vertx-testing.version>4.4.4</vertx-testing.version>
-		<netty.version>4.1.94.Final</netty.version>
+		<vertx.version>4.4.6</vertx.version>
+		<vertx-testing.version>4.4.6</vertx-testing.version>
+		<netty.version>4.1.100.Final</netty.version>
 		<kafka.version>3.6.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.1</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
This PR bumps Vert.x and Netty for the CVE-2023-44487.