### PR TITLE
Move to UBI9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Dependency updates (Vert.x 4.5.7, Netty 4.1.108.Final)
 * Added support for records key and value to be JSON array when using the `json` embedded format.
+* Update the base image used by Strimzi containers from UBI8 to UBI9
 
 ## 0.28.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ARG JAVA_VERSION=17
 ARG TARGETPLATFORM
 
 USER root
 
 RUN microdnf update \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
     && microdnf clean all
 
 # Set JAVA_HOME env var


### PR DESCRIPTION
This PR follows the https://github.com/strimzi/strimzi-kafka-operator/pull/10126 and updates the Bridge container image to be based on UBI9 as well.