### PR TITLE
Trying to add retries on s390x tests failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     os: linux
     arch: s390x
     jdk: openjdk11
-    script: mvn install -Dmaven.javadoc.skip=true
+    script: mvn install -Dmaven.javadoc.skip=true -Dsurefire.rerunFailingTestsCount=10
     addons:
       apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
     arch: s390x
     jdk: openjdk11
     # because of flakiness of tests on s390x, adding automatic retries on failure
-    script: mvn install -Dmaven.javadoc.skip=true -Dsurefire.rerunFailingTestsCount=10
+    script: mvn install -Dmaven.javadoc.skip=true -Dfailsafe.rerunFailingTestsCount=10
     addons:
       apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
     os: linux
     arch: s390x
     jdk: openjdk11
+    # because of flakiness of tests on s390x, adding automatic retries on failure
     script: mvn install -Dmaven.javadoc.skip=true -Dsurefire.rerunFailingTestsCount=10
     addons:
       apt:


### PR DESCRIPTION
Travis CI s390x pipeline only seems to have a lot of flakyness with tests failing.
This PR adds some retries to make it more automatic (instead of me re-run jobs more and more times).