### PR TITLE
Updated documentation about next SNAPSHOT version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.32.0
+
+
 ## 0.31.0
 
 * Dependency updates (Kafka 3.9.0, Vert.x 4.5.11, Netty 4.1.115.Final)

--- a/development-docs/RELEASING.md
+++ b/development-docs/RELEASING.md
@@ -30,6 +30,8 @@ The build pipeline should automatically start for any new commit pushed into the
 Wait until the build pipeline is (successfully) finished for the last commit in the release branch.
 The regular pipeline will build the release ZIP / TAR.GZ files as well as the documentation and store them as artifacts.
 It will also stage the Maven artifacts.
+When it's done, mark the build in the Azure Pipelines UI to be retained forever
+
 Then run the release pipeline manually from the Azure Pipelines UI.
 The release pipeline is named `kafka-bridge-release`.
 When starting the new run, it will ask for several parameters which you need to fill:
@@ -60,6 +62,13 @@ Announce the release on following channels:
 * Mailing lists
 * Slack
 * Twitter (if the release is significant enough)
+
+### Update to next release
+
+The `main` git branch has to be updated with the next SNAPSHOT version.
+Update the version to the next SNAPSHOT version using the `next_version` `make` target. 
+For example to update the next version to 0.32.0-SNAPSHOT run: `make NEXT_VERSION=0.32.0-SNAPSHOT next_version`.
+Add a header for the new release to the CHANGELOG.md file
 
 ### Release candidates
 


### PR DESCRIPTION
This trivial PR updates the documentation about:

* how to update the main branch with the next SNAPSHOT version
* remember to retain the build in Azure when releasing

It also adds an empty section for the future 0.32.0 release in the CHANGELOG.md.