### PR TITLE
Fixed a Vert.x bump to 4.5.11 which was lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.31.0
 
-* Dependency updates (Kafka 3.9.0, Vert.x 4.5.10)
+* Dependency updates (Kafka 3.9.0, Vert.x 4.5.11, Netty 4.1.115.Final)
 * Added support for creating a new topic via endpoint.
 
 ## 0.30.0

--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
-		<vertx.version>4.5.10</vertx.version>
-		<vertx-testing.version>4.5.10</vertx-testing.version>
+		<vertx.version>4.5.11</vertx.version>
+		<vertx-testing.version>4.5.11</vertx-testing.version>
 		<netty.version>4.1.115.Final</netty.version>
 		<kafka.version>3.9.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>


### PR DESCRIPTION
After merging https://github.com/strimzi/strimzi-kafka-bridge/pull/929, the Vert.x bump was lost and the CHANGELOG was in an incosistent state.
This PR fixes the issue.