### PR TITLE
Use jackson bom to control version of all transitive jackson deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,7 @@
 		<sonatype.nexus.staging>1.6.7</sonatype.nexus.staging>
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
-		<jackson-core.version>2.15.2</jackson-core.version>
-		<jackson-databind.version>2.15.2</jackson-databind.version>
+		<jackson.version>2.15.2</jackson.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
 		<strimzi-oauth.version>0.14.0</strimzi-oauth.version>
@@ -140,6 +139,18 @@
 		<!--suppress UnresolvedMavenProperty -->
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
 	</properties>
+        
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>com.fasterxml.jackson</groupId>
+                                <artifactId>jackson-bom</artifactId>
+                                <version>${jackson.version}</version>
+                                <scope>import</scope>
+                                <type>pom</type>
+                        </dependency>   
+                </dependencies>
+        </dependencyManagement>
 
 	<dependencies>
 		<dependency>
@@ -288,25 +299,16 @@
 			<artifactId>commons-cli</artifactId>
 			<version>${commons-cli.version}</version>
 		</dependency>
+                <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                </dependency>
+
 		<!-- Kubernetes Configuration Provider for Apache Kafka -->
 		<dependency>
 			<groupId>io.strimzi</groupId>
 			<artifactId>kafka-kubernetes-config-provider</artifactId>
 			<version>${kafka-kubernetes-config-provider.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-annotations</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<!-- EnvVar Configuration Provider for Apache Kafka -->
 		<dependency>
@@ -323,12 +325,6 @@
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
 			<version>${snakeyaml.version}</version>
-		</dependency>
-		<!-- Used only for test in the bridge, but needs to be here because OAuth brings it but a potential Maven bug remove it as runtime if only for test -->
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>${jackson-databind.version}</version>
 		</dependency>
 		<!-- Testing -->
 		<dependency>
@@ -504,8 +500,6 @@
 								<ignoredNonTestScopedDependencies>
 									<!-- OpenTelemetry - The SDK is using this at runtime to load the Vert.x “context storage provider”. To ignore because it is detected as used for test only. -->
 									<ignoredNonTestScopedDependency>io.vertx:vertx-opentelemetry</ignoredNonTestScopedDependency>
-									<!-- Used only for test in the bridge but needed by OAuth. If left "test" scoped, a potential Maven bug remove it from the runtime -->
-									<ignoredNonTestScopedDependencies>com.fasterxml.jackson.core:jackson-databind</ignoredNonTestScopedDependencies>
 								</ignoredNonTestScopedDependencies>
 								<ignoredUnusedDeclaredDependencies>
 									<ignoredUnusedDeclaredDependency>io.strimzi:kafka-env-var-config-provider</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
Why:
The 0.27 dist contains a mix of jackson versions, and there is what I think is a rotten comment in the pom.xml that jackson-databind is a test only dependency when we have usages in `src/main` like src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java

```
./com.fasterxml.jackson.core.jackson-annotations-2.15.2.jar
./com.fasterxml.jackson.core.jackson-core-2.15.0.jar
./com.fasterxml.jackson.core.jackson-databind-2.15.2.jar
./com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.14.2.jar
./com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.14.2.jar
```

We can use `jackson-bom` so everything is aligned on 2.15.2 without having to exclude transitive deps and include jackson-databind in the dependency analysis when checking for undeclared-but-used dependencies.

With the change you get:
```
mvn dependency:tree | grep jackson
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.15.2:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2:compile
[INFO] |  |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.15.2:compile
[INFO] |  |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.2:compile
```