### PR TITLE
Moved to use the Sonatype Central Portal

### DIFF
--- a/.azure/scripts/push-to-nexus.sh
+++ b/.azure/scripts/push-to-nexus.sh
@@ -18,6 +18,6 @@ export GPG_TTY=$(tty)
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
+GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P central verify deploy
 
 cleanup

--- a/.azure/scripts/settings.xml
+++ b/.azure/scripts/settings.xml
@@ -1,9 +1,9 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.NEXUS_USERNAME}</username>
-            <password>${env.NEXUS_PASSWORD}</password>
+            <id>central</id>
+            <username>${env.CENTRAL_USERNAME}</username>
+            <password>${env.CENTRAL_PASSWORD}</password>
         </server>
     </servers>
 </settings>

--- a/.azure/templates/jobs/deploy_java.yaml
+++ b/.azure/templates/jobs/deploy_java.yaml
@@ -33,6 +33,6 @@ jobs:
           BRANCH: $(Build.SourceBranch)
           GPG_PASSPHRASE: $(GPG_PASSPHRASE)
           GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
-          NEXUS_USERNAME: $(NEXUS_USERNAME)
-          NEXUS_PASSWORD: $(NEXUS_PASSWORD)
+          CENTRAL_USERNAME: $(CENTRAL_USERNAME)
+          CENTRAL_PASSWORD: $(CENTRAL_PASSWORD)
         displayName: "Deploy Java artifacts"

--- a/pom.xml
+++ b/pom.xml
@@ -90,17 +90,6 @@
 		</developer>
 	</developers>
 
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>
@@ -125,7 +114,7 @@
 		<maven.source.version>3.2.1</maven.source.version>
 		<maven.dependency.version>3.3.0</maven.dependency.version>
 		<maven.gpg.version>3.0.1</maven.gpg.version>
-		<sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
+		<central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
 		<openapi.generator.version>7.8.0</openapi.generator.version>
 		<jackson-core.version>2.18.3</jackson-core.version>
 		<jackson-databind.version>2.18.3</jackson-databind.version>
@@ -747,7 +736,7 @@
 			</properties>
 		</profile>
 		<profile>
-			<id>ossrh</id>
+			<id>central</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>
 			</activation>
@@ -781,14 +770,12 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>${sonatype.nexus.staging}</version>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>${central-publishing-maven-plugin.version}</version>
 						<extensions>true</extensions>
 						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+							<publishingServerId>central</publishingServerId>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
This PR fixes https://github.com/strimzi/strimzi-kafka-bridge/issues/987 which is about migrating the artifacts push from the OSSRH legacy system to the new Sonatype Central Publisher Portal.