### PR TITLE
Better look of logs within application or tests

### DIFF
--- a/config/log4j2.properties
+++ b/config/log4j2.properties
@@ -6,7 +6,7 @@ name = BridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %highlight{%-5p} [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -6,7 +6,7 @@ name = BridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %highlight{%-5p} [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -6,7 +6,7 @@ name = BridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %highlight{%-5p} %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -6,7 +6,7 @@ name = BridgeConfig
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p [%t] %highlight{%-5p} %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %highlight{%-5p} [%t] %c{1}:%L - %m%n
 
 rootLogger.level = INFO
 rootLogger.appenderRefs = console


### PR DESCRIPTION
This PR updates the logging of the `log4j2.properties` file. It is just a nuanced design change. 
Before:
<img width="1668" alt="image" src="https://github.com/strimzi/strimzi-kafka-bridge/assets/30839163/8df98dd7-c500-4187-a15a-9f23fa0f966a">

After:
<img width="1681" alt="image" src="https://github.com/strimzi/strimzi-kafka-bridge/assets/30839163/3d8eb669-b921-438f-a3b4-6f8555676a0a">