### PR TITLE
Bumped OAuth and Jackson dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.32.0
 
-* Dependency updates (Kafka 4.0.0, Vert.x 4.5.14, Netty 4.1.118.Final, JMX exporter 1.2.0)
+* Dependency updates (Kafka 4.0.0, Vert.x 4.5.14, Netty 4.1.118.Final, JMX exporter 1.2.0, OAuth 0.16.1)
 * Dropped support for Java 11 and replaced with Java 17.
 * Dropped support for OpenAPI v2 Swagger specification.
   * The `/openapi/v2` endpoint returns HTTP 410 Gone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.32.0
 
-* Dependency updates (Kafka 4.0.0, Vert.x 4.5.14, Netty 4.1.118.Final, JMX exporter 1.2.0, OAuth 0.16.1)
+* Dependency updates (Kafka 4.0.0, Vert.x 4.5.14, Netty 4.1.118.Final, JMX exporter 1.2.0, OAuth 0.16.2)
 * Dropped support for Java 11 and replaced with Java 17.
 * Dropped support for OpenAPI v2 Swagger specification.
   * The `/openapi/v2` endpoint returns HTTP 410 Gone.

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
 		</repository>
 	</distributionManagement>
 
+	<repositories>
+		<repository>
+			<id>staging</id>
+			<url>https://oss.sonatype.org/content/repositories/iostrimzi-1263</url>
+		</repository>
+	</repositories>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
 		<jackson-databind.version>2.18.3</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
-		<strimzi-oauth.version>0.16.1</strimzi-oauth.version>
+		<strimzi-oauth.version>0.16.2</strimzi-oauth.version>
 		<strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
 		<opentelemetry.version>1.34.1</opentelemetry.version>
 		<opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
@@ -146,7 +146,6 @@
 		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>2.4</snakeyaml.version>
 		<guava.version>32.1.3-jre</guava.version>
