### PR TITLE
Fix pushing of artifacts to Nexus

### DIFF
--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo "Build reason: ${BUILD_REASON}"
 echo "Source branch: ${BRANCH}"
 
-GPG_TTY=$(tty)
-export GPG_TTY
+function cleanup() {
+  rm -rf signing.gpg
+  gpg --delete-keys
+  gpg --delete-secret-keys
+}
 
-echo "$GPG_SIGNING_KEY" | base64 -d > signing.gpg
+# Run the cleanup on failure / exit
+trap cleanup EXIT
+
+export GPG_TTY=$(tty)
+echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
 GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
 
-rm -rf signing.gpg
-gpg --delete-keys
-gpg --delete-secret-keys
+cleanup

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 		<maven.source.version>3.2.1</maven.source.version>
 		<maven.dependency.version>3.3.0</maven.dependency.version>
 		<maven.gpg.version>3.0.1</maven.gpg.version>
-		<sonatype.nexus.staging>1.6.7</sonatype.nexus.staging>
+		<sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
 		<swagger2markup-plugin.version>1.3.7</swagger2markup-plugin.version>
 		<swagger2markup.version>1.3.4</swagger2markup.version>
 		<jackson-core.version>2.16.1</jackson-core.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some changes at Sonatype broker the way we push the JAR artifacts to Sonatype Nexus. This PR fixes it by updating the Sonatype plugin. It also updates the script we use for it to make it fail in case of problems.