### PR TITLE
Using JDK 17

### DIFF
--- a/.azure/templates/jobs/build_docs.yaml
+++ b/.azure/templates/jobs/build_docs.yaml
@@ -3,9 +3,9 @@ jobs:
     displayName: 'Build Docs'
     strategy:
       matrix:
-        'java-11':
+        'java-17':
           image: 'Ubuntu-22.04'
-          jdk_version: '11'
+          jdk_version: '17'
     # Strategy for the job
     # Set timeout for jobs
     timeoutInMinutes: 60

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -4,14 +4,10 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-11':
-          image: 'Ubuntu-22.04'
-          jdk_version: '11'
-          main_build: 'true'
         'java-17':
           image: 'Ubuntu-22.04'
           jdk_version: '17'
-          main_build: 'false'
+          main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system

--- a/.azure/templates/steps/prerequisites/install_java.yaml
+++ b/.azure/templates/steps/prerequisites/install_java.yaml
@@ -1,7 +1,7 @@
 # Step to configure JAVA on the agent
 parameters:
   - name: JDK_VERSION
-    default: '11'
+    default: '17'
 steps:
   - task: JavaToolInstaller@0
     inputs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,11 +37,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     
-    # Setup OpenJDK 11
+    # Setup OpenJDK 17
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: 'maven'
 
     # Initializes the CodeQL tools for scanning.

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   - build: ppc64le
     os: linux
     arch: ppc64le
-    jdk: openjdk11
+    jdk: openjdk17
     script: mvn install -Dmaven.javadoc.skip=true
     addons:
       apt:
@@ -17,7 +17,7 @@ jobs:
   - build: s390x
     os: linux
     arch: s390x
-    jdk: openjdk11
+    jdk: openjdk17
     # because of flakiness of tests on s390x, adding automatic retries on failure
     script: mvn install -Dmaven.javadoc.skip=true -Dfailsafe.rerunFailingTestsCount=10
     addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.32.0
 
 * Dependency updates (JMX exporter 1.1.0)
+* Dropped support for Java 11 and replaced with Java 17.
 
 ## 0.31.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.release>17</maven.compiler.release>
 		<log4j.version>2.17.2</log4j.version>
 		<vertx.version>4.5.11</vertx.version>
 		<vertx-testing.version>4.5.11</vertx-testing.version>


### PR DESCRIPTION
This PR moves the project to use Maven compiler 17 (from 11) and to use JDK 17 (removing JDK) 11 from pipelines.