### PR TITLE
Removed tracing related param which was used with OpenTracing only

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -283,7 +283,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
         if (ex == null) {
 
             for (ConsumerRecord<K, V> record : records) {
-                tracing.handleRecordSpan(span, record);
+                tracing.handleRecordSpan(record);
             }
             span.inject(routingContext);
 

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/NoopTracingHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/NoopTracingHandle.java
@@ -33,7 +33,7 @@ final class NoopTracingHandle implements TracingHandle {
     }
 
     @Override
-    public <K, V> void handleRecordSpan(SpanHandle<K, V> parentSpanHandle, ConsumerRecord<K, V> record) {
+    public <K, V> void handleRecordSpan(ConsumerRecord<K, V> record) {
     }
 
     @Override

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
@@ -89,7 +89,7 @@ class OpenTelemetryHandle implements TracingHandle {
     }
 
     @Override
-    public <K, V> void handleRecordSpan(SpanHandle<K, V> parentSpanHandle, ConsumerRecord<K, V> record) {
+    public <K, V> void handleRecordSpan(ConsumerRecord<K, V> record) {
         String operationName = record.topic() + " " + MessageOperation.RECEIVE;
         SpanBuilder spanBuilder = get().spanBuilder(operationName);
         Context parentContext = propagator().extract(Context.current(), TracingUtil.toHeaders(record), MG);

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/TracingHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/TracingHandle.java
@@ -51,10 +51,9 @@ public interface TracingHandle {
      *
      * @param <K> key type
      * @param <V> value type
-     * @param parentSpanHandle parent span handle
      * @param record Kafka consumer record
      */
-    <K, V>  void handleRecordSpan(SpanHandle<K, V> parentSpanHandle, ConsumerRecord<K, V> record);
+    <K, V>  void handleRecordSpan(ConsumerRecord<K, V> record);
 
     /**
      * Add producer properties, if any.


### PR DESCRIPTION
Trivial PR to remove a parameter from the tracing handling methods. It was used only for OpenTracing support which is now gone.