### PR TITLE
Fix metadata order in response when producing records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Dependency updates (Kafka 3.9.0, Vert.x 4.5.11, Netty 4.1.115.Final)
 * Added support for creating a new topic via endpoint.
+* Fixed metadata order on the HTTP "offsets" response when producing records.
 
 ## 0.30.0
 


### PR DESCRIPTION
fix: preserve record send order in response metadata
    
This uses the send CompletionStages to keep the original ordering of records.

kafka-clients [KafkaProducer#send](https://kafka.apache.org/39/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#send(org.apache.kafka.clients.producer.ProducerRecord,org.apache.kafka.clients.producer.Callback)) only guarantees that callbacks are executed in order per partition, the ordering across partitions is not guaranteed.

> Callbacks for records being sent to the same partition are guaranteed to execute in order. That is, in the following example callback1 is guaranteed to execute before callback2:
>
> producer.send(new ProducerRecord<byte[],byte[]>(topic, partition, key1, value1), callback1);
> producer. send(new ProducerRecord<byte[],byte[]>(topic, partition, key2, value2), callback2);

Closes #944