### PR TITLE
Update the Prometheus JMX Collector and Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.30.0
+
+* Dependency updates (Prometheus JMX Collector 1.0.1, Prometheus Client 1.3.1)
+
 ## 0.29.0
 
 * Dependency updates (Vert.x 4.5.8, Netty 4.1.110.Final)

--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,8 @@
 		<opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version>
 		<grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
 		<micrometer.version>1.12.3</micrometer.version>
-		<jmx-prometheus-collector.version>0.18.0</jmx-prometheus-collector.version>
-		<prometheus-simpleclient.version>0.16.0</prometheus-simpleclient.version>
+		<jmx-prometheus-collector.version>1.0.1</jmx-prometheus-collector.version>
+		<prometheus-client.version>1.3.1</prometheus-client.version>
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.106.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
@@ -292,13 +292,13 @@
 		</dependency>
 		<dependency>
 			<groupId>io.prometheus</groupId>
-			<artifactId>simpleclient</artifactId>
-			<version>${prometheus-simpleclient.version}</version>
+			<artifactId>prometheus-metrics-model</artifactId>
+			<version>${prometheus-client.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.prometheus</groupId>
-			<artifactId>simpleclient_common</artifactId>
-			<version>${prometheus-simpleclient.version}</version>
+			<artifactId>prometheus-metrics-exposition-formats</artifactId>
+			<version>${prometheus-client.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>
@@ -493,6 +493,7 @@
 						</goals>
 						<configuration>
 							<appendAssemblyId>false</appendAssemblyId>
+							<tarLongFileMode>posix</tarLongFileMode>
 							<descriptors>
 								<descriptor>src/main/assembly/assembly.xml</descriptor>
 							</descriptors>

--- a/src/main/resources/jmx_metrics_config.yaml
+++ b/src/main/resources/jmx_metrics_config.yaml
@@ -2,9 +2,23 @@ lowercaseOutputName: true
 
 rules:
   # more specific rules to consumer and producer with topic related information
+  - pattern: kafka.producer<type=(.+), client-id=(.+), topic=(.+)><>([a-z-]+)-total
+    name: strimzi_bridge_kafka_producer_$4_total
+    type: COUNTER
+    labels:
+      type: "$1"
+      clientId: "$2"
+      topic: "$3"
   - pattern: kafka.producer<type=(.+), client-id=(.+), topic=(.+)><>([a-z-]+)
     name: strimzi_bridge_kafka_producer_$4
     type: GAUGE
+    labels:
+      type: "$1"
+      clientId: "$2"
+      topic: "$3"
+  - pattern: kafka.consumer<type=(.+), client-id=(.+), topic=(.+)><>([a-z-]+)-total
+    name: strimzi_bridge_kafka_consumer_$4_total
+    type: COUNTER
     labels:
       type: "$1"
       clientId: "$2"
@@ -17,6 +31,18 @@ rules:
       clientId: "$2"
       topic: "$3"
   # more general metrics
+  - pattern: kafka.(\w+)<type=(.+), client-id=(.+)><>([a-z-]+-total-[a-z-]+) # handles the metrics with total in the middle of the metric name
+    name: strimzi_bridge_kafka_$1_$4
+    type: GAUGE
+    labels:
+      type: "$2"
+      clientId: "$3"
+  - pattern: kafka.(\w+)<type=(.+), client-id=(.+)><>([a-z-]+)-total
+    name: strimzi_bridge_kafka_$1_$4_total
+    type: COUNTER
+    labels:
+      type: "$2"
+      clientId: "$3"
   - pattern: kafka.(\w+)<type=(.+), client-id=(.+)><>([a-z-]+)
     name: strimzi_bridge_kafka_$1_$4
     type: GAUGE


### PR DESCRIPTION
This PR updates the Prometheus JMX Collector to 1.0.1. This new version has many changes to how it treats the metrics with some keywords such as `_total`. This required an update to the metrics configuration YAMl to maintain the compatibility of the produced metrics (essentially, the counters using `_total` suffix need to be mapped to counters in the rules).

In addition, the Prometheus Simple Client is now archived and not anymore supported by the Prometheus JMX Exporter. So it also moves the bridge to use the current Prometheus Client.