-		<json-smart.version>2.5.2</json-smart.version>
 		<!-- property to skip surefire tests during failsafe execution -->
 		<!--suppress UnresolvedMavenProperty -->
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -402,12 +401,6 @@
 			<version>${spotbugs.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		<!-- Transitive override to address CVE-2024-57699. Remove in the future when oauth will bring json-path with fixed json-smart -->
-		<dependency>
-			<groupId>net.minidev</groupId>
-			<artifactId>json-smart</artifactId>
-			<version>${json-smart.version}</version>
-		</dependency>
 		<!-- Testing -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -627,8 +620,6 @@
 									<ignoredUnusedDeclaredDependency>io.strimzi:metrics-reporter</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>io.prometheus:prometheus-metrics-instrumentation-jvm</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>io.prometheus:prometheus-metrics-exporter-httpserver</ignoredUnusedDeclaredDependency>
-									<!-- Transitive override to address CVE-2024-57699. Remove in the future when oauth will bring json-path with fixed json-smart -->
-									<ignoredUnusedDeclaredDependency>net.minidev:json-smart</ignoredUnusedDeclaredDependency>
 									<!-- Added direct dependency because of the old version 2.16.x brought by Vert.x 4.5.x -->
 									<ignoredUnusedDeclaredDependency>com.fasterxml.jackson.core:jackson-core</ignoredUnusedDeclaredDependency>
 								</ignoredUnusedDeclaredDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -101,13 +101,6 @@
 		</repository>
 	</distributionManagement>
 
-	<repositories>
-		<repository>
-			<id>staging</id>
-			<url>https://oss.sonatype.org/content/repositories/iostrimzi-1263</url>
-		</repository>
-	</repositories>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
 		<maven.gpg.version>3.0.1</maven.gpg.version>
 		<sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
 		<openapi.generator.version>7.8.0</openapi.generator.version>
+		<jackson-core.version>2.18.3</jackson-core.version>
 		<jackson-databind.version>2.18.3</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
@@ -370,6 +371,15 @@
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
 			<version>${snakeyaml.version}</version>
+		</dependency>
+		<!--
+			Added direct dependency because of the old version 2.16.x brought by Vert.x 4.5.x which
+			can't work together with the most updated jackson-databind throwing NoSuchMethodException
+		-->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>${jackson-core.version}</version>
 		</dependency>
 		<!-- Used only for test in the bridge, but needs to be here because OAuth brings it but a potential Maven bug remove it as runtime if only for test -->
 		<dependency>
@@ -619,6 +629,8 @@
 									<ignoredUnusedDeclaredDependency>io.prometheus:prometheus-metrics-exporter-httpserver</ignoredUnusedDeclaredDependency>
 									<!-- Transitive override to address CVE-2024-57699. Remove in the future when oauth will bring json-path with fixed json-smart -->
 									<ignoredUnusedDeclaredDependency>net.minidev:json-smart</ignoredUnusedDeclaredDependency>
+									<!-- Added direct dependency because of the old version 2.16.x brought by Vert.x 4.5.x -->
+									<ignoredUnusedDeclaredDependency>com.fasterxml.jackson.core:jackson-core</ignoredUnusedDeclaredDependency>
 								</ignoredUnusedDeclaredDependencies>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -127,11 +127,10 @@
 		<maven.gpg.version>3.0.1</maven.gpg.version>
 		<sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
 		<openapi.generator.version>7.8.0</openapi.generator.version>
-		<jackson-core.version>2.16.1</jackson-core.version>
-		<jackson-databind.version>2.16.1</jackson-databind.version>
+		<jackson-databind.version>2.18.3</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
-		<strimzi-oauth.version>0.15.0</strimzi-oauth.version>
+		<strimzi-oauth.version>0.16.1</strimzi-oauth.version>
 		<strimzi-metrics-reporter.version>0.2.0</strimzi-metrics-reporter.version>
 		<opentelemetry.version>1.34.1</opentelemetry.version>
 		<opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
@@ -144,8 +143,9 @@
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.110.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
-		<snakeyaml.version>2.2</snakeyaml.version>
+		<snakeyaml.version>2.4</snakeyaml.version>
 		<guava.version>32.1.3-jre</guava.version>
+		<json-smart.version>2.5.2</json-smart.version>
 		<!-- property to skip surefire tests during failsafe execution -->
 		<!--suppress UnresolvedMavenProperty -->
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -392,6 +392,12 @@
 			<version>${spotbugs.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<!-- Transitive override to address CVE-2024-57699. Remove in the future when oauth will bring json-path with fixed json-smart -->
+		<dependency>
+			<groupId>net.minidev</groupId>
+			<artifactId>json-smart</artifactId>
+			<version>${json-smart.version}</version>
+		</dependency>
 		<!-- Testing -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -598,11 +604,8 @@
 									<ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>org.yaml:snakeyaml</ignoredUnusedDeclaredDependency> <!-- CVE override -->
-									<ignoredUnusedDeclaredDependency>org.apache.tomcat.embed:tomcat-embed-core</ignoredUnusedDeclaredDependency>  <!-- CVE override -->
 									<!-- OpenTelemetry - used via classpath configuration -->
 									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-otlp</ignoredUnusedDeclaredDependency>
-									<!-- OpenTelemetry - Vert.x using old version and OpenTelemetry breaking API compatibility. See dependency declaration for details. -->
-									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-sdk-trace</ignoredUnusedDeclaredDependency>
 									<!-- OpenTelemetry - used via classpath configuration opentelemetry-exporter-sender-jdk is required at runtime to replace OKHTTP -->
 									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-sender-jdk</ignoredUnusedDeclaredDependency>
 									<!-- OpenTelemetry - used via classpath configuration opentelemetry-exporter-sender-grpc is required at runtime to replace OKHTTP -->
@@ -614,6 +617,8 @@
 									<ignoredUnusedDeclaredDependency>io.strimzi:metrics-reporter</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>io.prometheus:prometheus-metrics-instrumentation-jvm</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>io.prometheus:prometheus-metrics-exporter-httpserver</ignoredUnusedDeclaredDependency>
+									<!-- Transitive override to address CVE-2024-57699. Remove in the future when oauth will bring json-path with fixed json-smart -->
+									<ignoredUnusedDeclaredDependency>net.minidev:json-smart</ignoredUnusedDeclaredDependency>
 								</ignoredUnusedDeclaredDependencies>
 						</configuration>
 					</execution>


### PR DESCRIPTION
Trivial PR to bump OAuth 0.16.2 and Jackson related dependencies to 2.18.3.