### PR TITLE
Renamed Prometheus version property in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
 		<grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
 		<micrometer.version>1.12.13</micrometer.version>
 		<jmx-prometheus-collector.version>1.1.0</jmx-prometheus-collector.version>
-		<prometheus-client.version>1.3.4</prometheus-client.version>
+		<prometheus.version>1.3.4</prometheus.version>
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.109.1</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
@@ -310,7 +310,7 @@
 		<dependency>
 			<groupId>io.prometheus</groupId>
 			<artifactId>prometheus-metrics-model</artifactId>
-			<version>${prometheus-client.version}</version>
+			<version>${prometheus.version}</version>
 		</dependency>
 		<!-- We include explicitly prometheus-metrics-instrumentation-jvm 
 			and prometheus-metrics-exporter-httpserver to force the use of 
@@ -318,17 +318,17 @@
 		<dependency>
 			<groupId>io.prometheus</groupId>
 			<artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
-			<version>${prometheus-client.version}</version>
+			<version>${prometheus.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.prometheus</groupId>
 			<artifactId>prometheus-metrics-exporter-httpserver</artifactId>
-			<version>${prometheus-client.version}</version>
+			<version>${prometheus.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.prometheus</groupId>
 			<artifactId>prometheus-metrics-exposition-textformats</artifactId>
-			<version>${prometheus-client.version}</version>
+			<version>${prometheus.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>


### PR DESCRIPTION
Trivial PR to rename the pom property to define the Prometheus version. It was something like prometheus-client because we were including the Prometheus client time ago, but meanwhile Prometheus changed and the client is not brought anymore in the bridge. Renaming to just `prometheus.version` makes more sense to me.