### PR TITLE
docs(metrics): adds instructions for enabling metrics

### DIFF
--- a/documentation/assemblies/assembly-kafka-bridge-config.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-config.adoc
@@ -14,4 +14,5 @@ Distributed tracing allows you to track the progress of transactions between app
 NOTE: Use the `KafkaBridge` resource to configure properties when you are xref:overview-components-running-kafka-bridge-cluster-{context}[running the Kafka Bridge on Kubernetes].
 
 include::modules/proc-configuring-kafka-bridge.adoc[leveloffset=+1]
+include::modules/proc-configuring-kafka-bridge-metrics.adoc[leveloffset=+1]
 include::modules/proc-configuring-kafka-bridge-tracing.adoc[leveloffset=+1]

--- a/documentation/modules/proc-configuring-kafka-bridge-metrics.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge-metrics.adoc
@@ -1,0 +1,30 @@
+[id='proc-configuring-kafka-bridge-metrics-{context}']
+= Configuring metrics
+
+[role="_abstract"]
+Enable metrics for the Kafka Bridge by setting the `KAFKA_BRIDGE_METRICS_ENABLED` environment variable.
+
+.Prerequisites
+
+* xref:proc-downloading-kafka-bridge-{context}[The Kafka Bridge installation archive is downloaded].
+
+.Procedure
+
+. Set the environment variable for enabling metrics to `true`.
++
+.Environment variable for enabling metrics
+
+[source,properties]
+----
+KAFKA_BRIDGE_METRICS_ENABLE=true
+----
+
+. Run the Kafka Bridge script to enable metrics.
++
+.Running the Kafka Bridge to enable metrics
+[source,shell]
+----
+./bin/kafka_bridge_run.sh --config-file=<path>/application.properties
+----
++
+With metrics enabled, you can use `GET /metrics` with the `/metrics` endpoint to retrieve Kafka Bridge metrics in Prometheus format.

--- a/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge-tracing.adoc
@@ -66,7 +66,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 # <2>
 <1> The name of the OpenTelemetry tracer service.
 <2> The gRPC-based OTLP endpoint that listens for spans on port 4317.
 
-. Run the Kafka Bridge script with the property enabled for tracing:
+. Run the Kafka Bridge script with the property enabled for tracing.
 +
 .Running the Kafka Bridge with OpenTelemetry enabled
 [source,shell,subs="+quotes,attributes"]


### PR DESCRIPTION
**Documentation update**

Instructions for setting the `KAFKA_BRIDGE_METRICS_ENABLED` environment variable to `true` to enable metrics