### PR TITLE
[Fix] correct env vars names for consumer and producer enabled

### DIFF
--- a/bin/docker/kafka_bridge_config_generator.sh
+++ b/bin/docker/kafka_bridge_config_generator.sh
@@ -151,8 +151,8 @@ http.cors.enabled=${KAFKA_BRIDGE_CORS_ENABLED}
 http.cors.allowedOrigins=${KAFKA_BRIDGE_CORS_ALLOWED_ORIGINS}
 http.cors.allowedMethods=${KAFKA_BRIDGE_CORS_ALLOWED_METHODS}
 http.timeoutSeconds=${KAFKA_BRIDGE_HTTP_CONSUMER_TIMEOUT}
-http.consumer.enabled=${KAFKA_BRIDGE_HTTP_CONSUMER_ENABLED}
-http.producer.enabled=${KAFKA_BRIDGE_HTTP_PRODUCER_ENABLED}
+http.consumer.enabled=${KAFKA_BRIDGE_CONSUMER_ENABLED}
+http.producer.enabled=${KAFKA_BRIDGE_PRODUCER_ENABLED}
 EOF
 )
 


### PR DESCRIPTION
On our environment all http clients are disconnected after upgrade on latest strimzi and bridge due to latest changes.
I see that operator code passing with env vars `KAFKA_BRIDGE_CONSUMER_ENABLED` and `KAFKA_BRIDGE_PRODUCER_ENABLED` https://github.com/strimzi/strimzi-kafka-operator/pull/9820/files
But startup script in bridge passing different env vars which causes empty vars and consumer and producer is disabled.

There is a fix for that.