### PR TITLE
Use Log4j2 instead of SLF4J for our own loggers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,6 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
-		<slf4j.version>1.7.36</slf4j.version>
 		<vertx.version>4.5.2</vertx.version>
 		<vertx-testing.version>4.5.2</vertx-testing.version>
 		<netty.version>4.1.106.Final</netty.version>
@@ -193,9 +192,9 @@
 			<version>${netty.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -24,8 +24,8 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.management.MalformedObjectNameException;
 import java.io.BufferedReader;
@@ -44,8 +44,7 @@ import java.util.stream.Collectors;
  * Apache Kafka bridge main application class
  */
 public class Application {
-
-    private static final Logger log = LoggerFactory.getLogger(Application.class);
+    private static final Logger LOGGER = LogManager.getLogger(Application.class);
 
     private static final String KAFKA_BRIDGE_METRICS_ENABLED = "KAFKA_BRIDGE_METRICS_ENABLED";
 
@@ -55,12 +54,12 @@ public class Application {
      * @param args command line arguments
      */
     public static void main(String[] args) {
-        log.info("Strimzi Kafka Bridge {} is starting", Application.class.getPackage().getImplementationVersion());
+        LOGGER.info("Strimzi Kafka Bridge {} is starting", Application.class.getPackage().getImplementationVersion());
         try {
             VertxOptions vertxOptions = new VertxOptions();
             JmxCollectorRegistry jmxCollectorRegistry = null;
             if (Boolean.parseBoolean(System.getenv(KAFKA_BRIDGE_METRICS_ENABLED))) {
-                log.info("Metrics enabled and exposed on the /metrics endpoint");
+                LOGGER.info("Metrics enabled and exposed on the /metrics endpoint");
                 // setup Micrometer metrics options
                 vertxOptions.setMetricsOptions(metricsOptions());
                 jmxCollectorRegistry = getJmxCollectorRegistry();
@@ -75,7 +74,7 @@ public class Application {
 
             Map<String, Object> config = ConfigRetriever.getConfig(absoluteFilePath(commandLine.getOptionValue("config-file")));
             BridgeConfig bridgeConfig = BridgeConfig.fromMap(config);
-            log.info("Bridge configuration {}", bridgeConfig);
+            LOGGER.info("Bridge configuration {}", bridgeConfig);
 
             deployHttpBridge(vertx, bridgeConfig, metricsReporter).onComplete(done -> {
                 if (done.succeeded()) {
@@ -84,7 +83,7 @@ public class Application {
                 }
             });
         } catch (RuntimeException | MalformedObjectNameException | IOException | ParseException e) {
-            log.error("Error starting the bridge", e);
+            LOGGER.error("Error starting the bridge", e);
             System.exit(1);
         }
     }
@@ -122,10 +121,10 @@ public class Application {
         HttpBridge httpBridge = new HttpBridge(bridgeConfig, metricsReporter);
         vertx.deployVerticle(httpBridge, done -> {
             if (done.succeeded()) {
-                log.info("HTTP verticle instance deployed [{}]", done.result());
+                LOGGER.info("HTTP verticle instance deployed [{}]", done.result());
                 httpPromise.complete(httpBridge);
             } else {
-                log.error("Failed to deploy HTTP verticle instance", done.cause());
+                LOGGER.error("Failed to deploy HTTP verticle instance", done.cause());
                 httpPromise.fail(done.cause());
             }
         });

--- a/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeAdmin.java
+++ b/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeAdmin.java
@@ -13,8 +13,8 @@ import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletionStage;
  * Represents a Kafka bridge admin client
  */
 public class KafkaBridgeAdmin {
-    private final Logger log = LoggerFactory.getLogger(KafkaBridgeAdmin.class);
+    private static final Logger LOGGER = LogManager.getLogger(KafkaBridgeAdmin.class);
 
     private final KafkaConfig kafkaConfig;
     private AdminClient adminClient;
@@ -68,13 +68,13 @@ public class KafkaBridgeAdmin {
      * @return a CompletionStage bringing the set of topics
      */
     public CompletionStage<Set<String>> listTopics() {
-        log.trace("List topics thread {}", Thread.currentThread());
-        log.info("List topics");
+        LOGGER.trace("List topics thread {}", Thread.currentThread());
+        LOGGER.info("List topics");
         CompletableFuture<Set<String>> promise = new CompletableFuture<>();
         this.adminClient.listTopics()
                 .names()
                 .whenComplete((topics, exception) -> {
-                    log.trace("List topics callback thread {}", Thread.currentThread());
+                    LOGGER.trace("List topics callback thread {}", Thread.currentThread());
                     if (exception == null) {
                         promise.complete(topics);
                     } else {
@@ -91,13 +91,13 @@ public class KafkaBridgeAdmin {
      * @return a CompletionStage bringing the description of the specified topics.
      */
     public CompletionStage<Map<String, TopicDescription>> describeTopics(List<String> topicNames) {
-        log.trace("Describe topics thread {}", Thread.currentThread());
-        log.info("Describe topics {}", topicNames);
+        LOGGER.trace("Describe topics thread {}", Thread.currentThread());
+        LOGGER.info("Describe topics {}", topicNames);
         CompletableFuture<Map<String, TopicDescription>> promise = new CompletableFuture<>();
         this.adminClient.describeTopics(topicNames)
                 .allTopicNames()
                 .whenComplete((topics, exception) -> {
-                    log.trace("Describe topics callback thread {}", Thread.currentThread());
+                    LOGGER.trace("Describe topics callback thread {}", Thread.currentThread());
                     if (exception == null) {
                         promise.complete(topics);
                     } else {
@@ -114,13 +114,13 @@ public class KafkaBridgeAdmin {
      * @return a CompletionStage bringing the configuration of the specified resources.
      */
     public CompletionStage<Map<ConfigResource, Config>> describeConfigs(List<ConfigResource> configResources) {
-        log.trace("Describe configs thread {}", Thread.currentThread());
-        log.info("Describe configs {}", configResources);
+        LOGGER.trace("Describe configs thread {}", Thread.currentThread());
+        LOGGER.info("Describe configs {}", configResources);
         CompletableFuture<Map<ConfigResource, Config>> promise = new CompletableFuture<>();
         this.adminClient.describeConfigs(configResources)
                 .all()
                 .whenComplete((configs, exception) -> {
-                    log.trace("Describe configs callback thread {}", Thread.currentThread());
+                    LOGGER.trace("Describe configs callback thread {}", Thread.currentThread());
                     if (exception == null) {
                         promise.complete(configs);
                     } else {
@@ -137,13 +137,13 @@ public class KafkaBridgeAdmin {
      * @return a CompletionStage bringing the offset spec for the given partition.
      */
     public CompletionStage<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {
-        log.trace("Get offsets thread {}", Thread.currentThread());
-        log.info("Get the offset spec for partition {}", topicPartitionOffsets);
+        LOGGER.trace("Get offsets thread {}", Thread.currentThread());
+        LOGGER.info("Get the offset spec for partition {}", topicPartitionOffsets);
         CompletableFuture<Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo>> promise = new CompletableFuture<>();
         this.adminClient.listOffsets(topicPartitionOffsets)
                 .all()
                 .whenComplete((offsets, exception) -> {
-                    log.trace("Get offsets callback thread {}", Thread.currentThread());
+                    LOGGER.trace("Get offsets callback thread {}", Thread.currentThread());
                     if (exception == null) {
                         promise.complete(offsets);
                     } else {

--- a/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeConsumer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeConsumer.java
@@ -14,8 +14,8 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.time.Duration;
 import java.util.HashSet;
@@ -33,8 +33,7 @@ import java.util.stream.Collectors;
  * @param <V>   type of Kafka message payload
  */
 public class KafkaBridgeConsumer<K, V> {
-
-    private final Logger log = LoggerFactory.getLogger(KafkaBridgeConsumer.class);
+    private static final Logger LOGGER = LogManager.getLogger(KafkaBridgeConsumer.class);
 
     private final KafkaConfig kafkaConfig;
     private final Deserializer<K> keyDeserializer;
@@ -102,9 +101,9 @@ public class KafkaBridgeConsumer<K, V> {
             return;
         }
 
-        log.info("Subscribe to topics {}", topicSubscriptions);
+        LOGGER.info("Subscribe to topics {}", topicSubscriptions);
         Set<String> topics = topicSubscriptions.stream().map(SinkTopicSubscription::getTopic).collect(Collectors.toSet());
-        log.trace("Subscribe thread {}", Thread.currentThread());
+        LOGGER.trace("Subscribe thread {}", Thread.currentThread());
         this.consumer.subscribe(topics, loggingPartitionsRebalance);
     }
 
@@ -112,8 +111,8 @@ public class KafkaBridgeConsumer<K, V> {
      * Unsubscribe all the topics which the consumer currently subscribes
      */
     public void unsubscribe() {
-        log.info("Unsubscribe from topics");
-        log.trace("Unsubscribe thread {}", Thread.currentThread());
+        LOGGER.info("Unsubscribe from topics");
+        LOGGER.trace("Unsubscribe thread {}", Thread.currentThread());
         this.consumer.unsubscribe();
     }
 
@@ -123,8 +122,8 @@ public class KafkaBridgeConsumer<K, V> {
      * @return set of topic partitions to which the consumer is subscribed
      */
     public Set<TopicPartition> listSubscriptions() {
-        log.info("Listing subscribed topics");
-        log.trace("ListSubscriptions thread {}", Thread.currentThread());
+        LOGGER.info("Listing subscribed topics");
+        LOGGER.trace("ListSubscriptions thread {}", Thread.currentThread());
         return this.consumer.assignment();
     }
 
@@ -134,8 +133,8 @@ public class KafkaBridgeConsumer<K, V> {
      * @param pattern Java regex for topics subscription
      */
     public void subscribe(Pattern pattern) {
-        log.info("Subscribe to topics with pattern {}", pattern);
-        log.trace("Subscribe thread {}", Thread.currentThread());
+        LOGGER.info("Subscribe to topics with pattern {}", pattern);
+        LOGGER.trace("Subscribe thread {}", Thread.currentThread());
         this.consumer.subscribe(pattern, loggingPartitionsRebalance);
     }
 
@@ -149,7 +148,7 @@ public class KafkaBridgeConsumer<K, V> {
             throw new IllegalArgumentException("Topic subscriptions cannot be null");
         }
 
-        log.info("Assigning to topics partitions {}", topicSubscriptions);
+        LOGGER.info("Assigning to topics partitions {}", topicSubscriptions);
         // TODO: maybe we don't need the SinkTopicSubscription class anymore? Removing "offset" field, it's now the same as TopicPartition class?
         Set<TopicPartition> topicPartitions = new HashSet<>();
         for (SinkTopicSubscription topicSubscription : topicSubscriptions) {
@@ -161,7 +160,7 @@ public class KafkaBridgeConsumer<K, V> {
             return;
         }
 
-        log.trace("Assign thread {}", Thread.currentThread());
+        LOGGER.trace("Assign thread {}", Thread.currentThread());
         this.consumer.assign(topicPartitions);
     }
 
@@ -172,7 +171,7 @@ public class KafkaBridgeConsumer<K, V> {
      * @return records polled from the Kafka cluster
      */
     public ConsumerRecords<K, V> poll(long timeout) {
-        log.trace("Poll thread {}", Thread.currentThread());
+        LOGGER.trace("Poll thread {}", Thread.currentThread());
         return this.consumer.poll(Duration.ofMillis(timeout));
     }
 
@@ -183,7 +182,7 @@ public class KafkaBridgeConsumer<K, V> {
      * @return map containing topic partitions and corresponding committed offsets
      */
     public Map<TopicPartition, OffsetAndMetadata> commit(Map<TopicPartition, OffsetAndMetadata> offsetsData) {
-        log.trace("Commit thread {}", Thread.currentThread());
+        LOGGER.trace("Commit thread {}", Thread.currentThread());
         // TODO: doesn't it make sense to change using the commitAsync?
         //       does it still make sense to return the offsets we get as parameter?
         this.consumer.commitSync(offsetsData);
@@ -194,7 +193,7 @@ public class KafkaBridgeConsumer<K, V> {
      * Commit offsets returned on the last poll() for all the subscribed list of topics and partitions
      */
     public void commitLastPolledOffsets() {
-        log.trace("Commit thread {}", Thread.currentThread());
+        LOGGER.trace("Commit thread {}", Thread.currentThread());
         // TODO: doesn't it make sense to change using the commitAsync?
         this.consumer.commitSync();
     }
@@ -206,7 +205,7 @@ public class KafkaBridgeConsumer<K, V> {
      * @param offset offset to seek to on the topic partition
      */
     public void seek(TopicPartition topicPartition, long offset) {
-        log.trace("Seek thread {}", Thread.currentThread());
+        LOGGER.trace("Seek thread {}", Thread.currentThread());
         this.consumer.seek(topicPartition, offset);
     }
 
@@ -216,7 +215,7 @@ public class KafkaBridgeConsumer<K, V> {
      * @param topicPartitionSet set of topic partition on which to seek at the beginning
      */
     public void seekToBeginning(Set<TopicPartition> topicPartitionSet) {
-        log.trace("SeekToBeginning thread {}", Thread.currentThread());
+        LOGGER.trace("SeekToBeginning thread {}", Thread.currentThread());
         this.consumer.seekToBeginning(topicPartitionSet);
     }
 
@@ -226,7 +225,7 @@ public class KafkaBridgeConsumer<K, V> {
      * @param topicPartitionSet set of topic partition on which to seek at the end
      */
     public void seekToEnd(Set<TopicPartition> topicPartitionSet) {
-        log.trace("SeekToEnd thread {}", Thread.currentThread());
+        LOGGER.trace("SeekToEnd thread {}", Thread.currentThread());
         this.consumer.seekToEnd(topicPartitionSet);
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeProducer.java
+++ b/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeProducer.java
@@ -13,8 +13,8 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.Serializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
@@ -24,8 +24,7 @@ import java.util.concurrent.CompletionStage;
  * Represents a Kafka bridge producer client
  */
 public class KafkaBridgeProducer<K, V> {
-
-    private final Logger log = LoggerFactory.getLogger(KafkaBridgeProducer.class);
+    private static final Logger LOGGER = LogManager.getLogger(KafkaBridgeProducer.class);
 
     private final KafkaConfig kafkaConfig;
     private final Serializer<K> keySerializer;
@@ -56,11 +55,11 @@ public class KafkaBridgeProducer<K, V> {
      */
     public CompletionStage<RecordMetadata> send(ProducerRecord<K, V> record) {
         CompletableFuture<RecordMetadata> promise = new CompletableFuture<>();
-        log.trace("Send thread {}", Thread.currentThread());
-        log.debug("Sending record {}", record);
+        LOGGER.trace("Send thread {}", Thread.currentThread());
+        LOGGER.debug("Sending record {}", record);
         this.producer.send(record, (metadata, exception) -> {
-            log.trace("Kafka client callback thread {}", Thread.currentThread());
-            log.debug("Sent record {} at offset {}", record, metadata.offset());
+            LOGGER.trace("Kafka client callback thread {}", Thread.currentThread());
+            LOGGER.debug("Sent record {} at offset {}", record, metadata.offset());
             if (exception == null) {
                 promise.complete(metadata);
             } else {
@@ -76,8 +75,8 @@ public class KafkaBridgeProducer<K, V> {
      * @param record Kafka record to send
      */
     public void sendIgnoreResult(ProducerRecord<K, V> record) {
-        log.trace("Send ignore result thread {}", Thread.currentThread());
-        log.debug("Sending record {}", record);
+        LOGGER.trace("Send ignore result thread {}", Thread.currentThread());
+        LOGGER.debug("Sending record {}", record);
         this.producer.send(record);
     }
 

--- a/src/main/java/io/strimzi/kafka/bridge/LoggingPartitionsRebalance.java
+++ b/src/main/java/io/strimzi/kafka/bridge/LoggingPartitionsRebalance.java
@@ -7,8 +7,8 @@ package io.strimzi.kafka.bridge;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 
@@ -17,27 +17,26 @@ import java.util.Collection;
  * It just logs partitions if enabled
  */
 public class LoggingPartitionsRebalance implements ConsumerRebalanceListener {
-
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LogManager.getLogger(LoggingPartitionsRebalance.class);
 
     @Override
     public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-        log.debug("Partitions revoked {}", partitions.size());
+        LOGGER.debug("Partitions revoked {}", partitions.size());
 
-        if (log.isDebugEnabled() && !partitions.isEmpty()) {
+        if (LOGGER.isDebugEnabled() && !partitions.isEmpty()) {
             for (TopicPartition partition : partitions) {
-                log.debug("topic {} partition {}", partition.topic(), partition.partition());
+                LOGGER.debug("topic {} partition {}", partition.topic(), partition.partition());
             }
         }
     }
 
     @Override
     public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-        log.debug("Partitions assigned {}", partitions.size());
+        LOGGER.debug("Partitions assigned {}", partitions.size());
 
-        if (log.isDebugEnabled() && !partitions.isEmpty()) {
+        if (LOGGER.isDebugEnabled() && !partitions.isEmpty()) {
             for (TopicPartition partition : partitions) {
-                log.debug("topic {} partition {}", partition.topic(), partition.partition());
+                LOGGER.debug("topic {} partition {}", partition.topic(), partition.partition());
             }
         }
     }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
@@ -25,6 +25,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -38,6 +40,7 @@ import java.util.concurrent.CompletionStage;
  * Represents an HTTP bridge endpoint for the Kafka administration operations
  */
 public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
+    private static final Logger LOGGER = LogManager.getLogger(HttpAdminBridgeEndpoint.class);
 
     private final HttpBridgeContext httpBridgeContext;
     private final KafkaBridgeAdmin kafkaBridgeAdmin;
@@ -68,7 +71,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
 
     @Override
     public void handle(RoutingContext routingContext, Handler<HttpBridgeEndpoint> handler) {
-        log.trace("HttpAdminClientEndpoint handle thread {}", Thread.currentThread());
+        LOGGER.trace("HttpAdminClientEndpoint handle thread {}", Thread.currentThread());
         switch (this.httpBridgeContext.getOpenApiOperation()) {
             case LIST_TOPICS:
                 doListTopics(routingContext);
@@ -104,7 +107,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
     public void doListTopics(RoutingContext routingContext) {
         this.kafkaBridgeAdmin.listTopics()
                 .whenComplete((topics, ex) -> {
-                    log.trace("List topics handler thread {}", Thread.currentThread());
+                    LOGGER.trace("List topics handler thread {}", Thread.currentThread());
                     if (ex == null) {
                         ArrayNode root = JsonUtils.createArrayNode();
                         topics.forEach(topic -> root.add(topic));
@@ -133,7 +136,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
 
         CompletableFuture.allOf(describeTopicsPromise.toCompletableFuture(), describeConfigsPromise.toCompletableFuture())
                 .whenComplete((v, ex) -> {
-                    log.trace("Get topic handler thread {}", Thread.currentThread());
+                    LOGGER.trace("Get topic handler thread {}", Thread.currentThread());
                     if (ex == null) {
                         Map<String, TopicDescription> topicDescriptions = describeTopicsPromise.toCompletableFuture().getNow(Map.of());
                         Map<ConfigResource, Config> configDescriptions = describeConfigsPromise.toCompletableFuture().getNow(Map.of());
@@ -179,7 +182,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
         String topicName = routingContext.pathParam("topicname");
         this.kafkaBridgeAdmin.describeTopics(List.of(topicName))
                 .whenComplete((topicDescriptions, ex) -> {
-                    log.trace("List partitions handler thread {}", Thread.currentThread());
+                    LOGGER.trace("List partitions handler thread {}", Thread.currentThread());
                     if (ex == null) {
                         ArrayNode root = JsonUtils.createArrayNode();
                         TopicDescription description = topicDescriptions.get(topicName);
@@ -225,7 +228,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
         }
         this.kafkaBridgeAdmin.describeTopics(List.of(topicName))
                 .whenComplete((topicDescriptions, ex) -> {
-                    log.trace("Get partition handler thread {}", Thread.currentThread());
+                    LOGGER.trace("Get partition handler thread {}", Thread.currentThread());
                     if (ex == null) {
                         TopicDescription description = topicDescriptions.get(topicName);
                         if (description != null && partitionId < description.partitions().size()) {
@@ -297,7 +300,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
 
                 CompletableFuture.allOf(getBeginningOffsetsPromise.toCompletableFuture(), getEndOffsetsPromise.toCompletableFuture())
                         .whenComplete((v, ex) -> {
-                            log.trace("Get offsets handler thread {}", Thread.currentThread());
+                            LOGGER.trace("Get offsets handler thread {}", Thread.currentThread());
                             if (ex == null) {
                                 ObjectNode root = JsonUtils.createObjectNode();
                                 ListOffsetsResult.ListOffsetsResultInfo beginningOffset = getBeginningOffsetsPromise.toCompletableFuture().getNow(Map.of()).get(topicPartition);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeEndpoint.java
@@ -9,16 +9,11 @@ import io.strimzi.kafka.bridge.EmbeddedFormat;
 import io.strimzi.kafka.bridge.Handler;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.vertx.ext.web.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Abstract class for an endpoint bridging traffic between HTTP and Apache Kafka
  */
 public abstract class HttpBridgeEndpoint {
-
-    protected final Logger log = LoggerFactory.getLogger(getClass());
-
     protected String name;
     protected final EmbeddedFormat format;
     protected final BridgeConfig bridgeConfig;

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperation.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperation.java
@@ -5,11 +5,10 @@
 
 package io.strimzi.kafka.bridge.http;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Represents an OpenApi operation with related logging
@@ -28,7 +27,7 @@ public abstract class HttpOpenApiOperation implements Handler<RoutingContext> {
      */
     public HttpOpenApiOperation(HttpOpenApiOperations operationId) {
         this.operationId = operationId;
-        this.log = LoggerFactory.getLogger(LOGGER_NAME_PREFIX + operationId.toString());
+        this.log = LogManager.getLogger(LOGGER_NAME_PREFIX + operationId.toString());
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
@@ -9,15 +9,14 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.strimzi.kafka.bridge.http.converter.JsonUtils;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Provides some utility methods for HTTP request/response
  */
 public class HttpUtils {
-
-    private static final Logger log = LoggerFactory.getLogger(HttpUtils.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpUtils.class);
 
     /**
      * Send an HTTP response
@@ -31,14 +30,14 @@ public class HttpUtils {
         if (!routingContext.response().closed() && !routingContext.response().ended()) {
             routingContext.response().setStatusCode(statusCode);
             if (body != null) {
-                log.debug("[{}] Response: body = {}", routingContext.get("request-id"), JsonUtils.bytesToJson(body));
+                LOGGER.debug("[{}] Response: body = {}", routingContext.get("request-id"), JsonUtils.bytesToJson(body));
                 routingContext.response().putHeader(HttpHeaderNames.CONTENT_TYPE, contentType);
                 routingContext.response().putHeader(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(body.length));
                 routingContext.response().write(Buffer.buffer(body));
             }
             routingContext.response().end();
         } else if (routingContext.response().ended()) {
-            log.warn("[{}] Response: already ended!", routingContext.get("request-id").toString());
+            LOGGER.warn("[{}] Response: already ended!", routingContext.get("request-id").toString());
         }
     }
 
@@ -53,10 +52,10 @@ public class HttpUtils {
     public static void sendFile(RoutingContext routingContext, int statusCode, String contentType, String filename) {
         if (!routingContext.response().closed() && !routingContext.response().ended()) {
             routingContext.response().setStatusCode(statusCode);
-            log.debug("[{}] Response: filename = {}", routingContext.get("request-id"), filename);
+            LOGGER.debug("[{}] Response: filename = {}", routingContext.get("request-id"), filename);
             routingContext.response().putHeader(HttpHeaderNames.CONTENT_TYPE, contentType).sendFile(filename);
         } else if (routingContext.response().ended()) {
-            log.warn("[{}] Response: already ended!", routingContext.get("request-id").toString());
+            LOGGER.warn("[{}] Response: already ended!", routingContext.get("request-id").toString());
         } 
     }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/TracingUtil.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/TracingUtil.java
@@ -9,8 +9,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -24,7 +24,7 @@ import static io.strimzi.kafka.bridge.tracing.TracingConstants.OPENTELEMETRY;
  */
 @SuppressFBWarnings({"MS_EXPOSE_REP"})
 public class TracingUtil {
-    private static final Logger log = LoggerFactory.getLogger(TracingUtil.class);
+    private static final Logger LOGGER = LogManager.getLogger(TracingUtil.class);
     private static TracingHandle tracing = new NoopTracingHandle();
 
     /**
@@ -47,14 +47,14 @@ public class TracingUtil {
 
                 String serviceName = instance.serviceName(config);
                 if (serviceName != null) {
-                    log.info("Initializing OpenTelemetry tracing config with service name {}", serviceName);
+                    LOGGER.info("Initializing OpenTelemetry tracing config with service name {}", serviceName);
                     instance.initialize();
                     tracing = instance;
                 } else {
-                    log.error("Tracing configuration cannot be initialized because {} environment variable is not defined", instance.envServiceName());
+                    LOGGER.error("Tracing configuration cannot be initialized because {} environment variable is not defined", instance.envServiceName());
                 }
             } else {
-                log.warn("Tracing with {} is not supported/valid", tracingConfig);
+                LOGGER.warn("Tracing with {} is not supported/valid", tracingConfig);
             }
         }
     }

--- a/src/test/java/io/strimzi/kafka/bridge/clients/Consumer.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/Consumer.java
@@ -12,8 +12,8 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Properties;
 import java.util.Random;
@@ -22,7 +22,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 
 public class Consumer extends ClientHandlerBase<Integer> implements AutoCloseable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Consumer.class);
+    private static final Logger LOGGER = LogManager.getLogger(Consumer.class);
+
     private final Properties properties;
     private final AtomicInteger numReceived = new AtomicInteger(0);
     private final String topic;

--- a/src/test/java/io/strimzi/kafka/bridge/clients/Producer.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/Producer.java
@@ -13,8 +13,8 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 
 public class Producer extends ClientHandlerBase<Integer> implements AutoCloseable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Producer.class);
+    private static final Logger LOGGER = LogManager.getLogger(Producer.class);
     private Properties properties;
     private final AtomicInteger numSent = new AtomicInteger(0);
     private final String topic;

--- a/src/test/java/io/strimzi/kafka/bridge/facades/AdminClientFacade.java
+++ b/src/test/java/io/strimzi/kafka/bridge/facades/AdminClientFacade.java
@@ -10,8 +10,8 @@ import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.KafkaFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -23,7 +23,7 @@ import java.util.concurrent.ExecutionException;
  * Class AdminClientFacade used for encapsulate complexity and asynchronous code of AdminClient.
  */
 public class AdminClientFacade {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AdminClientFacade.class);
+    private static final Logger LOGGER = LogManager.getLogger(AdminClientFacade.class);
     private static AdminClient adminClient;
     private static AdminClientFacade adminClientFacade;
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
@@ -25,14 +25,14 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,7 +49,7 @@ import static org.hamcrest.Matchers.is;
 @Tag(HTTP_BRIDGE)
 @DisabledIfEnvironmentVariable(named = "EXTERNAL_BRIDGE", matches = "((?i)TRUE(?-i))")
 public class ConsumerGeneratedNameIT {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerGeneratedNameIT.class);
+    private static final Logger LOGGER = LogManager.getLogger(ConsumerGeneratedNameIT.class);
     static String kafkaUri;
     private static Map<String, Object> config = new HashMap<>();
     private static StrimziKafkaContainer kafkaContainer;

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -20,14 +20,14 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
@@ -47,7 +47,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConsumerIT extends HttpBridgeITAbstract {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerIT.class);
+    private static final Logger LOGGER = LogManager.getLogger(ConsumerIT.class);
     private static final String FORWARDED = "Forwarded";
     private static final String X_FORWARDED_HOST = "X-Forwarded-Host";
     private static final String X_FORWARDED_PROTO = "X-Forwarded-Proto";

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -15,11 +15,11 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerSubscriptionIT.class);
+    private static final Logger LOGGER = LogManager.getLogger(ConsumerSubscriptionIT.class);
 
     String groupId = "my-group";
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/DisablingConsumerProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/DisablingConsumerProducerIT.java
@@ -27,14 +27,14 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -50,8 +50,7 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(VertxExtension.class)
 @Tag(HTTP_BRIDGE)
 public class DisablingConsumerProducerIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DisablingConsumerProducerIT.class);
+    private static final Logger LOGGER = LogManager.getLogger(DisablingConsumerProducerIT.class);
 
     private static Vertx vertx;
     private static WebClient client;

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -48,7 +46,6 @@ import static org.hamcrest.Matchers.hasItem;
 @ExtendWith(VertxExtension.class)
 @SuppressWarnings({"checkstyle:JavaNCSS"})
 public class HttpCorsIT {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HttpCorsIT.class);
     static Map<String, Object> config = new HashMap<>();
     static long timeout = 5L;
     static String kafkaUri;

--- a/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
@@ -20,10 +20,10 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class InvalidProducerIT extends HttpBridgeITAbstract {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(InvalidProducerIT.class);
+    private static final Logger LOGGER = LogManager.getLogger(InvalidProducerIT.class);
 
     @Test
     void sendSimpleMessage(VertxTestContext context) throws InterruptedException, ExecutionException {

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
@@ -11,9 +11,9 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxTestContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class OtherServicesIT extends HttpBridgeITAbstract {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OtherServicesIT.class);
+    private static final Logger LOGGER = LogManager.getLogger(OtherServicesIT.class);
 
     @Test
     void readyTest(VertxTestContext context) throws InterruptedException {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -25,11 +25,11 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
@@ -47,8 +47,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class ProducerIT extends HttpBridgeITAbstract {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProducerIT.class);
+    private static final Logger LOGGER = LogManager.getLogger(ProducerIT.class);
 
     @Test
     void sendSimpleMessage(VertxTestContext context) throws InterruptedException, ExecutionException {

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -15,10 +15,10 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -32,7 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class SeekIT extends HttpBridgeITAbstract {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SeekIT.class);
+    private static final Logger LOGGER = LogManager.getLogger(SeekIT.class);
 
     private String name = "my-kafka-consumer";
     private String groupId = "my-group";

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -29,14 +29,14 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -50,7 +50,7 @@ import static io.strimzi.kafka.bridge.Constants.HTTP_BRIDGE;
 @SuppressWarnings({"checkstyle:JavaNCSS"})
 @Tag(HTTP_BRIDGE)
 public abstract class HttpBridgeITAbstract {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HttpBridgeITAbstract.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpBridgeITAbstract.class);
     protected static Map<String, Object> config = new HashMap<>();
 
     // for periodic/multiple messages test

--- a/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
@@ -15,8 +15,8 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxTestContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -30,7 +30,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConsumerService extends BaseService {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerService.class);
+    private static final Logger LOGGER = LogManager.getLogger(ConsumerService.class);
 
     private static final int POLL_TIMEOUT = 4000;
 

--- a/src/test/java/io/strimzi/kafka/bridge/tracing/TracingTestBase.java
+++ b/src/test/java/io/strimzi/kafka/bridge/tracing/TracingTestBase.java
@@ -24,13 +24,13 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.util.UUID;
@@ -47,13 +47,13 @@ import static org.hamcrest.Matchers.is;
  */
 @ExtendWith(VertxExtension.class)
 public abstract class TracingTestBase {
-    Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LogManager.getLogger(TracingTestBase.class);
 
     private void assumeServer(String url) {
         try {
             new URL(url).openConnection().getInputStream();
         } catch (Exception e) {
-            log.info("Cannot connect to server", e);
+            LOGGER.info("Cannot connect to server", e);
             Assumptions.assumeTrue(false, "Server is not running: " + url);
         }
     }


### PR DESCRIPTION
Right now, the bridge seems to be using SLF4J for logging. It seems to have also a mix of ways how the loggers are defined. 

This PR moves it to use Log4j2 and unifies the way the loggers are created (as a `static final` variables called `LOGGER`). The only exception is the logging of the HTTP request that seems to not use logger based on the class but rather based on the endpoint - this behavior is kept. These changes bring the Bridge more in-line with Strimzi operators and should make it easier to manage and test the logging dependencies. It also allows it to remove SLF4J as a direct dependency (but it remains a transitive dependency for things such as Kafka clients). This does change only the API used for logging. The actual logging was already before done with Log4j2.