### PR TITLE
docs(bridge): cleans up naming of kafka bridge

### DIFF
--- a/documentation/assemblies/assembly-kafka-bridge-overview.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-overview.adoc
@@ -6,7 +6,7 @@
 = Kafka Bridge overview
 
 [role="_abstract"]
-Use the Strimzi Kafka Bridge to make HTTP requests to a Kafka cluster.
+Use the Kafka Bridge to make HTTP requests to a Kafka cluster.
 
 You can use the Kafka Bridge to integrate HTTP client applications with your Kafka cluster.
 

--- a/documentation/assemblies/assembly-kafka-bridge-quickstart.adoc
+++ b/documentation/assemblies/assembly-kafka-bridge-quickstart.adoc
@@ -6,7 +6,7 @@
 = Kafka Bridge quickstart
 
 [role="_abstract"]
-Use this quickstart to try out the Strimzi Kafka Bridge in your local development environment.
+Use this quickstart to try out the Kafka Bridge in your local development environment.
 
 You will learn how to do the following:
 

--- a/documentation/book/api/overview.adoc
+++ b/documentation/book/api/overview.adoc
@@ -1,9 +1,9 @@
-= Strimzi Kafka Bridge API Reference
+= Kafka Bridge API Reference
 
 
 [[_overview]]
 == Overview
-The Strimzi Kafka Bridge provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol.
+The Kafka Bridge provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol.
 
 
 === Version information

--- a/documentation/modules/con-overview-components-kafka-bridge.adoc
+++ b/documentation/modules/con-overview-components-kafka-bridge.adoc
@@ -32,4 +32,4 @@ Clients can produce and consume messages without the requirement to use the nati
 
 [role="_additional-resources"]
 .Additional resources
-* xref:api_reference-{context}[Strimzi Kafka Bridge API reference]
+* xref:api_reference-{context}[Kafka Bridge API reference]

--- a/documentation/modules/con-overview-running-kafka-bridge.adoc
+++ b/documentation/modules/con-overview-running-kafka-bridge.adoc
@@ -6,7 +6,7 @@
 = Running the Kafka Bridge
 
 [role="_abstract"]
-Install the Strimzi Kafka Bridge to run in the same environment as your Kafka cluster.
+Install the Kafka Bridge to run in the same environment as your Kafka cluster.
 
 You can download and add the Kafka Bridge installation artifacts to your host machine.
 To try out the Kafka Bridge in your local environment, see the xref:assembly-kafka-bridge-quickstart-{context}[Kafka Bridge quickstart].

--- a/documentation/modules/proc-bridge-seeking-offsets-for-partition.adoc
+++ b/documentation/modules/proc-bridge-seeking-offsets-for-partition.adoc
@@ -61,7 +61,7 @@ NOTE: You can also use the xref:_seektobeginning[positions/beginning] endpoint t
 
 .What to do next
 
-In this quickstart, you have used the Strimzi Kafka Bridge to perform several common operations on a Kafka cluster. You can now xref:proc-bridge-deleting-consumer-{context}[delete the Kafka Bridge consumer] that you created earlier.
+In this quickstart, you have used the Kafka Bridge to perform several common operations on a Kafka cluster. You can now xref:proc-bridge-deleting-consumer-{context}[delete the Kafka Bridge consumer] that you created earlier.
 
 [role="_additional-resources"]
 .Additional resources

--- a/documentation/modules/proc-downloading-kafka-bridge.adoc
+++ b/documentation/modules/proc-downloading-kafka-bridge.adoc
@@ -7,8 +7,8 @@
 = Downloading a Kafka Bridge archive
 
 [role="_abstract"]
-A zipped distribution of the Strimzi Kafka Bridge is available for download.
+A zipped distribution of the Kafka Bridge is available for download.
 
 .Procedure
 
-- Download the latest version of the Strimzi Kafka Bridge archive from the {ReleaseDownload}.
+- Download the latest version of the Kafka Bridge archive from the {ReleaseDownload}.

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1,8 +1,8 @@
 {
     "openapi": "3.0.0",
     "info": {
-      "title": "Strimzi Kafka Bridge API Reference",
-      "description": "The Strimzi Kafka Bridge provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol. ",
+      "title": "Kafka Bridge API Reference",
+      "description": "The Kafka Bridge provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol. ",
         "version": "0.1.0"
     },
     "paths": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1,8 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "Strimzi Kafka Bridge API Reference",
-    "description": "The Strimzi Kafka Bridge provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol. ",
+    "title": "Kafka Bridge API Reference",
+    "description": "The Kafka Bridge provides a REST API for integrating HTTP based client applications with a Kafka cluster. You can use the API to create and manage consumers and send and receive records over HTTP rather than the native Kafka protocol. ",
     "version": "0.1.0"
   },
   "consumes": [


### PR DESCRIPTION
**Documentation**

In a few places in the docs we say "Strimzi Kafka Bridge" without needing to make this distinction. These instances have been updated to say just "Kafka Bridge"