### PR TITLE
Update Micrometer Metrics to 1.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0
 
-* Dependency updates (Kafka 3.6.1, Kubernetes configuration provider 1.1.2, Vert.x 4.5.2, Netty 4.1.106.Final, Jackson FasterXML 2.16.1)
+* Dependency updates (Kafka 3.6.1, Kubernetes configuration provider 1.1.2, Vert.x 4.5.2, Netty 4.1.106.Final, Jackson FasterXML 2.16.1, Micrometer 1.12.2)
 * Fixed missing messaging semantic attributes to the Kafka consumer spans
 
 ## 0.27.0

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 		<strimzi-oauth.version>0.14.0</strimzi-oauth.version>
 		<opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
 		<opentelemetry.version>1.19.0</opentelemetry.version>
-		<micrometer.version>1.9.5</micrometer.version>
+		<micrometer.version>1.12.2</micrometer.version>
 		<jmx-prometheus-collector.version>0.18.0</jmx-prometheus-collector.version>
 		<prometheus-simpleclient.version>0.16.0</prometheus-simpleclient.version>
 		<commons-cli.version>1.4</commons-cli.version>


### PR DESCRIPTION
This PR updates the Micrometer Metrics to 1.12.2 to bring the version inline with what is used by Vert.x 4.5.2.