### PR TITLE
Bumped Kafka 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.32.0
 
-* Dependency updates (Vert.x 4.5.13, Netty 4.1.118.Final, JMX exporter 1.1.0)
+* Dependency updates (Kafka 4.0.0, Vert.x 4.5.13, Netty 4.1.118.Final, JMX exporter 1.1.0)
 * Dropped support for Java 11 and replaced with Java 17.
 * Dropped support for OpenAPI v2 Swagger specification.
   * The `/openapi/v2` endpoint returns HTTP 410 Gone.

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<vertx.version>4.5.13</vertx.version>
 		<vertx-testing.version>4.5.13</vertx-testing.version>
 		<netty.version>4.1.118.Final</netty.version>
-		<kafka.version>3.9.0</kafka.version>
+		<kafka.version>4.0.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<maven.checkstyle.version>3.3.0</maven.checkstyle.version>

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -462,7 +462,7 @@ public class ConsumerIT extends HttpBridgeITAbstract {
     @Test
     void createConsumerWithWrongAutoOffsetReset(VertxTestContext context) throws InterruptedException, TimeoutException, ExecutionException {
         checkCreatingConsumer("auto.offset.reset", "foo", HttpResponseStatus.UNPROCESSABLE_ENTITY,
-                "Invalid value foo for configuration auto.offset.reset: String must be one of: latest, earliest, none", context);
+                "Invalid value foo for configuration auto.offset.reset: Invalid value `foo` for configuration auto.offset.reset. The value must be either 'earliest', 'latest', 'none' or of the format 'by_duration:<PnDTnHnMn.nS.>'.", context);
 
         context.completeNow();
         assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -900,8 +900,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
                         String statusMessage = offsets.getJsonObject(0).getString("message");
 
                         assertThat(code, is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(statusMessage, is("Topic " + topic + " not present in metadata after " +
-                                    config.get(KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.MAX_BLOCK_MS_CONFIG) + " ms."));
+                        assertThat(statusMessage, is("Partition 1 of topic " + topic + " with partition count 1 is not present in metadata after " +
+                                config.get(KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.MAX_BLOCK_MS_CONFIG) + " ms."));
                     });
                     context.completeNow();
                 });
@@ -1104,7 +1104,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
                         assertThat(metadata.getLong("offset"), is(0L));
                         HttpBridgeError error = HttpBridgeError.fromJson(offsets.getJsonObject(1));
                         assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.message(), is("Topic " + topic + " not present in metadata after 10000 ms."));
+                        assertThat(error.message(), is("Partition 500 of topic " + topic + " with partition count 3 is not present in metadata after 10000 ms."));
                     });
                     context.completeNow();
                 });


### PR DESCRIPTION
This PR bumps the Apache Kafka version (for used clients) to the new 4.0.0