### PR TITLE
Fixed missing Java 17 installation on deploy job

### DIFF
--- a/.azure/templates/jobs/deploy_java.yaml
+++ b/.azure/templates/jobs/deploy_java.yaml
@@ -1,6 +1,13 @@
 jobs:
   - job: 'deploy_java'
     displayName: 'Deploy Java'
+    # Strategy for the job
+    strategy:
+      matrix:
+        'java-17':
+          image: 'Ubuntu-22.04'
+          jdk_version: '17'
+          main_build: 'true'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system
@@ -8,6 +15,7 @@ jobs:
       vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
+      - template: '../steps/prerequisites/install_java.yaml'
       - task: DownloadPipelineArtifact@2
         inputs:
           source: '${{ parameters.artifactSource }}'


### PR DESCRIPTION
The current pipeline is failing on deploy Java because it's using the pre-installed Java 11 while we moved to Java 17.
This PR fixes the issue by installing Java 17 as prerequisite of the deploy job.