### PR TITLE
Update Vert.x 4.5.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.32.0
 
-* Dependency updates (Vert.x 4.5.12, Netty 4.1.117.Final, JMX exporter 1.1.0)
+* Dependency updates (Vert.x 4.5.13, Netty 4.1.118.Final, JMX exporter 1.1.0)
 * Dropped support for Java 11 and replaced with Java 17.
 * Dropped support for OpenAPI v2 Swagger specification.
   * The `/openapi/v2` endpoint returns HTTP 410 Gone.

--- a/pom.xml
+++ b/pom.xml
@@ -105,9 +105,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>
 		<log4j.version>2.17.2</log4j.version>
-		<vertx.version>4.5.12</vertx.version>
-		<vertx-testing.version>4.5.12</vertx-testing.version>
-		<netty.version>4.1.117.Final</netty.version>
+		<vertx.version>4.5.13</vertx.version>
+		<vertx-testing.version>4.5.13</vertx-testing.version>
+		<netty.version>4.1.118.Final</netty.version>
 		<kafka.version>3.9.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
This trivial PR updates Vert.x to 4.5.13 together with the new Netty version with some CVE fixes as well as various bugfixes.