### PR TITLE
Bump test container depedency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
 		<jmx-prometheus-collector.version>0.18.0</jmx-prometheus-collector.version>
 		<prometheus-simpleclient.version>0.16.0</prometheus-simpleclient.version>
 		<commons-cli.version>1.4</commons-cli.version>
-		<test-container.version>0.105.0</test-container.version>
+		<test-container.version>0.106.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>2.0</snakeyaml.version>
 		<!-- property to skip surefire tests during failsafe execution -->


### PR DESCRIPTION
This PR adds a recently released test container with a new Kafka 3.7.0 version