### PR TITLE
Fixed handling of wrong key when text embedded format is used by the producer

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
@@ -38,7 +38,11 @@ public class HttpTextMessageConverter implements MessageConverter<byte[], byte[]
 
         if (!json.isEmpty()) {
             if (json.has("key")) {
-                key = json.get("key").asText().getBytes();
+                JsonNode keyNode = json.get("key");
+                if (!keyNode.isTextual()) {
+                    throw new IllegalStateException("Because the embedded format is 'text', the key must be a string");
+                }
+                key = keyNode.asText().getBytes();
             }
             if (json.has("value")) {
                 JsonNode valueNode = json.get("value");


### PR DESCRIPTION
The embedded format in the bridge is representative for both key and value.
With the new added `text` embedded format, there is check on the value only while it should be the same for the key.
Currently, if the producer uses `text` embedded format but sends a JSON key, the message is accepted but the consumer gets an empty key on the other side. This PR fixes the issue by rejecting the message having a wrongly formatted key (in JSON).