### PR TITLE
Bumped Vert.x 4.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.29.0
 
-* Dependency updates (Vert.x 4.5.6, Netty 4.1.108.Final)
+* Dependency updates (Vert.x 4.5.7, Netty 4.1.108.Final)
 
 ## 0.28.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
-		<vertx.version>4.5.6</vertx.version>
-		<vertx-testing.version>4.5.6</vertx-testing.version>
+		<vertx.version>4.5.7</vertx.version>
+		<vertx-testing.version>4.5.7</vertx-testing.version>
 		<netty.version>4.1.108.Final</netty.version>
 		<kafka.version>3.7.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>


### PR DESCRIPTION
Trivial PR to bump to Vert.x 4.5.7 because the previous fix in 4.5.6 for CVE-2024-29025 had some regression.