### PR TITLE
#8732 Enhance KafkaBridge resource with consumer inactivity timeout and HTTP consumer/producer parts enablement

### DIFF
--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -150,6 +150,9 @@ http.port=${KAFKA_BRIDGE_HTTP_PORT}
 http.cors.enabled=${KAFKA_BRIDGE_CORS_ENABLED}
 http.cors.allowedOrigins=${KAFKA_BRIDGE_CORS_ALLOWED_ORIGINS}
 http.cors.allowedMethods=${KAFKA_BRIDGE_CORS_ALLOWED_METHODS}
+http.timeoutSeconds=${KAFKA_BRIDGE_HTTP_CONSUMER_TIMEOUT}
+http.consumer.enabled=${KAFKA_BRIDGE_HTTP_CONSUMER_ENABLED}
+http.producer.enabled=${KAFKA_BRIDGE_HTTP_PRODUCER_ENABLED}
 EOF
 )
 


### PR DESCRIPTION
Enabling ENVs as part of changes in: https://github.com/strimzi/strimzi-kafka-operator/pull/9820 related to changes in improvement: https://github.com/strimzi/strimzi-kafka-operator/issues/8732