### PR TITLE
Fix spotbugs issues and CI

### DIFF
--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -24,10 +24,6 @@ jobs:
       - template: '../steps/prerequisites/install_java.yaml'
         parameters:
           JDK_VERSION: $(jdk_version)
-      - bash: "make spotbugs"
-        displayName: "Spotbugs"
-        env:
-          MVN_ARGS: "-e -V -B"
       - bash: "make java_verify"
         displayName: "Build & Test Java"
         env:
@@ -35,6 +31,10 @@ jobs:
           BRANCH: $(Build.SourceBranch)
           TESTCONTAINERS_RYUK_DISABLED: "TRUE"
           TESTCONTAINERS_CHECKS_DISABLE: "TRUE"
+          MVN_ARGS: "-e -V -B"          
+      - bash: "make spotbugs"
+        displayName: "Spotbugs"
+        env:
           MVN_ARGS: "-e -V -B"
       # We have to TAR the target directory to maintain the permissions of
       # the files which would otherwise change when downloading the artifact

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -824,7 +824,15 @@ public class HttpBridge extends AbstractVerticle {
         }
     };
 
-    final HttpOpenApiOperation OPENAPIV2 = new NotSupportedApi(HttpOpenApiOperations.OPENAPIV2);
+    final static HttpOpenApiOperation OPENAPIV2 = new HttpOpenApiOperation(HttpOpenApiOperations.OPENAPIV2) {
+
+        @Override
+        public void process(RoutingContext routingContext) {
+            HttpBridgeError error = new HttpBridgeError(HttpResponseStatus.GONE.code(), "OpenAPI v2 Swagger not supported");
+            HttpUtils.sendResponse(routingContext, HttpResponseStatus.GONE.code(),
+                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
+        }
+    };
 
     final HttpOpenApiOperation OPENAPIV3 = new HttpOpenApiOperation(HttpOpenApiOperations.OPENAPIV3) {
 
@@ -849,17 +857,4 @@ public class HttpBridge extends AbstractVerticle {
             information(routingContext);
         }
     };
-
-    static class NotSupportedApi extends HttpOpenApiOperation {
-        public NotSupportedApi(HttpOpenApiOperations operationId) {
-            super(operationId);
-        }
-
-        @Override
-        public void process(RoutingContext routingContext) {
-            HttpBridgeError error = new HttpBridgeError(HttpResponseStatus.GONE.code(), "OpenAPI v2 Swagger not supported");
-            HttpUtils.sendResponse(routingContext, HttpResponseStatus.GONE.code(),
-                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
-        }
-    }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -824,15 +824,7 @@ public class HttpBridge extends AbstractVerticle {
         }
     };
 
-    final HttpOpenApiOperation OPENAPIV2 = new HttpOpenApiOperation(HttpOpenApiOperations.OPENAPIV2) {
-
-        @Override
-        public void process(RoutingContext routingContext) {
-            HttpBridgeError error = new HttpBridgeError(HttpResponseStatus.GONE.code(), "OpenAPI v2 Swagger not supported");
-            HttpUtils.sendResponse(routingContext, HttpResponseStatus.GONE.code(),
-                    BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
-        }
-    };
+    final HttpOpenApiOperation OPENAPIV2 = new NotSupportedApi(HttpOpenApiOperations.OPENAPIV2);
 
     final HttpOpenApiOperation OPENAPIV3 = new HttpOpenApiOperation(HttpOpenApiOperations.OPENAPIV3) {
 
@@ -857,4 +849,17 @@ public class HttpBridge extends AbstractVerticle {
             information(routingContext);
         }
     };
+
+    static class NotSupportedApi extends HttpOpenApiOperation {
+        public NotSupportedApi(HttpOpenApiOperations operationId) {
+            super(operationId);
+        }
+
+        @Override
+        public void process(RoutingContext routingContext) {
+            HttpBridgeError error = new HttpBridgeError(HttpResponseStatus.GONE.code(), "OpenAPI v2 Swagger not supported");
+            HttpUtils.sendResponse(routingContext, HttpResponseStatus.GONE.code(),
+                BridgeContentType.KAFKA_JSON, JsonUtils.jsonToBytes(error.toJson()));
+        }
+    }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
@@ -18,6 +18,8 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import javax.xml.bind.DatatypeConverter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +30,6 @@ import java.util.List;
 public class HttpTextMessageConverter implements MessageConverter<byte[], byte[], byte[], byte[]> {
     @Override
     public ProducerRecord<byte[], byte[]> toKafkaRecord(String kafkaTopic, Integer partition, byte[] message) {
-
         Integer partitionFromBody = null;
         Long timestamp = null;
         byte[] key = null;
@@ -43,14 +44,14 @@ public class HttpTextMessageConverter implements MessageConverter<byte[], byte[]
                 if (!keyNode.isTextual()) {
                     throw new IllegalStateException("Because the embedded format is 'text', the key must be a string");
                 }
-                key = keyNode.asText().getBytes();
+                key = keyNode.asText().getBytes(Charset.forName("UTF-8"));
             }
             if (json.has("value")) {
                 JsonNode valueNode = json.get("value");
                 if (!valueNode.isTextual()) {
                     throw new IllegalStateException("Because the embedded format is 'text', the value must be a string");
                 }
-                value = valueNode.asText().getBytes();
+                value = valueNode.asText().getBytes(Charset.forName("UTF-8"));
             }
             if (json.has("timestamp")) {
                 timestamp = json.get("timestamp").asLong();
@@ -101,8 +102,8 @@ public class HttpTextMessageConverter implements MessageConverter<byte[], byte[]
             ObjectNode jsonObject = JsonUtils.createObjectNode();
 
             jsonObject.set("topic", new TextNode(record.topic()));
-            jsonObject.set("key", record.key() != null ? new TextNode(new String(record.key())) : null);
-            jsonObject.set("value", record.value() != null ? new TextNode(new String(record.value())) : null);
+            jsonObject.set("key", record.key() != null ? new TextNode(new String(record.key(), StandardCharsets.UTF_8)) : null);
+            jsonObject.set("value", record.value() != null ? new TextNode(new String(record.value(), StandardCharsets.UTF_8)) : null);
             jsonObject.put("partition", record.partition());
             jsonObject.put("offset", record.offset());
             jsonObject.put("timestamp", record.timestamp());

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
@@ -18,7 +18,6 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import javax.xml.bind.DatatypeConverter;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,14 +43,14 @@ public class HttpTextMessageConverter implements MessageConverter<byte[], byte[]
                 if (!keyNode.isTextual()) {
                     throw new IllegalStateException("Because the embedded format is 'text', the key must be a string");
                 }
-                key = keyNode.asText().getBytes(Charset.forName("UTF-8"));
+                key = keyNode.asText().getBytes(StandardCharsets.UTF_8);
             }
             if (json.has("value")) {
                 JsonNode valueNode = json.get("value");
                 if (!valueNode.isTextual()) {
                     throw new IllegalStateException("Because the embedded format is 'text', the value must be a string");
                 }
-                value = valueNode.asText().getBytes(Charset.forName("UTF-8"));
+                value = valueNode.asText().getBytes(StandardCharsets.UTF_8);
             }
             if (json.has("timestamp")) {
                 timestamp = json.get("timestamp").asLong();


### PR DESCRIPTION
This change fixes the following spotbugs issues:

```sh
[ERROR] Low: Private method io.strimzi.kafka.bridge.http.HttpBridge.contentTypeToFormat(String) is never called [io.strimzi.kafka.bridge.http.HttpBridge] At HttpBridge.java:[lines 644-652] UPM_UNCALLED_PRIVATE_METHOD
[ERROR] High: Found reliance on default encoding in io.strimzi.kafka.bridge.http.converter.HttpTextMessageConverter.toKafkaRecord(String, Integer, byte[]): String.getBytes() [io.strimzi.kafka.bridge.http.converter.HttpTextMessageConverter, io.strimzi.kafka.bridge.http.converter.HttpTextMessageConverter] At HttpTextMessageConverter.java:[line 46]Another occurrence at HttpTextMessageConverter.java:[line 53] DM_DEFAULT_ENCODING
[ERROR] High: Found reliance on default encoding in io.strimzi.kafka.bridge.http.converter.HttpTextMessageConverter.toMessages(ConsumerRecords): new String(byte[]) [io.strimzi.kafka.bridge.http.converter.HttpTextMessageConverter, io.strimzi.kafka.bridge.http.converter.HttpTextMessageConverter] At HttpTextMessageConverter.java:[line 104]Another occurrence at HttpTextMessageConverter.java:[line 105] DM_DEFAULT_ENCODING
```

It also fixes the CI that was not detecting the issue because spotbugs was run before building the project.