### PR TITLE
Update Kafka to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0
 
-* Dependency updates (Kafka 3.6.1, Kubernetes configuration provider 1.1.2, Vert.x 4.5.4, Netty 4.1.107.Final, Jackson FasterXML 2.16.1, Micrometer 1.12.3)
+* Dependency updates (Kafka 3.7.0, Kubernetes configuration provider 1.1.2, Vert.x 4.5.4, Netty 4.1.107.Final, Jackson FasterXML 2.16.1, Micrometer 1.12.3)
 * Fixed missing messaging semantic attributes to the Kafka consumer spans
 
 ## 0.27.0

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 		<vertx.version>4.5.4</vertx.version>
 		<vertx-testing.version>4.5.4</vertx-testing.version>
 		<netty.version>4.1.107.Final</netty.version>
-		<kafka.version>3.6.1</kafka.version>
+		<kafka.version>3.7.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<maven.checkstyle.version>3.3.0</maven.checkstyle.version>


### PR DESCRIPTION
This PR updates the Kafka version used in the bridge to 3.7.0.