### PR TITLE
Bump Vert.x and Netty versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.30.0
 
-* Dependency updates (Kafka 3.7.1, Prometheus JMX Collector 1.0.1, Prometheus Client 1.3.1)
+* Dependency updates (Kafka 3.7.1, Vert.x 4.5.9, Netty 4.1.111.Final, Prometheus JMX Collector 1.0.1, Prometheus Client 1.3.1)
 
 ## 0.29.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,9 +100,9 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
-		<vertx.version>4.5.8</vertx.version>
-		<vertx-testing.version>4.5.8</vertx-testing.version>
-		<netty.version>4.1.110.Final</netty.version>
+		<vertx.version>4.5.9</vertx.version>
+		<vertx-testing.version>4.5.9</vertx-testing.version>
+		<netty.version>4.1.111.Final</netty.version>
 		<kafka.version>3.7.1</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
This trivial PR bumps the Vert.x and Netty dependencies to 4.5.9 and 4.1.111.