### PR TITLE
Added additional check OpenAPI version on `/openapi` endpoint

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
@@ -117,6 +117,9 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
                         assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
                         JsonObject bridgeResponse = response.body();
 
+                        String version = bridgeResponse.getString("swagger");
+                        assertThat(version, is("2.0"));
+
                         Map<String, Object> paths = bridgeResponse.getJsonObject("paths").getMap();
                         // subscribe, list subscriptions and unsubscribe are using the same endpoint but different methods (-2)
                         // getTopic and send are using the same endpoint but different methods (-1)


### PR DESCRIPTION
Related to #905 , this PR adds the check on the OpenAPI version in the test on the `/openapi` endpoint to be sure it still returns the (deprecated) v2 version for now.