### PR TITLE
Bumped JMX exporter and Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.32.0
 
-* Dependency updates (Kafka 4.0.0, Vert.x 4.5.13, Netty 4.1.118.Final, JMX exporter 1.1.0)
+* Dependency updates (Kafka 4.0.0, Vert.x 4.5.13, Netty 4.1.118.Final, JMX exporter 1.2.0)
 * Dropped support for Java 11 and replaced with Java 17.
 * Dropped support for OpenAPI v2 Swagger specification.
   * The `/openapi/v2` endpoint returns HTTP 410 Gone.

--- a/pom.xml
+++ b/pom.xml
@@ -139,8 +139,8 @@
 		<opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version>
 		<grpc-netty-shaded.version>1.61.0</grpc-netty-shaded.version>
 		<micrometer.version>1.12.13</micrometer.version>
-		<jmx-prometheus-collector.version>1.1.0</jmx-prometheus-collector.version>
-		<prometheus.version>1.3.4</prometheus.version>
+		<jmx-prometheus-collector.version>1.2.0</jmx-prometheus-collector.version>
+		<prometheus.version>1.3.6</prometheus.version>
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.109.1</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>


### PR DESCRIPTION
This PR bumps the JMX exporter and the Prometheus to the latest versions.