### PR TITLE
Bump Vert.x and Jackson dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0
 
-* Dependency updates (Kubernetes configuration provider)
+* Dependency updates (Kubernetes configuration provider 1.1.2, Vert.x 4.5.0)
 
 ## 0.27.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.21</slf4j.version>
-		<vertx.version>4.4.6</vertx.version>
-		<vertx-testing.version>4.4.6</vertx-testing.version>
+		<vertx.version>4.5.0</vertx.version>
+		<vertx-testing.version>4.5.0</vertx-testing.version>
 		<netty.version>4.1.100.Final</netty.version>
 		<kafka.version>3.6.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
@@ -122,8 +122,8 @@
 		<sonatype.nexus.staging>1.6.7</sonatype.nexus.staging>
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
-		<jackson-core.version>2.15.2</jackson-core.version>
-		<jackson-databind.version>2.15.2</jackson-databind.version>
+		<jackson-core.version>2.15.3</jackson-core.version>
+		<jackson-databind.version>2.15.3</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
 		<strimzi-oauth.version>0.14.0</strimzi-oauth.version>


### PR DESCRIPTION
This PR bumps Vert.x and Jackson dependencies' versions to align with latest update on the Strimzi operator.