### PR TITLE
docs(metrics): env var name fix

### DIFF
--- a/documentation/modules/proc-configuring-kafka-bridge-metrics.adoc
+++ b/documentation/modules/proc-configuring-kafka-bridge-metrics.adoc
@@ -16,7 +16,7 @@ Enable metrics for the Kafka Bridge by setting the `KAFKA_BRIDGE_METRICS_ENABLED
 
 [source,properties]
 ----
-KAFKA_BRIDGE_METRICS_ENABLE=true
+KAFKA_BRIDGE_METRICS_ENABLED=true
 ----
 
 . Run the Kafka Bridge script to enable metrics.


### PR DESCRIPTION
**Documentation fix**
Configuring metrics procedure: Fixes a typo in the name of the KAFKA_BRIDGE_METRICS_ENABLED environment variable