### PR TITLE
Updated main CHANGELOG with the 0.31.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 0.32.0
 
 
+## 0.31.1
+
+* Fixed missing SCRAM-SHA-256 support.
+
 ## 0.31.0
 
 * Dependency updates (Kafka 3.9.0, Vert.x 4.5.11, Netty 4.1.115.Final)


### PR DESCRIPTION
This trivial PR just updates the main CHANGELOG including the latest 0.31.1 patch release that was missing when we already moved to have the 0.32.0 section there (after the 0.31.0 release).