### PR TITLE
Updated OAuth dependency 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.0
 
-* Dependency updates (Kafka 3.7.0, Kubernetes configuration provider 1.1.2, Vert.x 4.5.4, Netty 4.1.107.Final, Jackson FasterXML 2.16.1, Micrometer 1.12.3)
+* Dependency updates (Kafka 3.7.0, Kubernetes configuration provider 1.1.2, Vert.x 4.5.4, Netty 4.1.107.Final, Jackson FasterXML 2.16.1, Micrometer 1.12.3, OAuth 0.15.0)
 * Fixed missing messaging semantic attributes to the Kafka consumer spans
 * Introduced a new text embedded format to send and receive plain strings for record key and value.
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 		<jackson-databind.version>2.16.1</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
-		<strimzi-oauth.version>0.14.0</strimzi-oauth.version>
+		<strimzi-oauth.version>0.15.0</strimzi-oauth.version>
 		<opentelemetry.alpha-version>1.19.0-alpha</opentelemetry.alpha-version>
 		<opentelemetry.version>1.19.0</opentelemetry.version>
 		<micrometer.version>1.12.3</micrometer.version>


### PR DESCRIPTION
Trivial PR to bump the newer OAuth 0.15.0 release.