### PR TITLE
Added an additional OpenAPI v3 endpoint and deprecate v2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Dependency updates (Vert.x 4.5.7, Netty 4.1.108.Final)
 * Added support for records key and value to be JSON array when using the `json` embedded format.
 * Update the base image used by Strimzi containers from UBI8 to UBI9
+* The OpenAPI v2 (Swagger) specification support is now deprecated.
+  * The `/openapi` endpoint still returns the OpenAPI v2 specification. There is an additional `/openapi/v2` endpoint returning the same.
+  * The newly added `/openapi/v3` endpoint returns the OpenAPI v3 specification. Please use this one, because the v2 will be removed in the future.
 
 ## 0.28.0
 

--- a/documentation/book/api/paths.adoc
+++ b/documentation/book/api/paths.adoc
@@ -959,6 +959,48 @@ Retrieves the OpenAPI v2 specification in JSON format.
 * `application/json`
 
 
+[[_openapiv2]]
+=== GET /openapi/v2
+
+==== Description
+Retrieves the OpenAPI v2 specification in JSON format.
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**204**|OpenAPI v2 specification in JSON format retrieved successfully.|string
+|===
+
+
+==== Produces
+
+* `application/json`
+
+
+[[_openapiv3]]
+=== GET /openapi/v3
+
+==== Description
+Retrieves the OpenAPI v3 specification in JSON format.
+
+
+==== Responses
+
+[options="header", cols=".^2a,.^14a,.^4a"]
+|===
+|HTTP Code|Description|Schema
+|**204**|OpenAPI v3 specification in JSON format retrieved successfully.|string
+|===
+
+
+==== Produces
+
+* `application/json`
+
+
 [[_ready]]
 === GET /ready
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpOpenApiOperations.java
@@ -50,8 +50,12 @@ public enum HttpOpenApiOperations {
     HEALTHY("healthy"),
     /** check the readiness of the bridge */
     READY("ready"),
-    /** get the OpenAPI specification */
+    /** get the OpenAPI v2 specification */
     OPENAPI("openapi"),
+    /** get the OpenAPI v2 specification */
+    OPENAPIV2("openapiv2"),
+    /** get the OpenAPI v3 specification */
+    OPENAPIV3("openapiv3"),
     /** get general information (i.e. version) about the bridge */
     INFO("info"),
     /** get metrics (if enabled) in Prometheus format */

--- a/src/main/resources/openapi.json
+++ b/src/main/resources/openapi.json
@@ -1395,6 +1395,42 @@
                 "description": "Retrieves the OpenAPI v2 specification in JSON format."
             }
         },
+        "/openapi/v2": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "OpenAPI v2 specification in JSON format retrieved successfully."
+                    }
+                },
+                "operationId": "openapiv2",
+                "description": "Retrieves the OpenAPI v2 specification in JSON format."
+            }
+        },
+        "/openapi/v3": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "OpenAPI v3 specification in JSON format retrieved successfully."
+                    }
+                },
+                "operationId": "openapiv3",
+                "description": "Retrieves the OpenAPI v3 specification in JSON format."
+            }
+        },
         "/metrics": {
             "get": {
                 "responses": {

--- a/src/main/resources/openapiv2.json
+++ b/src/main/resources/openapiv2.json
@@ -1235,6 +1235,40 @@
         "description": "Retrieves the OpenAPI v2 specification in JSON format."
       }
     },
+    "/openapi/v2": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "204": {
+            "description": "OpenAPI v2 specification in JSON format retrieved successfully.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "operationId": "openapiv2",
+        "description": "Retrieves the OpenAPI v2 specification in JSON format."
+      }
+    },
+    "/openapi/v3": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "204": {
+            "description": "OpenAPI v3 specification in JSON format retrieved successfully.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "operationId": "openapiv3",
+        "description": "Retrieves the OpenAPI v3 specification in JSON format."
+      }
+    },
     "/metrics": {
       "get": {
         "produces": [

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
@@ -68,6 +68,44 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
     }
 
     @Test
+    void openapiv2Test(VertxTestContext context) {
+        baseService()
+            .getRequest("/openapi/v2")
+                .as(BodyCodec.jsonObject())
+                .send(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+                        JsonObject bridgeResponse = response.body();
+
+                        String version = bridgeResponse.getString("swagger");
+                        assertThat(version, is("2.0"));
+                    });
+                    context.completeNow();
+                });
+    }
+
+    @Test
+    void openapiv3Test(VertxTestContext context) {
+        baseService()
+                .getRequest("/openapi/v3")
+                .as(BodyCodec.jsonObject())
+                .send(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+                        JsonObject bridgeResponse = response.body();
+
+                        String version = bridgeResponse.getString("openapi");
+                        assertThat(version, is("3.0.0"));
+                    });
+                    context.completeNow();
+                });
+    }
+
+    @Test
     void openapiTest(VertxTestContext context) {
         baseService()
             .getRequest("/openapi")


### PR DESCRIPTION
This PR fixes #903 and implement what is described in proposal [71](https://github.com/strimzi/proposals/blob/main/071-deprecate-bridge-openapi-2.md).
It adds the new `/openapi/v3` endpoint to return the OpenAPI v3 specification.
It also adds the new `/openapi/v2` endpoint returning the OpenAPI v2 specification as the already existing `/openapi` endpoint.
That's for deprecating the OpenAPI v2 specification, incouraging users to use the v3 endpoint because v2 will be removed at the beginning of 2025 (as per proposal above).