### PR TITLE
Fix use of deprecated Vert.x methods and unchecked casts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
 		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>3.0.0-M7</maven-failsafe-plugin.version>
+		<maven.compiler.version>3.10.1</maven.compiler.version>
 		<maven.assembly.version>3.4.2</maven.assembly.version>
 		<maven.javadoc.version>3.4.1</maven.javadoc.version>
 		<maven.source.version>3.2.1</maven.source.version>
@@ -184,11 +185,6 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-common</artifactId>
-			<version>${netty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-buffer</artifactId>
 			<version>${netty.version}</version>
 		</dependency>
 		<dependency>
@@ -419,6 +415,26 @@
 						<goals>
 							<goal>check</goal>
 						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven.compiler.version}</version>
+				<executions>
+					<execution>
+						<id>default-compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<compilerArgs>
+								<arg>-Xlint:unchecked,deprecation</arg>
+								<arg>-Werror</arg>
+							</compilerArgs>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -547,7 +547,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
         try {
             // check for an empty body
             if (!routingContext.body().isEmpty()) {
-                bodyAsJson = JsonUtils.bytesToJson(routingContext.body().buffer().getByteBuf().array());
+                bodyAsJson = JsonUtils.bytesToJson(routingContext.body().buffer().getBytes());
             }
             LOGGER.debug("[{}] Request: body = {}", routingContext.get("request-id"), bodyAsJson);
         } catch (JsonDecodeException ex) {
@@ -605,6 +605,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private MessageConverter<K, V, byte[], byte[]> buildMessageConverter() {
         switch (this.format) {
             case JSON:
@@ -634,7 +635,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
     private String buildRequestUri(RoutingContext routingContext) {
         // by default schema/proto and host comes from the base request information (i.e. "Host" header)
         String scheme = routingContext.request().scheme();
-        String host = routingContext.request().host();
+        String host = routingContext.request().authority().toString();
         // eventually get the request path from "X-Forwarded-Path" if set by a gateway/proxy
         String xForwardedPath = routingContext.request().getHeader("x-forwarded-path");
         String path = (xForwardedPath != null && !xForwardedPath.isEmpty()) ? xForwardedPath : routingContext.request().path();

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSourceBridgeEndpoint.java
@@ -115,7 +115,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
 
                 return;
             }
-            records = messageConverter.toKafkaRecords(topic, partition, routingContext.body().buffer().getByteBuf().array());
+            records = messageConverter.toKafkaRecords(topic, partition, routingContext.body().buffer().getBytes());
 
             for (ProducerRecord<K, V> record :records)   {
                 span.inject(record);
@@ -213,6 +213,7 @@ public class HttpSourceBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private MessageConverter<K, V, byte[], byte[]> buildMessageConverter() {
         switch (this.format) {
             case JSON:

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/BridgeContextStorageProvider.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/BridgeContextStorageProvider.java
@@ -45,7 +45,7 @@ public class BridgeContextStorageProvider implements ContextStorageProvider {
     enum BridgeContextStorage implements ContextStorage {
         INSTANCE;
 
-        private final ConcurrentMap<Object, Object> data = new ConcurrentHashMap();
+        private final ConcurrentMap<Object, Object> data = new ConcurrentHashMap<>();
 
         @Override
         public Scope attach(Context toAttach) {


### PR DESCRIPTION
This Pr updates how the compiler handles warnings in the Bridge and treats them as errors (similar to most of our other projects). It also addresses some cases where we use deprecated Vert.x methods and some unchecked casts (for the unchecked casts, it just silences the warnings). Not using one of the deprecated methods also leads to us not using the Netty Buffer package directly so I remove it from the `pom.xml` file.