### PR TITLE
Update JMX exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.32.0
 
+* Dependency updates (JMX exporter 1.1.0)
 
 ## 0.31.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,8 +132,8 @@
 		<opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version>
 		<grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
 		<micrometer.version>1.12.3</micrometer.version>
-		<jmx-prometheus-collector.version>1.0.1</jmx-prometheus-collector.version>
-		<prometheus-client.version>1.3.1</prometheus-client.version>
+		<jmx-prometheus-collector.version>1.1.0</jmx-prometheus-collector.version>
+		<prometheus-client.version>1.3.4</prometheus-client.version>
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.109.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
@@ -302,7 +302,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.prometheus</groupId>
-			<artifactId>prometheus-metrics-exposition-formats</artifactId>
+			<artifactId>prometheus-metrics-exposition-textformats</artifactId>
 			<version>${prometheus-client.version}</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
As already done in the Strimzi cluster operator, this PR bumps the JMX exporter to the new 1.1.0 release (with also the corresponding new Prometheus client).