### PR TITLE
Improve lifecycle of Integration tests

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
@@ -44,7 +44,7 @@ public class ConsumerGeneratedNameIT extends HttpBridgeITAbstract {
     private String consumerInstanceId = "";
 
     @Override
-    protected Map<String, Object> overridableConfig() {
+    protected Map<String, Object> overrideConfig() {
         Map<String, Object> overrides = new HashMap<>();
         overrides.put(BridgeConfig.BRIDGE_ID, null);
         overrides.put(BridgeConfig.METRICS_TYPE, null);

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerGeneratedNameIT.java
@@ -6,26 +6,16 @@ package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
-import io.strimzi.kafka.bridge.config.KafkaConfig;
 import io.strimzi.kafka.bridge.config.KafkaConsumerConfig;
-import io.strimzi.kafka.bridge.config.KafkaProducerConfig;
-import io.strimzi.kafka.bridge.http.services.ConsumerService;
-import io.strimzi.kafka.bridge.utils.Urls;
-import io.strimzi.test.container.StrimziKafkaCluster;
-import io.vertx.core.Vertx;
+import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
@@ -45,74 +35,21 @@ import static org.hamcrest.Matchers.is;
 @ExtendWith(VertxExtension.class)
 @Tag(HTTP_BRIDGE)
 @DisabledIfEnvironmentVariable(named = "EXTERNAL_BRIDGE", matches = "((?i)TRUE(?-i))")
-public class ConsumerGeneratedNameIT {
+public class ConsumerGeneratedNameIT extends HttpBridgeITAbstract {
     private static final Logger LOGGER = LogManager.getLogger(ConsumerGeneratedNameIT.class);
-    static String kafkaUri;
-    private static Map<String, Object> config = new HashMap<>();
-    private static StrimziKafkaCluster kafkaCluster;
-    private static final String BRIDGE_EXTERNAL_ENV = System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE");
-    private static final String KAFKA_EXTERNAL_ENV = System.getenv().getOrDefault("EXTERNAL_KAFKA", "FALSE");
-
-    static {
-        if ("FALSE".equals(KAFKA_EXTERNAL_ENV)) {
-            kafkaCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
-                .withNumberOfBrokers(1)
-                .withSharedNetwork()
-                .build();
-            kafkaCluster.start();
-            kafkaUri = kafkaCluster.getBootstrapServers();
-        } else {
-            // else use external kafka
-            kafkaUri = "localhost:9092";
-        }
-
-        config.put(KafkaConfig.KAFKA_CONFIG_PREFIX + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
-        config.put(KafkaConsumerConfig.KAFKA_CONSUMER_CONFIG_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        config.put(KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.MAX_BLOCK_MS_CONFIG, "10000");
-        config.put(HttpConfig.HTTP_CONSUMER_TIMEOUT, 5L);
-    }
-
     private static final int TEST_TIMEOUT = 60;
-    private static Vertx vertx;
-    private static HttpBridge httpBridge;
-    private static WebClient client;
-    private static BridgeConfig bridgeConfig;
 
-    ConsumerService consumerService() {
-        return ConsumerService.getInstance(client);
-    }
+    private final String groupId = "my-group";
 
-    private String groupId = "my-group";
     private String consumerInstanceId = "";
 
-    @BeforeAll
-    static void beforeAll(VertxTestContext context) {
-        vertx = Vertx.vertx();
-
-        LOGGER.info("Environment variable EXTERNAL_BRIDGE:" + BRIDGE_EXTERNAL_ENV);
-
-        if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
-
-            bridgeConfig = BridgeConfig.fromMap(config);
-            httpBridge = new HttpBridge(bridgeConfig);
-
-            LOGGER.info("Deploying in-memory bridge");
-            vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> context.completeNow()));
-        }
-        // else we create external bridge from the OS invoked by `.jar`
-
-        client = WebClient.create(vertx, new WebClientOptions()
-            .setDefaultHost(Urls.BRIDGE_HOST)
-            .setDefaultPort(Urls.BRIDGE_PORT)
-        );
-    }
-
-    @AfterAll
-    static void afterAll(VertxTestContext context) {
-        if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
-            kafkaCluster.stop();
-            vertx.close().onComplete(context.succeeding(arg -> context.completeNow()));
-        }
+    @Override
+    protected Map<String, Object> overridableConfig() {
+        Map<String, Object> overrides = new HashMap<>();
+        overrides.put(BridgeConfig.BRIDGE_ID, null);
+        overrides.put(BridgeConfig.METRICS_TYPE, null);
+        overrides.put(KafkaConsumerConfig.KAFKA_CONSUMER_CONFIG_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        return overrides;
     }
 
     @Test

--- a/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
@@ -25,7 +25,7 @@ public class InvalidProducerIT extends HttpBridgeITAbstract {
     private static final Logger LOGGER = LogManager.getLogger(InvalidProducerIT.class);
 
     @Override
-    protected Map<String, Object> overridableConfig() {
+    protected Map<String, Object> overrideConfig() {
         Map<String, Object> cfg = new HashMap<>();
         cfg.put("kafka.producer.acks", "5"); // invalid config
         return cfg;

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -59,7 +59,7 @@ import static io.strimzi.kafka.bridge.Constants.HTTP_BRIDGE;
  * <p>
  * The suite is designed for extensibility. Common extension points:
  * <ul>
- *   <li>{@link #overridableConfig()} — override to customize bridge or Kafka configuration for your tests.</li>
+ *   <li>{@link #overrideConfig()} — override to customize bridge or Kafka configuration for your tests.</li>
  *   <li>{@link #setupKafkaCluster()} — override to customize embedded cluster setup.</li>
  *   <li>{@link #deployBridge(VertxTestContext)} — override to deploy the Bridge in a custom way (e.g. external or per-test deployment).</li>
  * </ul>
@@ -180,7 +180,7 @@ public abstract class HttpBridgeITAbstract {
         config.putAll(defaults);
 
         // Apply overrides
-        overridableConfig().forEach((key, value) -> {
+        overrideConfig().forEach((key, value) -> {
             if (value == null) {
                 config.remove(key);
             } else {
@@ -238,7 +238,7 @@ public abstract class HttpBridgeITAbstract {
      * Return a map with configuration keys to override default values,
      * or keys mapped to {@code null} to remove them.
      */
-    protected Map<String, Object> overridableConfig() {
+    protected Map<String, Object> overrideConfig() {
         return new HashMap<>();
     }
 


### PR DESCRIPTION
This PR improves our Integration tests lifecycle. It re-implements the approach to **not USE** shared objects during the whole test execution. Therefore, we decided to create new instances of Kafka cluster, Bridge, etc., for each test suite. For edge cases where a different configuration is needed, I have added overridable hooks. 