### PR TITLE
Fixed some missing refactoring Future completion with onSuccess and onFailure

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -94,11 +94,12 @@ public class ProducerIT extends HttpBridgeITAbstract {
             context.completeNow();
         });
 
-        consumer.subscribe(topic, done -> {
-            if (!done.succeeded()) {
-                context.failNow(done.cause());
-            }
-        });
+        consumer.subscribe(topic)
+                .onComplete(done -> {
+                    if (!done.succeeded()) {
+                        context.failNow(done.cause());
+                    }
+                });
         assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
     }
 


### PR DESCRIPTION
Fixing some missing refactoring to the usage of Future completion (pattern `onSuccess` + `onFailure`) for the migration to Vert.x 5.