### PR TITLE
Prepare for Vert.x 5

### DIFF
--- a/development-docs/TESTING.md
+++ b/development-docs/TESTING.md
@@ -112,7 +112,7 @@ Setup in-memory Strimzi `Kafka` container and in-memory `Kafka Bridge` example:
         httpBridge.setHealthChecker(new HealthChecker());
 
         LOGGER.info("Deploying in-memory bridge");
-        vertx.deployVerticle(httpBridge, context.succeeding(id -> context.completeNow())); <--- deploy in-memory Kafka Bridge
+        vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> context.completeNow())); <--- deploy in-memory Kafka Bridge
     
         client = WebClient.create(vertx, new WebClientOptions() <--- webclient for communication with REST API of Kafka Bridge
             .setDefaultHost(Urls.BRIDGE_HOST)
@@ -142,7 +142,7 @@ Teardown is triggered in `@AfterAll` of `HttpBridgeTestBase`:
     @AfterAll
     static void afterAll(VertxTestContext context) {
         if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {                              <--- checking if external Kafka Bridge should run
-            vertx.close(context.succeeding(arg -> context.completeNow()));      <--- closing the vertx instance
+            vertx.close().onComplete(context.succeeding(arg -> context.completeNow()));      <--- closing the vertx instance
         } else {
             // if we running external bridge
             context.completeNow();

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 		<opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
 		<opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version>
 		<grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
-		<micrometer.version>1.12.3</micrometer.version>
+		<micrometer.version>1.12.13</micrometer.version>
 		<jmx-prometheus-collector.version>1.1.0</jmx-prometheus-collector.version>
 		<prometheus-client.version>1.3.4</prometheus-client.version>
 		<commons-cli.version>1.4</commons-cli.version>

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -119,15 +119,16 @@ public class Application {
         Promise<HttpBridge> httpPromise = Promise.promise();
 
         HttpBridge httpBridge = new HttpBridge(bridgeConfig, metricsReporter);
-        vertx.deployVerticle(httpBridge, done -> {
-            if (done.succeeded()) {
-                LOGGER.info("HTTP verticle instance deployed [{}]", done.result());
-                httpPromise.complete(httpBridge);
-            } else {
-                LOGGER.error("Failed to deploy HTTP verticle instance", done.cause());
-                httpPromise.fail(done.cause());
-            }
-        });
+        vertx.deployVerticle(httpBridge)
+                .onComplete(done -> {
+                    if (done.succeeded()) {
+                        LOGGER.info("HTTP verticle instance deployed [{}]", done.result());
+                        httpPromise.complete(httpBridge);
+                    } else {
+                        LOGGER.error("Failed to deploy HTTP verticle instance", done.cause());
+                        httpPromise.fail(done.cause());
+                    }
+                });
 
         return httpPromise.future();
     }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -92,10 +92,11 @@ public class HttpBridge extends AbstractVerticle {
     private void bindHttpServer(Promise<Void> startPromise) {
         HttpServerOptions httpServerOptions = httpServerOptions();
 
-        this.httpServer = this.vertx.createHttpServer(httpServerOptions)
+        this.vertx.createHttpServer(httpServerOptions)
                 .connectionHandler(this::processConnection)
                 .requestHandler(this.router)
-                .listen(httpServerAsyncResult -> {
+                .listen()
+                .onComplete(httpServerAsyncResult -> {
                     if (httpServerAsyncResult.succeeded()) {
                         LOGGER.info("HTTP-Kafka Bridge started and listening on port {}", httpServerAsyncResult.result().actualPort());
                         LOGGER.info("HTTP-Kafka Bridge bootstrap servers {}",
@@ -108,6 +109,7 @@ public class HttpBridge extends AbstractVerticle {
                         }
 
                         this.isReady = true;
+                        this.httpServer = httpServerAsyncResult.result();
                         startPromise.complete();
                     } else {
                         LOGGER.error("Error starting HTTP-Kafka Bridge", httpServerAsyncResult.cause());
@@ -139,66 +141,67 @@ public class HttpBridge extends AbstractVerticle {
     @Override
     public void start(Promise<Void> startPromise) {
 
-        RouterBuilder.create(vertx, "openapi.json", ar -> {
-            if (ar.succeeded()) {
-                RouterBuilder routerBuilder = ar.result();
-                routerBuilder.operation(this.SEND.getOperationId().toString()).handler(this.SEND);
-                routerBuilder.operation(this.SEND_TO_PARTITION.getOperationId().toString()).handler(this.SEND_TO_PARTITION);
-                routerBuilder.operation(this.CREATE_CONSUMER.getOperationId().toString()).handler(this.CREATE_CONSUMER);
-                routerBuilder.operation(this.DELETE_CONSUMER.getOperationId().toString()).handler(this.DELETE_CONSUMER);
-                routerBuilder.operation(this.SUBSCRIBE.getOperationId().toString()).handler(this.SUBSCRIBE);
-                routerBuilder.operation(this.UNSUBSCRIBE.getOperationId().toString()).handler(this.UNSUBSCRIBE);
-                routerBuilder.operation(this.LIST_SUBSCRIPTIONS.getOperationId().toString()).handler(this.LIST_SUBSCRIPTIONS);
-                routerBuilder.operation(this.ASSIGN.getOperationId().toString()).handler(this.ASSIGN);
-                routerBuilder.operation(this.POLL.getOperationId().toString()).handler(this.POLL);
-                routerBuilder.operation(this.COMMIT.getOperationId().toString()).handler(this.COMMIT);
-                routerBuilder.operation(this.SEEK.getOperationId().toString()).handler(this.SEEK);
-                routerBuilder.operation(this.SEEK_TO_BEGINNING.getOperationId().toString()).handler(this.SEEK_TO_BEGINNING);
-                routerBuilder.operation(this.SEEK_TO_END.getOperationId().toString()).handler(this.SEEK_TO_END);
-                routerBuilder.operation(this.LIST_TOPICS.getOperationId().toString()).handler(this.LIST_TOPICS);
-                routerBuilder.operation(this.GET_TOPIC.getOperationId().toString()).handler(this.GET_TOPIC);
-                routerBuilder.operation(this.CREATE_TOPIC.getOperationId().toString()).handler(this.CREATE_TOPIC);
-                routerBuilder.operation(this.LIST_PARTITIONS.getOperationId().toString()).handler(this.LIST_PARTITIONS);
-                routerBuilder.operation(this.GET_PARTITION.getOperationId().toString()).handler(this.GET_PARTITION);
-                routerBuilder.operation(this.GET_OFFSETS.getOperationId().toString()).handler(this.GET_OFFSETS);
-                routerBuilder.operation(this.HEALTHY.getOperationId().toString()).handler(this.HEALTHY);
-                routerBuilder.operation(this.READY.getOperationId().toString()).handler(this.READY);
-                routerBuilder.operation(this.OPENAPI.getOperationId().toString()).handler(this.OPENAPI);
-                routerBuilder.operation(this.OPENAPIV2.getOperationId().toString()).handler(this.OPENAPIV2);
-                routerBuilder.operation(this.OPENAPIV3.getOperationId().toString()).handler(this.OPENAPIV3);
-                routerBuilder.operation(this.METRICS.getOperationId().toString()).handler(this.METRICS);
-                routerBuilder.operation(this.INFO.getOperationId().toString()).handler(this.INFO);
-                if (this.bridgeConfig.getHttpConfig().isCorsEnabled()) {
-                    routerBuilder.rootHandler(getCorsHandler());
-                    // body handler is added automatically when the global handlers in the OpenAPI builder is empty
-                    // when adding the CORS handler, we have to add the body handler explicitly instead
-                    routerBuilder.rootHandler(BodyHandler.create());
-                }
+        RouterBuilder.create(vertx, "openapi.json")
+                .onComplete(ar -> {
+                    if (ar.succeeded()) {
+                        RouterBuilder routerBuilder = ar.result();
+                        routerBuilder.operation(this.SEND.getOperationId().toString()).handler(this.SEND);
+                        routerBuilder.operation(this.SEND_TO_PARTITION.getOperationId().toString()).handler(this.SEND_TO_PARTITION);
+                        routerBuilder.operation(this.CREATE_CONSUMER.getOperationId().toString()).handler(this.CREATE_CONSUMER);
+                        routerBuilder.operation(this.DELETE_CONSUMER.getOperationId().toString()).handler(this.DELETE_CONSUMER);
+                        routerBuilder.operation(this.SUBSCRIBE.getOperationId().toString()).handler(this.SUBSCRIBE);
+                        routerBuilder.operation(this.UNSUBSCRIBE.getOperationId().toString()).handler(this.UNSUBSCRIBE);
+                        routerBuilder.operation(this.LIST_SUBSCRIPTIONS.getOperationId().toString()).handler(this.LIST_SUBSCRIPTIONS);
+                        routerBuilder.operation(this.ASSIGN.getOperationId().toString()).handler(this.ASSIGN);
+                        routerBuilder.operation(this.POLL.getOperationId().toString()).handler(this.POLL);
+                        routerBuilder.operation(this.COMMIT.getOperationId().toString()).handler(this.COMMIT);
+                        routerBuilder.operation(this.SEEK.getOperationId().toString()).handler(this.SEEK);
+                        routerBuilder.operation(this.SEEK_TO_BEGINNING.getOperationId().toString()).handler(this.SEEK_TO_BEGINNING);
+                        routerBuilder.operation(this.SEEK_TO_END.getOperationId().toString()).handler(this.SEEK_TO_END);
+                        routerBuilder.operation(this.LIST_TOPICS.getOperationId().toString()).handler(this.LIST_TOPICS);
+                        routerBuilder.operation(this.GET_TOPIC.getOperationId().toString()).handler(this.GET_TOPIC);
+                        routerBuilder.operation(this.CREATE_TOPIC.getOperationId().toString()).handler(this.CREATE_TOPIC);
+                        routerBuilder.operation(this.LIST_PARTITIONS.getOperationId().toString()).handler(this.LIST_PARTITIONS);
+                        routerBuilder.operation(this.GET_PARTITION.getOperationId().toString()).handler(this.GET_PARTITION);
+                        routerBuilder.operation(this.GET_OFFSETS.getOperationId().toString()).handler(this.GET_OFFSETS);
+                        routerBuilder.operation(this.HEALTHY.getOperationId().toString()).handler(this.HEALTHY);
+                        routerBuilder.operation(this.READY.getOperationId().toString()).handler(this.READY);
+                        routerBuilder.operation(this.OPENAPI.getOperationId().toString()).handler(this.OPENAPI);
+                        routerBuilder.operation(this.OPENAPIV2.getOperationId().toString()).handler(this.OPENAPIV2);
+                        routerBuilder.operation(this.OPENAPIV3.getOperationId().toString()).handler(this.OPENAPIV3);
+                        routerBuilder.operation(this.METRICS.getOperationId().toString()).handler(this.METRICS);
+                        routerBuilder.operation(this.INFO.getOperationId().toString()).handler(this.INFO);
+                        if (this.bridgeConfig.getHttpConfig().isCorsEnabled()) {
+                            routerBuilder.rootHandler(getCorsHandler());
+                            // body handler is added automatically when the global handlers in the OpenAPI builder is empty
+                            // when adding the CORS handler, we have to add the body handler explicitly instead
+                            routerBuilder.rootHandler(BodyHandler.create());
+                        }
 
-                this.router = routerBuilder.createRouter();
+                        this.router = routerBuilder.createRouter();
 
-                // handling validation errors and not existing endpoints
-                this.router.errorHandler(HttpResponseStatus.BAD_REQUEST.code(), this::errorHandler);
-                this.router.errorHandler(HttpResponseStatus.NOT_FOUND.code(), this::errorHandler);
+                        // handling validation errors and not existing endpoints
+                        this.router.errorHandler(HttpResponseStatus.BAD_REQUEST.code(), this::errorHandler);
+                        this.router.errorHandler(HttpResponseStatus.NOT_FOUND.code(), this::errorHandler);
 
-                if (this.metricsReporter.getMeterRegistry() != null) {
-                    // exclude to report the HTTP server metrics for the /metrics endpoint itself
-                    this.metricsReporter.getMeterRegistry().config().meterFilter(
-                            MeterFilter.deny(meter -> "/metrics".equals(meter.getTag(Label.HTTP_PATH.toString())))
-                    );
-                }
+                        if (this.metricsReporter.getMeterRegistry() != null) {
+                            // exclude to report the HTTP server metrics for the /metrics endpoint itself
+                            this.metricsReporter.getMeterRegistry().config().meterFilter(
+                                    MeterFilter.deny(meter -> "/metrics".equals(meter.getTag(Label.HTTP_PATH.toString())))
+                            );
+                        }
 
-                LOGGER.info("Starting HTTP-Kafka bridge verticle...");
-                this.httpBridgeContext = new HttpBridgeContext<>();
-                HttpAdminBridgeEndpoint adminClientEndpoint = new HttpAdminBridgeEndpoint(this.bridgeConfig, this.httpBridgeContext);
-                this.httpBridgeContext.setHttpAdminEndpoint(adminClientEndpoint);
-                adminClientEndpoint.open();
-                this.bindHttpServer(startPromise);
-            } else {
-                LOGGER.error("Failed to create OpenAPI router factory");
-                startPromise.fail(ar.cause());
-            }
-        });
+                        LOGGER.info("Starting HTTP-Kafka bridge verticle...");
+                        this.httpBridgeContext = new HttpBridgeContext<>();
+                        HttpAdminBridgeEndpoint adminClientEndpoint = new HttpAdminBridgeEndpoint(this.bridgeConfig, this.httpBridgeContext);
+                        this.httpBridgeContext.setHttpAdminEndpoint(adminClientEndpoint);
+                        adminClientEndpoint.open();
+                        this.bindHttpServer(startPromise);
+                    } else {
+                        LOGGER.error("Failed to create OpenAPI router factory");
+                        startPromise.fail(ar.cause());
+                    }
+                });
     }
 
     private CorsHandler getCorsHandler() {
@@ -251,16 +254,16 @@ public class HttpBridge extends AbstractVerticle {
 
         if (this.httpServer != null) {
 
-            this.httpServer.close(done -> {
-
-                if (done.succeeded()) {
-                    LOGGER.info("HTTP-Kafka bridge has been shut down successfully");
-                    stopPromise.complete();
-                } else {
-                    LOGGER.info("Error while shutting down HTTP-Kafka bridge", done.cause());
-                    stopPromise.fail(done.cause());
-                }
-            });
+            this.httpServer.close()
+                    .onComplete(done -> {
+                        if (done.succeeded()) {
+                            LOGGER.info("HTTP-Kafka bridge has been shut down successfully");
+                            stopPromise.complete();
+                        } else {
+                            LOGGER.info("Error while shutting down HTTP-Kafka bridge", done.cause());
+                            stopPromise.fail(done.cause());
+                        }
+                    });
         }
     }
 
@@ -524,33 +527,34 @@ public class HttpBridge extends AbstractVerticle {
 
     private void openapi(RoutingContext routingContext) {
         FileSystem fileSystem = vertx.fileSystem();
-        fileSystem.readFile("openapi.json", readFile -> {
-            if (readFile.succeeded()) {
-                String xForwardedPath = routingContext.request().getHeader("x-forwarded-path");
-                String xForwardedPrefix = routingContext.request().getHeader("x-forwarded-prefix");
-                if (xForwardedPath == null && xForwardedPrefix == null) {
-                    HttpUtils.sendFile(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, "openapi.json");
-                } else {
-                    String path = "/";
-                    if (xForwardedPrefix != null) {
-                        path = xForwardedPrefix;
+        fileSystem.readFile("openapi.json")
+                .onComplete(readFile -> {
+                    if (readFile.succeeded()) {
+                        String xForwardedPath = routingContext.request().getHeader("x-forwarded-path");
+                        String xForwardedPrefix = routingContext.request().getHeader("x-forwarded-prefix");
+                        if (xForwardedPath == null && xForwardedPrefix == null) {
+                            HttpUtils.sendFile(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, "openapi.json");
+                        } else {
+                            String path = "/";
+                            if (xForwardedPrefix != null) {
+                                path = xForwardedPrefix;
+                            }
+                            if (xForwardedPath != null) {
+                                path = xForwardedPath;
+                            }
+                            ObjectNode json = (ObjectNode) JsonUtils.bytesToJson(readFile.result().getBytes());
+                            json.put("basePath", path);
+                            HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, JsonUtils.jsonToBytes(json));
+                        }
+                    } else {
+                        LOGGER.error("Failed to read OpenAPI JSON file", readFile.cause());
+                        HttpBridgeError error = new HttpBridgeError(
+                            HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                            readFile.cause().getMessage());
+                        HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+                                BridgeContentType.JSON, JsonUtils.jsonToBytes(error.toJson()));
                     }
-                    if (xForwardedPath != null) {
-                        path = xForwardedPath;
-                    }
-                    ObjectNode json = (ObjectNode) JsonUtils.bytesToJson(readFile.result().getBytes());
-                    json.put("basePath", path);
-                    HttpUtils.sendResponse(routingContext, HttpResponseStatus.OK.code(), BridgeContentType.JSON, JsonUtils.jsonToBytes(json));
-                }
-            } else {
-                LOGGER.error("Failed to read OpenAPI JSON file", readFile.cause());
-                HttpBridgeError error = new HttpBridgeError(
-                    HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                    readFile.cause().getMessage());
-                HttpUtils.sendResponse(routingContext, HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                        BridgeContentType.JSON, JsonUtils.jsonToBytes(error.toJson()));
-            }
-        });
+                });
     }
 
     private void metrics(RoutingContext routingContext) {

--- a/src/test/java/io/strimzi/kafka/bridge/clients/Producer.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/Producer.java
@@ -92,7 +92,7 @@ public class Producer extends ClientHandlerBase<Integer> implements AutoCloseabl
 
             record.addHeaders(headers);
 
-            producer.send(record, done -> {
+            producer.send(record).onComplete(done -> {
                 if (done.succeeded()) {
                     RecordMetadata recordMetadata = done.result();
                     LOGGER.info("Message {} written on topic={}, partition={}, offset={}",

--- a/src/test/java/io/strimzi/kafka/bridge/http/AdminClientIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/AdminClientIT.java
@@ -32,7 +32,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .getRequest("/topics")
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -52,7 +53,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .getRequest("/topics/" + topic)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -85,7 +87,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .getRequest("/topics/" + topic)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -102,7 +105,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .getRequest("/topics/" + topic + "/partitions")
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -132,7 +136,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .getRequest("/topics/" + topic + "/partitions/0")
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -157,7 +162,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .getRequest("/topics/" + topic + "/partitions/0/offsets")
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -175,7 +181,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .getRequest("/topics/" + topic + "/partitions/0/offsets")
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -207,7 +214,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> producer = new CompletableFuture<>();
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                .sendJsonObject(root, ar1 -> {
+                .sendJsonObject(root)
+                .onComplete(ar1 -> {
                     context.verify(() -> {
                         assertThat(ar1.succeeded(), is(true));
                         producer.complete(true);
@@ -224,7 +232,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .postRequest("/admin/topics")
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(jsonObject, ar -> {
+                .sendJsonObject(jsonObject)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -243,7 +252,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .postRequest("/admin/topics")
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(jsonObject, ar -> {
+                .sendJsonObject(jsonObject)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -264,7 +274,8 @@ public class AdminClientIT extends HttpBridgeITAbstract {
         baseService()
                 .postRequest("/admin/topics")
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(jsonObject, ar -> {
+                .sendJsonObject(jsonObject)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
@@ -101,7 +101,7 @@ public class ConsumerGeneratedNameIT {
             httpBridge = new HttpBridge(bridgeConfig, new MetricsReporter(jmxCollectorRegistry, meterRegistry));
 
             LOGGER.info("Deploying in-memory bridge");
-            vertx.deployVerticle(httpBridge, context.succeeding(id -> context.completeNow()));
+            vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> context.completeNow()));
         }
         // else we create external bridge from the OS invoked by `.jar`
 
@@ -115,7 +115,7 @@ public class ConsumerGeneratedNameIT {
     static void afterAll(VertxTestContext context) {
         if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
             kafkaContainer.stop();
-            vertx.close(context.succeeding(arg -> context.completeNow()));
+            vertx.close().onComplete(context.succeeding(arg -> context.completeNow()));
         }
     }
 
@@ -127,7 +127,8 @@ public class ConsumerGeneratedNameIT {
         consumerService()
             .createConsumerRequest(groupId, json)
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(json, ar -> {
+                .sendJsonObject(json)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         LOGGER.info("Verifying that consumer name is created with 'kafka-bridge-consumer-' plus random hashcode");
                         assertThat(ar.succeeded(), is(true));
@@ -157,7 +158,8 @@ public class ConsumerGeneratedNameIT {
         consumerService()
                 .createConsumerRequest(groupId, json)
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(json, ar -> {
+                .sendJsonObject(json)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -85,7 +85,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         // create consumer
         CompletableFuture<Boolean> create = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, consumerJson)
-                .sendJsonObject(consumerJson, ar -> {
+                .sendJsonObject(consumerJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -109,7 +110,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         // create consumer
         CompletableFuture<Boolean> create = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, null)
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -147,7 +149,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         // create consumer
         CompletableFuture<Boolean> createBooleanAsString = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, consumerJson)
-                .sendJsonObject(consumerJson, ar -> {
+                .sendJsonObject(consumerJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -168,7 +171,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         // create consumer
         CompletableFuture<Boolean> createGenericString = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, consumerJson)
-                .sendJsonObject(consumerJson, ar -> {
+                .sendJsonObject(consumerJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -212,7 +216,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         // create consumer
         CompletableFuture<Boolean> createIntegerAsString = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, consumerJson)
-                .sendJsonObject(consumerJson, ar -> {
+                .sendJsonObject(consumerJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -233,7 +238,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         // create consumer
         CompletableFuture<Boolean> createGenericString = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, consumerJson)
-                .sendJsonObject(consumerJson, ar -> {
+                .sendJsonObject(consumerJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -264,7 +270,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService().createConsumerRequest(groupId, consumerWithEarliestResetJson)
                 .putHeader(X_FORWARDED_HOST, xForwardedHost)
                 .putHeader(X_FORWARDED_PROTO, xForwardedProto)
-                .sendJsonObject(consumerWithEarliestResetJson, ar -> {
+                .sendJsonObject(consumerWithEarliestResetJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -295,7 +302,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> create = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, consumerWithEarliestResetJson)
                 .putHeader(FORWARDED, forwarded)
-                .sendJsonObject(consumerWithEarliestResetJson, ar -> {
+                .sendJsonObject(consumerWithEarliestResetJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -331,7 +339,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> create = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, consumerWithEarliestResetJson)
                 .putHeaders(headers)
-                .sendJsonObject(consumerWithEarliestResetJson, ar -> {
+                .sendJsonObject(consumerWithEarliestResetJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -365,7 +374,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService().createConsumerRequest(groupId, consumerWithEarliestResetJson)
                 .putHeader(FORWARDED, forwarded)
                 .putHeader("X-Forwarded-Path", xForwardedPath)
-                .sendJsonObject(consumerWithEarliestResetJson, ar -> {
+                .sendJsonObject(consumerWithEarliestResetJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -396,7 +406,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> create = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, consumerWithEarliestResetJson)
                 .putHeader(FORWARDED, forwarded)
-                .sendJsonObject(consumerWithEarliestResetJson, ar -> {
+                .sendJsonObject(consumerWithEarliestResetJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -424,7 +435,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
 
         consumerService().createConsumerRequest(groupId, consumerWithEarliestResetJson)
                 .putHeader(FORWARDED, forwarded)
-                .sendJsonObject(consumerWithEarliestResetJson, ar -> {
+                .sendJsonObject(consumerWithEarliestResetJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -502,7 +514,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
             .as(BodyCodec.jsonArray())
-            .send(ar -> {
+            .send()
+            .onComplete(ar -> {
                 context.verify(() -> {
                     assertThat(ar.succeeded(), is(true));
                     HttpResponse<JsonArray> response = ar.result();
@@ -553,7 +566,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
             .as(BodyCodec.jsonArray())
-            .send(ar -> {
+            .send()
+            .onComplete(ar -> {
                 context.verify(() -> {
                     assertThat(ar.succeeded(), is(true));
                     HttpResponse<JsonArray> response = ar.result();
@@ -599,7 +613,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_TEXT)
             .as(BodyCodec.jsonArray())
-            .send(ar -> {
+            .send()
+            .onComplete(ar -> {
                 context.verify(() -> {
                     assertThat(ar.succeeded(), is(true));
                     HttpResponse<JsonArray> response = ar.result();
@@ -655,7 +670,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
             .as(BodyCodec.jsonArray())
-            .send(ar -> {
+            .send()
+            .onComplete(ar -> {
                 context.verify(() -> {
                     assertThat(ar.succeeded(), is(true));
                     HttpResponse<JsonArray> response = ar.result();
@@ -723,7 +739,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_BINARY)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -786,7 +803,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -857,7 +875,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -921,7 +940,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -975,7 +995,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -1035,7 +1056,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -1072,7 +1094,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> commit = new CompletableFuture<>();
         consumerService()
             .offsetsRequest(groupId, name, root)
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1123,7 +1146,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -1151,7 +1175,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
 
         consumerService()
             .offsetsRequest(groupId, name)
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1190,7 +1215,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         // create the same consumer again
         consumerService()
             .createConsumerRequest(groupId, json)
-                .sendJsonObject(json, ar -> {
+                .sendJsonObject(json)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1210,7 +1236,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         json.put("name", name + "diff");
         consumerService()
             .createConsumerRequest(groupId, json)
-                .sendJsonObject(json, ar -> {
+                .sendJsonObject(json)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1238,7 +1265,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
             .as(BodyCodec.jsonObject())
-            .send(ar -> {
+            .send()
+            .onComplete(ar -> {
                 context.verify(() -> {
                     assertThat(ar.succeeded(), is(true));
                     HttpResponse<JsonObject> response = ar.result();
@@ -1266,7 +1294,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
 
         consumerService()
             .offsetsRequest(groupId, name, root)
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1303,7 +1332,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, null, 1, BridgeContentType.KAFKA_JSON_BINARY)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1347,7 +1377,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -1382,7 +1413,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1423,7 +1455,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_BINARY)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1473,7 +1506,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> produce = new CompletableFuture<>();
         producerService()
             .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1506,7 +1540,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -1565,7 +1600,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1596,7 +1632,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .createConsumerRequest(groupId, json)
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(json, ar -> {
+                .sendJsonObject(json)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1624,7 +1661,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
                 .createConsumerRequest(groupId, json)
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(json, ar -> {
+                .sendJsonObject(json)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1649,7 +1687,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .createConsumerRequest(groupId, consumerJson)
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(consumerJson, ar -> {
+                .sendJsonObject(consumerJson)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1665,7 +1704,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
                             // consumer deletion
                             consumerService()
                                 .deleteConsumerRequest(groupId, name)
-                                    .send(consumerDeletedResponse -> {
+                                    .send()
+                                    .onComplete(consumerDeletedResponse -> {
                                         context.verify(() -> assertThat(ar.succeeded(), is(true)));
 
                                         HttpResponse<JsonObject> deletionResponse = consumerDeletedResponse.result();
@@ -1688,7 +1728,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
 
         CompletableFuture<Boolean> consumer = new CompletableFuture<>();
         consumerService().createConsumerRequest(groupId, json)
-            .sendJsonObject(json, ar -> {
+            .sendJsonObject(json)
+            .onComplete(ar -> {
                 context.verify(() -> {
                     assertThat(ar.succeeded(), is(true));
                     HttpResponse<JsonObject> response = ar.result();
@@ -1716,7 +1757,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
                 .createConsumerRequest(groupId, requestHeader)
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(requestHeader, ar -> {
+                .sendJsonObject(requestHeader)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1741,7 +1783,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
             .createConsumerRequest(groupId, json)
             .as(BodyCodec.jsonObject())
-            .sendJsonObject(json, ar -> {
+            .sendJsonObject(json)
+            .onComplete(ar -> {
                 context.verify(() -> {
                     assertThat(ar.succeeded(), is(true));
                     HttpResponse<JsonObject> response = ar.result();
@@ -1789,7 +1832,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> assign = new CompletableFuture<>();
         consumerService()
                 .assignRequest(groupId, name, partitionsRoot)
-                .sendJsonObject(partitionsRoot, ar -> {
+                .sendJsonObject(partitionsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), Matchers.is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1805,7 +1849,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
                 .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), CoreMatchers.is(true));
                         HttpResponse<JsonArray> response = ar.result();
@@ -1858,7 +1903,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> assign = new CompletableFuture<>();
         consumerService()
                 .assignRequest(groupId, name, partitionsRoot)
-                .sendJsonObject(partitionsRoot, ar -> {
+                .sendJsonObject(partitionsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), Matchers.is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1880,7 +1926,8 @@ public class ConsumerIT extends HttpBridgeITAbstract {
         consumerService()
                 .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), CoreMatchers.is(true));
                         HttpResponse<JsonArray> response = ar.result();

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerSubscriptionIT.java
@@ -52,7 +52,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
             .deleteRequest(Urls.consumerInstanceSubscription(groupId, name + "consumer-invalidation"))
                 .putHeader("Content-length", String.valueOf(topicsRoot.toBuffer().length()))
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(topicsRoot, ar -> {
+                .sendJsonObject(topicsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -91,7 +92,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> subscribeConflict = new CompletableFuture<>();
         consumerService()
             .subscribeConsumerRequest(groupId, name, topicsRoot)
-                .sendJsonObject(topicsRoot, ar -> {
+                .sendJsonObject(topicsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -111,7 +113,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> subscribeEmpty = new CompletableFuture<>();
         consumerService()
             .subscribeConsumerRequest(groupId, name, topicsRoot)
-                .sendJsonObject(topicsRoot, ar -> {
+                .sendJsonObject(topicsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -146,7 +149,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> subscribe = new CompletableFuture<>();
         consumerService()
             .subscribeConsumerRequest(groupId, name, topicsRoot)
-                .sendJsonObject(topicsRoot, ar -> {
+                .sendJsonObject(topicsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -186,7 +190,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         consumerService()
                 .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     if (ar.succeeded()) {
                         LOGGER.info("Request result: {}", ar.result().body());
                         consume.complete(true);
@@ -199,7 +204,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         consumerService()
                 .listSubscriptionsConsumerRequest(groupId, name)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -216,7 +222,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> subscribe = new CompletableFuture<>();
         consumerService()
                 .subscribeConsumerRequest(groupId, name, unsubscribeTopicRoot)
-                .sendJsonObject(unsubscribeTopicRoot, ar -> {
+                .sendJsonObject(unsubscribeTopicRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -232,7 +239,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         consumerService()
                 .listSubscriptionsConsumerRequest(groupId, name)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -271,7 +279,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> subscribe = new CompletableFuture<>();
         consumerService()
                 .subscribeConsumerRequest(anotherGroupId, name, topicsRoot)
-                .sendJsonObject(topicsRoot, ar -> {
+                .sendJsonObject(topicsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -323,7 +332,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         consumerService()
                 .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonArray())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     if (ar.succeeded()) {
                         LOGGER.info("Request result: {}", ar.result().body());
                         consume.complete(true);
@@ -335,7 +345,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         consumerService()
                 .listSubscriptionsConsumerRequest(groupId, name)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -371,7 +382,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         consumerService()
                 .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -423,7 +435,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> assignCF = new CompletableFuture<>();
         consumerService()
                 .assignRequest(groupId, name, partitionsRoot)
-                .sendJsonObject(partitionsRoot, ar -> {
+                .sendJsonObject(partitionsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -475,7 +488,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> assignCF = new CompletableFuture<>();
         consumerService()
                 .assignRequest(groupId, name, partitionsRoot)
-                .sendJsonObject(partitionsRoot, ar -> {
+                .sendJsonObject(partitionsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -491,7 +505,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         consumerService()
                 .listSubscriptionsConsumerRequest(groupId, name)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -509,7 +524,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         CompletableFuture<Boolean> assignEmptyCF = new CompletableFuture<>();
         consumerService()
                 .assignRequest(groupId, name, emptyPartitionsRoot)
-                .sendJsonObject(emptyPartitionsRoot, ar -> {
+                .sendJsonObject(emptyPartitionsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -525,7 +541,8 @@ public class ConsumerSubscriptionIT extends HttpBridgeITAbstract {
         consumerService()
                 .listSubscriptionsConsumerRequest(groupId, name)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
@@ -90,7 +90,7 @@ public class HttpCorsIT {
 
     @AfterEach
     void cleanup(VertxTestContext context) {
-        vertx.close(context.succeeding(arg -> context.completeNow()));
+        vertx.close().onComplete(context.succeeding(arg -> context.completeNow()));
     }
 
     @AfterAll
@@ -107,15 +107,17 @@ public class HttpCorsIT {
         configureBridge(false, null);
 
         if ("FALSE".equalsIgnoreCase(System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE"))) {
-            vertx.deployVerticle(httpBridge, context.succeeding(id -> client
+            vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/consumers/1/instances/1/subscription")
                     .putHeader("Origin", "https://evil.io")
                     .putHeader("Access-Control-Request-Method", "POST")
-                    .send(ar -> context.verify(() -> {
+                    .send()
+                    .onComplete(ar -> context.verify(() -> {
                         assertThat(ar.result().statusCode(), is(HttpResponseStatus.METHOD_NOT_ALLOWED.code()));
                         client.request(HttpMethod.POST, 8080, "localhost", "/consumers/1/instances/1/subscription")
                                 .putHeader("Origin", "https://evil.io")
-                                .send(ar2 -> context.verify(() -> {
+                                .send()
+                                .onComplete(ar2 -> context.verify(() -> {
                                     assertThat(ar2.result().statusCode(), is(HttpResponseStatus.BAD_REQUEST.code()));
                                     context.completeNow();
                                 }));
@@ -134,16 +136,18 @@ public class HttpCorsIT {
         configureBridge(true, null);
 
         if ("FALSE".equalsIgnoreCase(System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE"))) {
-            vertx.deployVerticle(httpBridge, context.succeeding(id -> client
+            vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/consumers/1/instances/1/subscription")
                     .putHeader("Origin", "https://evil.io")
                     .putHeader("Access-Control-Request-Method", "POST")
-                    .send(ar -> context.verify(() -> {
+                    .send()
+                    .onComplete(ar -> context.verify(() -> {
                         assertThat(ar.result().statusCode(), is(HttpResponseStatus.FORBIDDEN.code()));
                         assertThat(ar.result().statusMessage(), is("CORS Rejected - Invalid origin"));
                         client.request(HttpMethod.POST, 8080, "localhost", "/consumers/1/instances/1/subscription")
                                 .putHeader("Origin", "https://evil.io")
-                                .send(ar2 -> context.verify(() -> {
+                                .send()
+                                .onComplete(ar2 -> context.verify(() -> {
                                     assertThat(ar2.result().statusCode(), is(HttpResponseStatus.FORBIDDEN.code()));
                                     assertThat(ar2.result().statusMessage(), is("CORS Rejected - Invalid origin"));
                                     context.completeNow();
@@ -172,11 +176,12 @@ public class HttpCorsIT {
         final String origin = "https://strimzi.io";
 
         if ("FALSE".equalsIgnoreCase(System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE"))) {
-            vertx.deployVerticle(httpBridge, context.succeeding(id -> client
+            vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/consumers/1/instances/1/subscription")
                     .putHeader("Origin", "https://strimzi.io")
                     .putHeader("Access-Control-Request-Method", "POST")
-                    .send(ar -> context.verify(() -> {
+                    .send()
+                    .onComplete(ar -> context.verify(() -> {
                         assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
                         assertThat(ar.result().getHeader("access-control-allow-origin"), is(origin));
                         assertThat(ar.result().getHeader("access-control-allow-headers"), is("access-control-allow-origin,content-length,x-forwarded-proto,x-forwarded-host,origin,x-requested-with,content-type,access-control-allow-methods,accept"));
@@ -185,7 +190,8 @@ public class HttpCorsIT {
                         client.request(HttpMethod.POST, 8080, "localhost", "/consumers/1/instances/1/subscription")
                                 .putHeader("Origin", "https://strimzi.io")
                                 .putHeader("content-type", BridgeContentType.KAFKA_JSON)
-                                .sendJsonObject(topicsRoot, ar2 -> context.verify(() -> {
+                                .sendJsonObject(topicsRoot)
+                                .onComplete(ar2 -> context.verify(() -> {
                                     // we don't have created a consumer, so the address for the subscription doesn't exist
                                     assertThat(ar2.result().statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
                                     context.completeNow();
@@ -221,11 +227,12 @@ public class HttpCorsIT {
         final String origin = "https://strimzi.io";
 
         if ("FALSE".equalsIgnoreCase(System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE"))) {
-            vertx.deployVerticle(httpBridge, context.succeeding(id -> client
+            vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/topics/my-topic")
                     .putHeader("Origin", "https://strimzi.io")
                     .putHeader("Access-Control-Request-Method", "POST")
-                    .send(ar -> context.verify(() -> {
+                    .send()
+                    .onComplete(ar -> context.verify(() -> {
                         assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
                         assertThat(ar.result().getHeader("access-control-allow-origin"), is(origin));
                         assertThat(ar.result().getHeader("access-control-allow-headers"), is("access-control-allow-origin,content-length,x-forwarded-proto,x-forwarded-host,origin,x-requested-with,content-type,access-control-allow-methods,accept"));
@@ -234,7 +241,8 @@ public class HttpCorsIT {
                         client.request(HttpMethod.POST, 8080, "localhost", "/topics/my-topic")
                                 .putHeader("Origin", "https://strimzi.io")
                                 .putHeader("content-type", BridgeContentType.KAFKA_JSON_JSON)
-                                .sendJsonObject(root, ar2 -> context.verify(() -> {
+                                .sendJsonObject(root)
+                                .onComplete(ar2 -> context.verify(() -> {
                                     assertThat(ar2.result().statusCode(), is(HttpResponseStatus.OK.code()));
                                     context.completeNow();
                                 }));
@@ -256,11 +264,12 @@ public class HttpCorsIT {
         final String origin = "https://strimzi.io";
 
         if ("FALSE".equalsIgnoreCase(System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE"))) {
-            vertx.deployVerticle(httpBridge, context.succeeding(id -> client
+            vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/consumers/1/instances/1/subscription")
                     .putHeader("Origin", "https://strimzi.io")
                     .putHeader("Access-Control-Request-Method", "POST")
-                    .send(ar -> context.verify(() -> {
+                    .send()
+                    .onComplete(ar -> context.verify(() -> {
                         assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
                         assertThat(ar.result().getHeader("access-control-allow-origin"), is(origin));
                         assertThat(ar.result().getHeader("access-control-allow-headers"), is("access-control-allow-origin,content-length,x-forwarded-proto,x-forwarded-host,origin,x-requested-with,content-type,access-control-allow-methods,accept"));

--- a/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
@@ -53,7 +53,8 @@ public class InvalidProducerIT extends HttpBridgeITAbstract {
 
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     assertThat(ar.succeeded(), is(true));
                     assertThat(ar.result().statusCode(), is(500));
                     context.completeNow();
@@ -78,7 +79,7 @@ public class InvalidProducerIT extends HttpBridgeITAbstract {
             httpBridge = new HttpBridge(bridgeConfig, new MetricsReporter(jmxCollectorRegistry, meterRegistry));
 
             LOGGER.info("Deploying in-memory bridge");
-            vertx.deployVerticle(httpBridge, context.succeeding(id -> context.completeNow()));
+            vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> context.completeNow()));
         } else {
             context.completeNow();
         }

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
@@ -30,8 +30,9 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
         for (int i = 1; i <= iterations; i++) {
             int l = i;
             baseService()
-                .getRequest("/ready")
-                    .send(ar -> {
+                    .getRequest("/ready")
+                    .send()
+                    .onComplete(ar -> {
                         context.verify(() -> {
                             assertThat(ar.succeeded(), is(true));
                             assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
@@ -50,8 +51,9 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
         for (int i = 1; i <= iterations; i++) {
             int l = i;
             baseService()
-                .getRequest("/healthy")
-                    .send(ar -> {
+                    .getRequest("/healthy")
+                    .send()
+                    .onComplete(ar -> {
                         context.verify(() -> {
                             LOGGER.info("Verifying that endpoint /healthy is ready " + ar.succeeded() + " for "
                                 + l + " time with status code " + ar.result().statusCode());
@@ -71,7 +73,8 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
     void metricsTest(VertxTestContext context) {
         baseService()
                 .getRequest("/metrics")
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         assertThat(ar.result().statusCode(), is(HttpResponseStatus.OK.code()));
@@ -84,9 +87,10 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
     @Test
     void openapiv2Test(VertxTestContext context) {
         baseService()
-            .getRequest("/openapi/v2")
+                .getRequest("/openapi/v2")
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -104,7 +108,8 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
         baseService()
                 .getRequest("/openapi/v3")
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -121,9 +126,10 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
     @Test
     void openapiTest(VertxTestContext context) {
         baseService()
-            .getRequest("/openapi")
+                .getRequest("/openapi")
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -185,18 +191,19 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
     @Test
     void postToNonexistentEndpoint(VertxTestContext context) {
         baseService()
-            .postRequest("/not-existing-endpoint")
-            .as(BodyCodec.jsonObject())
-            .sendJsonObject(null, ar -> {
-                context.verify(() -> {
-                    assertThat(ar.succeeded(), is(true));
-                    HttpResponse<JsonObject> response = ar.result();
-                    HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-                    assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
-                    assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
+                .postRequest("/not-existing-endpoint")
+                .as(BodyCodec.jsonObject())
+                .sendJsonObject(null)
+                .onComplete(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        HttpBridgeError error = HttpBridgeError.fromJson(response.body());
+                        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
+                        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
+                    });
+                    context.completeNow();
                 });
-                context.completeNow();
-            });
     }
 
     @Test
@@ -204,7 +211,8 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
         baseService()
                 .getRequest("/")
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -221,7 +229,8 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
                 .getRequest("/openapi")
                 .putHeader("x-Forwarded-Path", forwardedPath)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -240,7 +249,8 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
                 .getRequest("/openapi")
                 .putHeader("x-Forwarded-Prefix", forwardedPrefix)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -261,7 +271,8 @@ public class OtherServicesIT extends HttpBridgeITAbstract {
                 .putHeader("x-Forwarded-Path", forwardedPath)
                 .putHeader("x-Forwarded-Prefix", forwardedPrefix)
                 .as(BodyCodec.jsonObject())
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -73,7 +73,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyOK(context));
+            .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -123,7 +123,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                .sendJsonObject(root, ar ->
+                .sendJsonObject(root)
+                .onComplete(ar ->
                         context.verify(() -> {
                             assertThat(ar.succeeded(), is(true));
                             HttpResponse<JsonObject> response = ar.result();
@@ -173,7 +174,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyOK(context));
+            .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -194,7 +195,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -223,7 +224,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyOK(context));
+            .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -245,7 +246,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -274,7 +275,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyOK(context));
+            .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -295,7 +296,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -323,7 +324,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyOK(context));
+            .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -344,7 +345,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -371,7 +372,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
             .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyOK(context));
+            .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -392,7 +393,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -418,8 +419,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         root.put("records", records);
 
         producerService()
-            .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_BINARY)
-                .sendJsonObject(root, verifyOK(context));
+                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_BINARY)
+                .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -441,7 +442,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -466,7 +467,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_TEXT)
-                .sendJsonObject(root, verifyOK(context));
+                .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -487,7 +488,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -524,8 +525,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyOK(context));
+                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -552,7 +553,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -586,14 +587,14 @@ public class ProducerIT extends HttpBridgeITAbstract {
                 root.put("records", records);
 
                 producerService()
-                    .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                    .sendJsonObject(root, ar -> { });
+                        .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
+                        .sendJsonObject(root).onComplete(ar -> { });
 
                 this.count++;
             } else {
                 vertx.cancelTimer(timerId);
 
-                consumer.subscribe(topic, done -> {
+                consumer.subscribe(topic).onComplete(done -> {
                     if (!done.succeeded()) {
                         context.failNow(done.cause());
                     }
@@ -640,22 +641,23 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, ar -> {
-                context.verify(() -> assertThat(ar.succeeded(), is(true)));
+                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root)
+                .onComplete(ar -> {
+                    context.verify(() -> assertThat(ar.succeeded(), is(true)));
 
-                HttpResponse<JsonObject> response = ar.result();
-                assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
-                JsonObject bridgeResponse = response.body();
+                    HttpResponse<JsonObject> response = ar.result();
+                    assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+                    JsonObject bridgeResponse = response.body();
 
-                JsonArray offsets = bridgeResponse.getJsonArray("offsets");
-                assertThat(offsets.size(), is(numMessages));
-                for (int i = 0; i < numMessages; i++) {
-                    JsonObject metadata = offsets.getJsonObject(i);
-                    assertThat(metadata.getInteger("partition"), is(0));
-                    assertThat(metadata.getLong("offset"), notNullValue());
-                }
-            });
+                    JsonArray offsets = bridgeResponse.getJsonArray("offsets");
+                    assertThat(offsets.size(), is(numMessages));
+                    for (int i = 0; i < numMessages; i++) {
+                        JsonObject metadata = offsets.getJsonObject(i);
+                        assertThat(metadata.getInteger("partition"), is(0));
+                        assertThat(metadata.getLong("offset"), notNullValue());
+                    }
+                });
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -681,7 +683,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             }
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -699,17 +701,18 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, ar -> {
-                context.verify(() -> {
-                    assertThat(ar.succeeded(), is(true));
-                    HttpResponse<JsonObject> response = ar.result();
-                    HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-                    assertThat(response.statusCode(), is(HttpResponseStatus.UNPROCESSABLE_ENTITY.code()));
-                    assertThat(error.code(), is(HttpResponseStatus.UNPROCESSABLE_ENTITY.code()));
+                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root)
+                .onComplete(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        HttpBridgeError error = HttpBridgeError.fromJson(response.body());
+                        assertThat(response.statusCode(), is(HttpResponseStatus.UNPROCESSABLE_ENTITY.code()));
+                        assertThat(error.code(), is(HttpResponseStatus.UNPROCESSABLE_ENTITY.code()));
+                    });
+                    context.completeNow();
                 });
-                context.completeNow();
-            });
     }
 
     @Test
@@ -731,7 +734,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         // produce and check the status code
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_TEXT)
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -764,7 +768,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         // produce and check the status code
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_TEXT)
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -797,7 +802,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                .sendJsonObject(root, verifyOK(context));
+                .sendJsonObject(root).onComplete(verifyOK(context));
 
         Properties consumerProperties = Consumer.fillDefaultProperties();
         consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
@@ -818,7 +823,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -842,25 +847,26 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, ar -> {
-                context.verify(() -> {
-                    assertThat(ar.succeeded(), is(true));
-                    HttpResponse<JsonObject> response = ar.result();
-                    JsonObject bridgeResponse = response.body();
+                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root)
+                .onComplete(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        JsonObject bridgeResponse = response.body();
 
-                    JsonArray offsets = bridgeResponse.getJsonArray("offsets");
-                    assertThat(offsets.size(), is(1));
+                        JsonArray offsets = bridgeResponse.getJsonArray("offsets");
+                        assertThat(offsets.size(), is(1));
 
-                    HttpBridgeError error = HttpBridgeError.fromJson(offsets.getJsonObject(0));
-                    assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
-                    // the message got from the Kafka producer (starting from 2.3) is misleading
-                    // this JIRA (https://issues.apache.org/jira/browse/KAFKA-8862) raises the issue
-                    assertThat(error.message(), is(
-                            "Topic " + topic + " not present in metadata after " +
-                                    config.get(KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.MAX_BLOCK_MS_CONFIG) + " ms."));
+                        HttpBridgeError error = HttpBridgeError.fromJson(offsets.getJsonObject(0));
+                        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
+                        // the message got from the Kafka producer (starting from 2.3) is misleading
+                        // this JIRA (https://issues.apache.org/jira/browse/KAFKA-8862) raises the issue
+                        assertThat(error.message(), is(
+                                "Topic " + topic + " not present in metadata after " +
+                                        config.get(KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.MAX_BLOCK_MS_CONFIG) + " ms."));
+                    });
                 });
-            });
 
         context.completeNow();
         assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
@@ -880,24 +886,25 @@ public class ProducerIT extends HttpBridgeITAbstract {
         root.put("records", records);
 
         producerService()
-            .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, ar -> {
-                context.verify(() -> {
-                    assertThat(ar.succeeded(), is(true));
-                    HttpResponse<JsonObject> response = ar.result();
-                    JsonObject bridgeResponse = response.body();
+                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root)
+                .onComplete(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        JsonObject bridgeResponse = response.body();
 
-                    JsonArray offsets = bridgeResponse.getJsonArray("offsets");
-                    assertThat(offsets.size(), is(1));
-                    int code = offsets.getJsonObject(0).getInteger("error_code");
-                    String statusMessage = offsets.getJsonObject(0).getString("message");
+                        JsonArray offsets = bridgeResponse.getJsonArray("offsets");
+                        assertThat(offsets.size(), is(1));
+                        int code = offsets.getJsonObject(0).getInteger("error_code");
+                        String statusMessage = offsets.getJsonObject(0).getString("message");
 
-                    assertThat(code, is(HttpResponseStatus.NOT_FOUND.code()));
-                    assertThat(statusMessage, is("Topic " + topic + " not present in metadata after " +
-                                config.get(KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.MAX_BLOCK_MS_CONFIG) + " ms."));
+                        assertThat(code, is(HttpResponseStatus.NOT_FOUND.code()));
+                        assertThat(statusMessage, is("Topic " + topic + " not present in metadata after " +
+                                    config.get(KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.MAX_BLOCK_MS_CONFIG) + " ms."));
+                    });
+                    context.completeNow();
                 });
-                context.completeNow();
-            });
     }
 
     @Test
@@ -918,23 +925,24 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsToPartitionRequest(topic, partition, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, ar -> {
-                context.verify(() -> {
-                    assertThat(ar.succeeded(), is(true));
-                    HttpResponse<JsonObject> response = ar.result();
-                    assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
-                    JsonObject bridgeResponse = response.body();
+                .sendRecordsToPartitionRequest(topic, partition, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root)
+                .onComplete(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+                        JsonObject bridgeResponse = response.body();
 
-                    JsonArray offsets = bridgeResponse.getJsonArray("offsets");
-                    assertThat(offsets.size(), is(1));
-                    JsonObject metadata = offsets.getJsonObject(0);
-                    assertThat(metadata.getInteger("partition"), notNullValue());
-                    assertThat(metadata.getInteger("partition"), is(partition));
-                    assertThat(metadata.getLong("offset"), is(0L));
+                        JsonArray offsets = bridgeResponse.getJsonArray("offsets");
+                        assertThat(offsets.size(), is(1));
+                        JsonObject metadata = offsets.getJsonObject(0);
+                        assertThat(metadata.getInteger("partition"), notNullValue());
+                        assertThat(metadata.getInteger("partition"), is(partition));
+                        assertThat(metadata.getLong("offset"), is(0L));
+                    });
+                    context.completeNow();
                 });
-                context.completeNow();
-            });
 
         assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
     }
@@ -957,8 +965,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsToPartitionRequest(topic, partition, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Parameter error on: partitionid - [Bad Request] Parsing error for parameter partitionid in location PATH: java.lang.NumberFormatException: For input string: \"" + partition + "\""));
+                .sendRecordsToPartitionRequest(topic, partition, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root).onComplete(verifyBadRequest(context, "Parameter error on: partitionid - [Bad Request] Parsing error for parameter partitionid in location PATH: java.lang.NumberFormatException: For input string: \"" + partition + "\""));
     }
 
     @Test
@@ -981,8 +989,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsToPartitionRequest(topic, partition, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: " + testProp));
+                .sendRecordsToPartitionRequest(topic, partition, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root).onComplete(verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: " + testProp));
     }
 
     @Test
@@ -1002,8 +1010,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - provided object should contain property value"));
+                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root).onComplete(verifyBadRequest(context, "Validation error on: /records/0 - provided object should contain property value"));
     }
 
     @Test
@@ -1025,8 +1033,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: " + testProp));
+                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root).onComplete(verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: " + testProp));
     }
 
     Handler<AsyncResult<HttpResponse<JsonObject>>> verifyBadRequest(VertxTestContext context, String message) {
@@ -1080,7 +1088,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1124,8 +1133,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         future.get();
 
         producerService()
-            .sendRecordsToPartitionRequest(topic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: " + testProp));
+                .sendRecordsToPartitionRequest(topic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root).onComplete(verifyBadRequest(context, "Validation error on: /records/0 - Provided object contains unexpected additional property: " + testProp));
 
         records.remove(json);
         records.clear();
@@ -1136,22 +1145,23 @@ public class ProducerIT extends HttpBridgeITAbstract {
         root.put("records", records);
 
         producerService()
-            .sendRecordsToPartitionRequest(topic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, ar -> {
-                context.verify(() -> {
-                    assertThat(ar.succeeded(), is(true));
-                    HttpResponse<JsonObject> response = ar.result();
-                    assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+                .sendRecordsToPartitionRequest(topic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root)
+                .onComplete(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
 
-                    JsonObject bridgeResponse = response.body();
-                    JsonArray offsets = bridgeResponse.getJsonArray("offsets");
-                    assertThat(offsets.size(), is(1));
+                        JsonObject bridgeResponse = response.body();
+                        JsonArray offsets = bridgeResponse.getJsonArray("offsets");
+                        assertThat(offsets.size(), is(1));
 
-                    JsonObject metadata = offsets.getJsonObject(0);
-                    assertThat(metadata.getInteger("partition"), is(0));
-                    assertThat(metadata.getInteger("offset"), is(1));
+                        JsonObject metadata = offsets.getJsonObject(0);
+                        assertThat(metadata.getInteger("partition"), is(0));
+                        assertThat(metadata.getInteger("offset"), is(1));
+                    });
                 });
-            });
 
         records.remove(json);
         records.clear();
@@ -1166,22 +1176,23 @@ public class ProducerIT extends HttpBridgeITAbstract {
         root.put("records", records);
 
         producerService()
-            .sendRecordsToPartitionRequest(topic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
-            .sendJsonObject(root, ar -> {
-                context.verify(() -> {
-                    assertThat(ar.succeeded(), is(true));
-                    HttpResponse<JsonObject> response = ar.result();
-                    assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+                .sendRecordsToPartitionRequest(topic, 0, root, BridgeContentType.KAFKA_JSON_JSON)
+                .sendJsonObject(root)
+                .onComplete(ar -> {
+                    context.verify(() -> {
+                        assertThat(ar.succeeded(), is(true));
+                        HttpResponse<JsonObject> response = ar.result();
+                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
 
-                    JsonObject bridgeResponse = response.body();
-                    JsonArray offsets = bridgeResponse.getJsonArray("offsets");
-                    assertThat(offsets.size(), is(1));
+                        JsonObject bridgeResponse = response.body();
+                        JsonArray offsets = bridgeResponse.getJsonArray("offsets");
+                        assertThat(offsets.size(), is(1));
 
-                    JsonObject metadata = offsets.getJsonObject(0);
-                    assertThat(metadata.getInteger("partition"), is(0));
-                    assertThat(metadata.getInteger("offset"), is(2));
+                        JsonObject metadata = offsets.getJsonObject(0);
+                        assertThat(metadata.getInteger("partition"), is(0));
+                        assertThat(metadata.getInteger("offset"), is(2));
+                    });
                 });
-            });
     }
 
     @Test
@@ -1206,7 +1217,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
                 .addQueryParam("async", "true")
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     context.verify(() -> assertThat(ar.succeeded(), is(true)));
 
                     HttpResponse<JsonObject> response = ar.result();
@@ -1238,7 +1250,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
             }
         });
 
-        consumer.subscribe(topic, done -> {
+        consumer.subscribe(topic).onComplete(done -> {
             if (!done.succeeded()) {
                 context.failNow(done.cause());
             }
@@ -1266,7 +1278,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
         producerService()
                 .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
                 .addQueryParam("async", "wrong")
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1299,7 +1312,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         producerService()
                 .sendRecordsRequest(topic, root, "bad-content-type")
-                .sendJsonObject(root, ar -> {
+                .sendJsonObject(root)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -1341,18 +1355,19 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         // Send the first request
         producerService()
-            .sendRecordsRequest(topic, root, firstContentType)
-            .sendJsonObject(root, response -> {
-                if (response.succeeded()) {
-                    HttpResponse<JsonObject> httpResponse = response.result();
-                    context.verify(() -> {
-                        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
-                        LOGGER.info("Successfully processed record with content type: {}", secondContentType);
-                    });
-                } else {
-                    context.failNow(response.cause());
-                }
-            });
+                .sendRecordsRequest(topic, root, firstContentType)
+                .sendJsonObject(root)
+                .onComplete(response -> {
+                    if (response.succeeded()) {
+                        HttpResponse<JsonObject> httpResponse = response.result();
+                        context.verify(() -> {
+                            assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
+                            LOGGER.info("Successfully processed record with content type: {}", secondContentType);
+                        });
+                    } else {
+                        context.failNow(response.cause());
+                    }
+                });
 
         record = createDynamicRecord(secondContentType);
         records = new JsonArray().add(record);
@@ -1360,19 +1375,20 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         // Send the second request
         producerService()
-            .sendRecordsRequest(topic, root, secondContentType)
-            .sendJsonObject(root, response -> {
-                if (response.succeeded()) {
-                    HttpResponse<JsonObject> httpResponse = response.result();
-                    context.verify(() -> {
-                        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
-                        LOGGER.info("Successfully processed record with content type: {}", secondContentType);
-                        context.completeNow();
-                    });
-                } else {
-                    context.failNow(response.cause());
-                }
-            });
+                .sendRecordsRequest(topic, root, secondContentType)
+                .sendJsonObject(root)
+                .onComplete(response -> {
+                    if (response.succeeded()) {
+                        HttpResponse<JsonObject> httpResponse = response.result();
+                        context.verify(() -> {
+                            assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
+                            LOGGER.info("Successfully processed record with content type: {}", secondContentType);
+                            context.completeNow();
+                        });
+                    } else {
+                        context.failNow(response.cause());
+                    }
+                });
 
         assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
     }

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -131,7 +131,7 @@ public abstract class HttpBridgeITAbstract {
             httpBridge = new HttpBridge(bridgeConfig, new MetricsReporter(jmxCollectorRegistry, meterRegistry));
 
             LOGGER.info("Deploying in-memory bridge");
-            vertx.deployVerticle(httpBridge, context.succeeding(id -> context.completeNow()));
+            vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> context.completeNow()));
         } else {
             context.completeNow();
             // else we create an external bridge from the OS invoked by `.jar`
@@ -146,7 +146,7 @@ public abstract class HttpBridgeITAbstract {
     @AfterAll
     static void afterAll(VertxTestContext context) {
         if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
-            vertx.close(context.succeeding(arg -> context.completeNow()));
+            vertx.close().onComplete(context.succeeding(arg -> context.completeNow()));
         } else {
             // if we are running an external bridge
             context.completeNow();

--- a/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/services/ConsumerService.java
@@ -117,7 +117,8 @@ public class ConsumerService extends BaseService {
         deleteRequest(Urls.consumerInstanceSubscription(groupId, name))
                 .putHeader(CONTENT_LENGTH.toString(), String.valueOf(topicsRoot.toBuffer().length()))
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(topicsRoot, ar -> {
+                .sendJsonObject(topicsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
@@ -144,7 +145,8 @@ public class ConsumerService extends BaseService {
                 .putHeader(CONTENT_LENGTH.toString(), String.valueOf(partitionsRoot.toBuffer().length()))
                 .putHeader(CONTENT_TYPE.toString(), BridgeContentType.KAFKA_JSON)
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(partitionsRoot, ar -> {
+                .sendJsonObject(partitionsRoot)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
@@ -161,7 +163,8 @@ public class ConsumerService extends BaseService {
 
         CompletableFuture<Boolean> create = new CompletableFuture<>();
         createConsumerRequest(groupId, json)
-                .sendJsonObject(json, ar -> {
+                .sendJsonObject(json)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
@@ -198,7 +201,8 @@ public class ConsumerService extends BaseService {
                 .putHeader(CONTENT_LENGTH.toString(), String.valueOf(jsonObject.toBuffer().length()))
                 .putHeader(CONTENT_TYPE.toString(), BridgeContentType.KAFKA_JSON)
                 .as(BodyCodec.jsonObject())
-                .sendJsonObject(jsonObject, ar -> {
+                .sendJsonObject(jsonObject)
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
@@ -216,7 +220,8 @@ public class ConsumerService extends BaseService {
         CompletableFuture<Boolean> delete = new CompletableFuture<>();
         // consumer deletion
         deleteConsumerRequest(groupId, name)
-                .send(ar -> {
+                .send()
+                .onComplete(ar -> {
                     context.verify(() -> {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();


### PR DESCRIPTION
This PR prepares the code base for Vert.x 5. This should allow us to simplify testing of new Vert.x 5 releases.
It mostly moves from the usage of the callback model (deprecated by Vert.x 5) to the future model.
It also updates Micrometer Metrics to use a version used by the current Vert.x 4 version we use.