### PR TITLE
Excluded android related dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,12 @@
 			<artifactId>grpc-netty-shaded</artifactId>
 			<version>${grpc-netty-shaded.version}</version>
 			<scope>runtime</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>annotations</artifactId>
+					<groupId>com.google.android</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>


### PR DESCRIPTION
This PR excludes `com.google.android:annotations` dependency from the `grpc-netty-shaded` because it's unneeded as bridge won't run on Android devices. This way we avoid to deliver useless jars.