### PR TITLE
Refactor handing and preparatin of trusted certificates

### DIFF
--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 set +x
 
 # Clean-up /tmp directory from files which might have remained from previous container restart
@@ -14,14 +15,7 @@ export CERTS_STORE_PASSWORD=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c32)
 mkdir -p /tmp/strimzi
 
 # Import certificates into keystore and truststore
-# $1 = trusted certs, $2 = TLS auth cert, $3 = TLS auth key, $4 = truststore path, $5 = keystore path, $6 = certs and key path
-"${MYPATH}"/kafka_bridge_tls_prepare_certificates.sh \
-    "$KAFKA_BRIDGE_TRUSTED_CERTS" \
-    "$KAFKA_BRIDGE_TLS_AUTH_CERT" \
-    "$KAFKA_BRIDGE_TLS_AUTH_KEY" \
-    "/tmp/strimzi/bridge.truststore.p12" \
-    "/tmp/strimzi/bridge.keystore.p12" \
-    "${STRIMZI_HOME}/bridge-certs"
+"${MYPATH}"/kafka_bridge_tls_prepare_certificates.sh
 
 # Generate and print the bridge config file
 echo "Kafka Bridge configuration:"

--- a/bin/docker/kafka_bridge_tls_prepare_certificates.sh
+++ b/bin/docker/kafka_bridge_tls_prepare_certificates.sh
@@ -33,12 +33,12 @@ function create_keystore {
 # $3: Base path where the certificates are mounted
 # $4: Environment variable defining the certs that should be loaded
 function prepare_truststore {
-    STORE=$1
+    TRUSTSTORE=$1
     PASSWORD=$2
     BASEPATH=$3
     TRUSTED_CERTS=$4
 
-    rm -f "$STORE"
+    rm -f "$TRUSTSTORE"
 
     IFS=';' read -ra CERTS <<< "${TRUSTED_CERTS}"
     for cert in "${CERTS[@]}"
@@ -46,8 +46,8 @@ function prepare_truststore {
         for file in $BASEPATH/$cert
         do
             if [ -f "$file" ]; then
-                echo "Adding $file to truststore $STORE with alias $file"
-                create_truststore "$STORE" "$PASSWORD" "$file" "$file"
+                echo "Adding $file to truststore $TRUSTSTORE with alias $file"
+                create_truststore "$TRUSTSTORE" "$PASSWORD" "$file" "$file"
             fi
         done
     done


### PR DESCRIPTION
This PR unifies how we prepare the truststore with trusted certificates. It unifies it within the Bridge it self (certs trusted by the Kafka client versus the OAuth client) as well as with the rest of Strimzi components (Connect etc.). It accompanies the https://github.com/strimzi/strimzi-kafka-operator/pull/10123 PR and is part of the implementation of [Strimz Proposal 72](https://github.com/strimzi/proposals/blob/main/073-improve-handling-of-CA-renewals-and-replacements-in-client-based-operands.md).