### PR TITLE
Added missing messaging semantic attributes on the consumer spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.28.0
 
 * Dependency updates (Kafka 3.6.1, Kubernetes configuration provider 1.1.2, Vert.x 4.5.0)
+* Fixed missing messaging semantic attributes to the Kafka consumer spans
 
 ## 0.27.0
 

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
@@ -92,6 +92,9 @@ class OpenTelemetryHandle implements TracingHandle {
     public <K, V> void handleRecordSpan(ConsumerRecord<K, V> record) {
         String operationName = record.topic() + " " + MessageOperation.RECEIVE;
         SpanBuilder spanBuilder = get().spanBuilder(operationName);
+        spanBuilder.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, record.topic());
+        spanBuilder.setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND, SemanticAttributes.MessagingDestinationKindValues.TOPIC);
+        spanBuilder.setAttribute(SemanticAttributes.MESSAGING_SYSTEM, "kafka");
         Context parentContext = propagator().extract(Context.current(), TracingUtil.toHeaders(record), MG);
         if (parentContext != null) {
             Span parentSpan = Span.fromContext(parentContext);

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
@@ -90,7 +91,7 @@ class OpenTelemetryHandle implements TracingHandle {
 
     @Override
     public <K, V> void handleRecordSpan(ConsumerRecord<K, V> record) {
-        String operationName = record.topic() + " " + MessageOperation.RECEIVE;
+        String operationName = record.topic() + " " + MessageOperation.RECEIVE.name().toLowerCase(Locale.ROOT);
         SpanBuilder spanBuilder = get().spanBuilder(operationName);
         spanBuilder.setAttribute(SemanticAttributes.MESSAGING_DESTINATION, record.topic());
         spanBuilder.setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND, SemanticAttributes.MessagingDestinationKindValues.TOPIC);


### PR DESCRIPTION
The current bridge implementation uses the Kafka producer interceptor way for injecting span on producing (by using the OpenTelemetry implementation) but it doesn't the same on the consumer side (because producer and consumers span are not linked the right way, as the OTel community is working to fix for the future).
For this reason we generate the Kafka consumer span manually but right now we are missing some "messaging" related smantic attributes which are added by the OTel interceptor on producer automatically.
This PR fixes this problem.