### PR TITLE
Update Vert.x to 4.5.2 and other related dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0
 
-* Dependency updates (Kafka 3.6.1, Kubernetes configuration provider 1.1.2, Vert.x 4.5.1, Netty 4.1.103.Final)
+* Dependency updates (Kafka 3.6.1, Kubernetes configuration provider 1.1.2, Vert.x 4.5.2, Netty 4.1.106.Final, Jackson FasterXML 2.16.1)
 * Fixed missing messaging semantic attributes to the Kafka consumer spans
 
 ## 0.27.0

--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,9 @@
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<vertx.version>4.5.1</vertx.version>
-		<vertx-testing.version>4.5.1</vertx-testing.version>
-		<netty.version>4.1.103.Final</netty.version>
+		<vertx.version>4.5.2</vertx.version>
+		<vertx-testing.version>4.5.2</vertx-testing.version>
+		<netty.version>4.1.106.Final</netty.version>
 		<kafka.version>3.6.1</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
@@ -122,8 +122,8 @@
 		<sonatype.nexus.staging>1.6.7</sonatype.nexus.staging>
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
-		<jackson-core.version>2.15.3</jackson-core.version>
-		<jackson-databind.version>2.15.3</jackson-databind.version>
+		<jackson-core.version>2.16.1</jackson-core.version>
+		<jackson-databind.version>2.16.1</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
 		<strimzi-oauth.version>0.14.0</strimzi-oauth.version>


### PR DESCRIPTION
This PR updates Vert.x to 4.5.2 that among other things addresses [CVE-2024-1023](https://access.redhat.com/security/cve/cve-2024-1023). It also bumps the related dependencies: Jakcson FasterXML and Netty to the versions used by Vert.x. It does not update SLF4j to 2.x as that does not seem to be fully ocmpatible with the Log4j2 version used. That change should be discussed separately for all of our projects (keeping old SLF4J 1.7.36 works fine with Vert.x 4.5.2).