### PR TITLE
Add a test case for multiple content type for specific kafkatopic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-kafka-client</artifactId>
 			<version>${vertx-testing.version}</version>

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -1203,9 +1203,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
                 record.put("value", Base64.getEncoder().encodeToString(value.encode().getBytes()));
                 break;
             case BridgeContentType.KAFKA_JSON_TEXT:
-                // Convert JSON objects to string representations
-                record.put("key", key.encode());
-                record.put("value", value.encode());
+                record.put("key", "key"); // Use pure plain text for the key
+                record.put("value", "value"); // Use pure plain text for the value
                 break;
             default:
                 throw new RuntimeException("Un-supported content type:" + contentType);

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -13,7 +13,6 @@ import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
 import io.strimzi.kafka.bridge.utils.KafkaJsonDeserializer;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -1134,13 +1134,13 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsRequest(topic, messageKafkaJsonContentType, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(messageKafkaJsonContentType, response -> handleResponse(context, response, BridgeContentType.KAFKA_JSON_JSON));
+            .sendJsonObject(messageKafkaJsonContentType, response -> handleResponse(context, response, BridgeContentType.KAFKA_JSON_JSON, HttpResponseStatus.OK));
 
         // Second request with binary content, simulating a binary message
         producerService()
             .sendRecordsRequest(topic, messageKafkaJsonBinaryContentType, BridgeContentType.KAFKA_JSON_BINARY)
             .sendBuffer(Buffer.buffer(messageKafkaJsonBinaryContentType.toString()), response -> {
-                handleResponse(context, response, BridgeContentType.KAFKA_JSON_BINARY);
+                handleResponse(context, response, BridgeContentType.KAFKA_JSON_BINARY, HttpResponseStatus.OK);
                 context.completeNow();
             });
 
@@ -1175,16 +1175,17 @@ public class ProducerIT extends HttpBridgeITAbstract {
      * Handles the response from sending a record to Kafka, logging the outcome and verifying the HTTP status code.
      * This method is used as a callback for the asynchronous HTTP request to send records to Kafka.
      *
-     * @param context       The VertxTestContext used for assertions and to mark the test as completed.
-     * @param ar            The result of the asynchronous HTTP request, containing either the response or an error.
-     * @param contentType   The content type of the message that was sent, used for logging purposes.
+     * @param context               The VertxTestContext used for assertions and to mark the test as completed.
+     * @param ar                    The result of the asynchronous HTTP request, containing either the response or an error.
+     * @param contentType           The content type of the message that was sent, used for logging purposes.
+     * @param httpResponseStatus    The response status code of the asynchronous HTTP request
      */
     private void handleResponse(final VertxTestContext context, final AsyncResult<HttpResponse<JsonObject>> ar,
-                                final String contentType) {
+                                final String contentType, final HttpResponseStatus httpResponseStatus) {
         if (ar.succeeded()) {
             HttpResponse<JsonObject> response = ar.result();
             context.verify(() -> {
-                assertThat(response.statusCode(), is(200));
+                assertThat(response.statusCode(), is(httpResponseStatus.code()));
                 LOGGER.info("Successfully processed " + contentType + " content");
             });
         } else {


### PR DESCRIPTION
This PR adds a test case where it uses binary and JSON content types within specific KafkaTopic. 