### PR TITLE
Update Kubernetes Config Provider to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 		<vertx-testing.version>4.5.10</vertx-testing.version>
 		<netty.version>4.1.111.Final</netty.version>
 		<kafka.version>3.8.0</kafka.version>
-		<kafka-kubernetes-config-provider.version>1.1.2</kafka-kubernetes-config-provider.version>
+		<kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<maven.checkstyle.version>3.3.0</maven.checkstyle.version>
 		<checkstyle.version>10.12.2</checkstyle.version>


### PR DESCRIPTION
This Pr updates the Kubernetes Config Provider that is bundled in the Bridge container image to the new release 1.2.0.