### PR TITLE
Renamed project name within pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>kafka-bridge</artifactId>
 	<version>0.33.0-SNAPSHOT</version>
 
-	<name>Strimzi Kafka Bridge</name>
+	<name>Strimzi HTTP bridge for Apache Kafka</name>
 	<description>Bridge that allows HTTP clients to interact with Apache Kafka clusters.</description>
 	<url>https://strimzi.io/</url>
 


### PR DESCRIPTION
Trivial PR to rename the project name within the pom.xml to reflect how we define it in the README and making clear it's an HTTP bridge (the AMQP part was removed long time ago).