### PR TITLE
Handling Content-Type from producer on each HTTP request

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
@@ -52,7 +52,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
      * @param context the HTTP bridge context
      */
     public HttpAdminBridgeEndpoint(BridgeConfig bridgeConfig, HttpBridgeContext context) {
-        super(bridgeConfig, null);
+        super(bridgeConfig);
         this.name = "kafka-bridge-admin";
         this.httpBridgeContext = context;
         this.kafkaBridgeAdmin = new KafkaBridgeAdmin(bridgeConfig.getKafkaConfig());

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeEndpoint.java
@@ -5,7 +5,6 @@
 
 package io.strimzi.kafka.bridge.http;
 
-import io.strimzi.kafka.bridge.EmbeddedFormat;
 import io.strimzi.kafka.bridge.Handler;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.vertx.ext.web.RoutingContext;
@@ -15,7 +14,6 @@ import io.vertx.ext.web.RoutingContext;
  */
 public abstract class HttpBridgeEndpoint {
     protected String name;
-    protected final EmbeddedFormat format;
     protected final BridgeConfig bridgeConfig;
     private Handler<HttpBridgeEndpoint> closeHandler;
 
@@ -23,11 +21,9 @@ public abstract class HttpBridgeEndpoint {
      * Constructor
      *
      * @param bridgeConfig the bridge configuration
-     * @param format the embedded format for consumed messages
      */
-    public HttpBridgeEndpoint(BridgeConfig bridgeConfig, EmbeddedFormat format) {
+    public HttpBridgeEndpoint(BridgeConfig bridgeConfig) {
         this.bridgeConfig = bridgeConfig;
-        this.format = format;
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -70,6 +70,7 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
     private MessageConverter<K, V, byte[], byte[]> messageConverter;
     private final HttpBridgeContext<K, V> httpBridgeContext;
     private final KafkaBridgeConsumer<K, V> kafkaBridgeConsumer;
+    private final EmbeddedFormat format;
     private ConsumerInstanceId consumerInstanceId;
     private boolean subscribed;
     private boolean assigned;
@@ -85,9 +86,10 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
      */
     public HttpSinkBridgeEndpoint(BridgeConfig bridgeConfig, HttpBridgeContext<K, V> context, EmbeddedFormat format,
                                   Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
-        super(bridgeConfig, format);
+        super(bridgeConfig);
         this.httpBridgeContext = context;
         this.kafkaBridgeConsumer = new KafkaBridgeConsumer<>(bridgeConfig.getKafkaConfig(), keyDeserializer, valueDeserializer);
+        this.format = format;
         this.subscribed = false;
         this.assigned = false;
     }


### PR DESCRIPTION
This PR fixes #874 and handles Content-Type for each HTTP request from a producer even on the same HTTP connection.