### PR TITLE
Update Vert.x to 4.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0
 
-* Dependency updates (Kafka 3.6.1, Kubernetes configuration provider 1.1.2, Vert.x 4.5.2, Netty 4.1.106.Final, Jackson FasterXML 2.16.1, Micrometer 1.12.2)
+* Dependency updates (Kafka 3.6.1, Kubernetes configuration provider 1.1.2, Vert.x 4.5.3, Netty 4.1.106.Final, Jackson FasterXML 2.16.1, Micrometer 1.12.2)
 * Fixed missing messaging semantic attributes to the Kafka consumer spans
 
 ## 0.27.0

--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
-		<vertx.version>4.5.2</vertx.version>
-		<vertx-testing.version>4.5.2</vertx-testing.version>
+		<vertx.version>4.5.3</vertx.version>
+		<vertx-testing.version>4.5.3</vertx-testing.version>
 		<netty.version>4.1.106.Final</netty.version>
 		<kafka.version>3.6.1</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>


### PR DESCRIPTION
This PR updates Vert.x to 4.5.3 to address [CVE-2024-1300](https://access.redhat.com/security/cve/CVE-2024-1300).