### PR TITLE
Improve integration tests logs between each test case + fix flaky SeekIT

### DIFF
--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -16,7 +16,6 @@ jobs:
     # Variables
     variables:
       MVN_CACHE_FOLDER: $(HOME)/.m2/repository
-      MVN_ARGS: '-e -V -B'
     # Pipeline steps
     steps:
       # Get cached Maven repository

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -30,7 +30,7 @@ jobs:
           BRANCH: $(Build.SourceBranch)
           TESTCONTAINERS_RYUK_DISABLED: "TRUE"
           TESTCONTAINERS_CHECKS_DISABLE: "TRUE"
-          MVN_ARGS: "-e -V -B -Dfailsafe.rerunFailingTestsCount=2"
+          MVN_ARGS: "-e -V -B"
       - bash: "make spotbugs"
         displayName: "Spotbugs"
         env:

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -31,7 +31,7 @@ jobs:
           BRANCH: $(Build.SourceBranch)
           TESTCONTAINERS_RYUK_DISABLED: "TRUE"
           TESTCONTAINERS_CHECKS_DISABLE: "TRUE"
-          MVN_ARGS: "-e -V -B"          
+          MVN_ARGS: "-e -V -B -Dfailsafe.rerunFailingTestsCount=2"
       - bash: "make spotbugs"
         displayName: "Spotbugs"
         env:

--- a/.azure/templates/jobs/build_java.yaml
+++ b/.azure/templates/jobs/build_java.yaml
@@ -30,7 +30,7 @@ jobs:
           BRANCH: $(Build.SourceBranch)
           TESTCONTAINERS_RYUK_DISABLED: "TRUE"
           TESTCONTAINERS_CHECKS_DISABLE: "TRUE"
-          MVN_ARGS: "-e -V -B"
+          MVN_ARGS: "-e -V -B -Dfailsafe.rerunFailingTestsCount=2"
       - bash: "make spotbugs"
         displayName: "Spotbugs"
         env:

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -408,7 +408,7 @@ public class SeekIT extends HttpBridgeITAbstract {
     }
 
     @Test
-    void seekToBeginningMultipleTopicsWithNotSuscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    void seekToBeginningMultipleTopicsWithNotSubscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
         String subscribedTopic = "seekToBeginningSubscribedTopic";
         String notSubscribedTopic = "seekToBeginningNotSubscribedTopic";
 
@@ -478,8 +478,8 @@ public class SeekIT extends HttpBridgeITAbstract {
     }
 
     @Test
-    void seekToOffsetMultipleTopicsWithNotSuscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        String subscribedTopic = "seekToOffseSubscribedTopic";
+    void seekToOffsetMultipleTopicsWithNotSubscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+        String subscribedTopic = "seekToOffsetSubscribedTopic";
         String notSubscribedTopic = "seekToOffsetNotSubscribedTopic";
 
         LOGGER.info("Creating topics " + subscribedTopic + "," + notSubscribedTopic);

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -478,8 +478,8 @@ public class SeekIT extends HttpBridgeITAbstract {
     }
 
     @Test
-    void seekToOffsetMultipleTopicsWithNotSuscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        String subscribedTopic = "seekToOffseSubscribedTopic";
+    void seekToOffsetMultipleTopicsWithNotSubscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+        String subscribedTopic = "seekToOffsetSubscribedTopic";
         String notSubscribedTopic = "seekToOffsetNotSubscribedTopic";
 
         LOGGER.info("Creating topics " + subscribedTopic + "," + notSubscribedTopic);
@@ -531,6 +531,12 @@ public class SeekIT extends HttpBridgeITAbstract {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
                         HttpBridgeError error = HttpBridgeError.fromJson(response.body());
+
+                        LOGGER.info("Seek response status code: {}", response.statusCode());
+                        LOGGER.info("Seek error code: {}", error.code());
+                        LOGGER.info("Seek error message: '{}'", error.message());
+                        LOGGER.info("Seek response body: {}", response.body());
+
                         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
                         assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
                         assertThat(error.message(), is("No current assignment for partition " + notSubscribedTopic + "-0"));

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -514,7 +514,7 @@ public class SeekIT extends HttpBridgeITAbstract {
                 retries++;
             }
         }
-        throw new TimeoutException("Timed out waiting for partition assignment for consumer " + name);
+        throw new TimeoutException("Timed out waiting for partition assignment for consumer " + groupId + "/" + name);
     }
 
     @Test

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -434,6 +434,15 @@ public class SeekIT extends HttpBridgeITAbstract {
                 .createConsumer(context, groupId, jsonConsumer)
                 .subscribeConsumer(context, groupId, name, topics);
 
+        CompletableFuture<Boolean> consume = new CompletableFuture<>();
+
+        // poll to subscribe
+        consumerService()
+            .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
+            .as(BodyCodec.jsonObject())
+            .send()
+            .onComplete(ar -> consume.complete(true));
+
         waitUntilPartitionAssigned(consumerService(), groupId, name, 5, 200);
 
         // seek

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -434,15 +434,6 @@ public class SeekIT extends HttpBridgeITAbstract {
                 .createConsumer(context, groupId, jsonConsumer)
                 .subscribeConsumer(context, groupId, name, topics);
 
-        CompletableFuture<Boolean> consume = new CompletableFuture<>();
-
-        // poll to subscribe
-        consumerService()
-            .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
-            .as(BodyCodec.jsonObject())
-            .send()
-            .onComplete(ar -> consume.complete(true));
-
         waitUntilPartitionAssigned(consumerService(), groupId, name, 5, 200);
 
         // seek

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -461,13 +461,6 @@ public class SeekIT extends HttpBridgeITAbstract {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
                         HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-
-                        LOGGER.info("Seek response status code: {}", response.statusCode());
-                        LOGGER.info("Seek error code: {}", error.code());
-                        LOGGER.info("Seek error message: '{}'", error.message());
-                        LOGGER.info("Seek response body: {}", response.body());
-
-
                         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
                         assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
                         assertThat(error.message(), is("No current assignment for partition " + notSubscribedTopic + "-0"));
@@ -485,8 +478,8 @@ public class SeekIT extends HttpBridgeITAbstract {
     }
 
     @Test
-    void seekToOffsetMultipleTopicsWithNotSubscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        String subscribedTopic = "seekToOffsetSubscribedTopic";
+    void seekToOffsetMultipleTopicsWithNotSuscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+        String subscribedTopic = "seekToOffseSubscribedTopic";
         String notSubscribedTopic = "seekToOffsetNotSubscribedTopic";
 
         LOGGER.info("Creating topics " + subscribedTopic + "," + notSubscribedTopic);
@@ -538,12 +531,6 @@ public class SeekIT extends HttpBridgeITAbstract {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
                         HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-
-                        LOGGER.info("Seek response status code: {}", response.statusCode());
-                        LOGGER.info("Seek error code: {}", error.code());
-                        LOGGER.info("Seek error message: '{}'", error.message());
-                        LOGGER.info("Seek response body: {}", response.body());
-
                         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
                         assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
                         assertThat(error.message(), is("No current assignment for partition " + notSubscribedTopic + "-0"));

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -461,6 +461,13 @@ public class SeekIT extends HttpBridgeITAbstract {
                         assertThat(ar.succeeded(), is(true));
                         HttpResponse<JsonObject> response = ar.result();
                         HttpBridgeError error = HttpBridgeError.fromJson(response.body());
+
+                        LOGGER.info("Seek response status code: {}", response.statusCode());
+                        LOGGER.info("Seek error code: {}", error.code());
+                        LOGGER.info("Seek error message: '{}'", error.message());
+                        LOGGER.info("Seek response body: {}", response.body());
+
+
                         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
                         assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
                         assertThat(error.message(), is("No current assignment for partition " + notSubscribedTopic + "-0"));

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -34,8 +34,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -17,6 +17,7 @@ import io.strimzi.kafka.bridge.http.services.BaseService;
 import io.strimzi.kafka.bridge.http.services.ConsumerService;
 import io.strimzi.kafka.bridge.http.services.ProducerService;
 import io.strimzi.kafka.bridge.http.services.SeekService;
+import io.strimzi.kafka.bridge.http.tools.TestSeparator;
 import io.strimzi.kafka.bridge.metrics.MetricsType;
 import io.strimzi.kafka.bridge.utils.Urls;
 import io.strimzi.test.container.StrimziKafkaCluster;
@@ -33,6 +34,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,7 +77,7 @@ import static io.strimzi.kafka.bridge.Constants.HTTP_BRIDGE;
 @SuppressWarnings({"checkstyle:JavaNCSS"})
 @Tag(HTTP_BRIDGE)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class HttpBridgeITAbstract {
+public abstract class HttpBridgeITAbstract implements TestSeparator {
     private static final Logger LOGGER = LogManager.getLogger(HttpBridgeITAbstract.class);
     protected static Map<String, Object> config = new HashMap<>();
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -102,6 +102,8 @@ public abstract class HttpBridgeITAbstract implements TestSeparator {
     protected static HttpBridge httpBridge;
     protected static BridgeConfig bridgeConfig;
 
+    private final static Random RNG = new Random();
+
     @BeforeAll
     void beforeAll(VertxTestContext context) {
         LOGGER.info("Environment variable EXTERNAL_BRIDGE:" + BRIDGE_EXTERNAL_ENV);
@@ -130,7 +132,7 @@ public abstract class HttpBridgeITAbstract implements TestSeparator {
 
     @BeforeEach
     void setUpEach() {
-        topic = "my-topic-" + new Random().nextInt(Integer.MAX_VALUE);
+        topic = "my-topic-" + RNG.nextInt(Integer.MAX_VALUE);
     }
 
     @AfterEach
@@ -157,7 +159,7 @@ public abstract class HttpBridgeITAbstract implements TestSeparator {
     }
 
     protected String generateRandomConsumerGroupName() {
-        int salt = new Random().nextInt(Integer.MAX_VALUE);
+        int salt = RNG.nextInt(Integer.MAX_VALUE);
         return "my-group-" + salt;
     }
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/tools/ExtensionContextParameterResolver.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/tools/ExtensionContextParameterResolver.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.http.tools;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+
+/**
+ * JUnit 5 {@link ParameterResolver} that injects the current {@link ExtensionContext}
+ * into test methods or lifecycle methods that declare it as a parameter.
+ * <p>
+ * This is typically used to provide test context to {@code @BeforeEach}, {@code @AfterEach},
+ * or test methods themselves.
+ * </p>
+ */
+public class ExtensionContextParameterResolver implements ParameterResolver {
+    /**
+     * Checks if the parameter is of type {@link ExtensionContext}.
+     *
+     * @param parameterContext The context for the parameter for which a value is to be resolved.
+     * @param extensionContext The extension context for the test or container.
+     * @return {@code true} if the parameter is of type {@code ExtensionContext}, otherwise {@code false}.
+     * @throws ParameterResolutionException If an error occurs while checking parameter support.
+     */
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == ExtensionContext.class;
+    }
+
+    /**
+     * Provides the {@link ExtensionContext} instance as the parameter value.
+     *
+     * @param parameterContext The context for the parameter for which a value is to be resolved.
+     * @param extensionContext The extension context for the test or container.
+     * @return The current {@code ExtensionContext} instance.
+     * @throws ParameterResolutionException If an error occurs during parameter resolution.
+     */
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return extensionContext;
+    }
+}

--- a/src/test/java/io/strimzi/kafka/bridge/http/tools/TestSeparator.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/tools/TestSeparator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.http.tools;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Collections;
+
+/**
+ * Provides a separator in the log output before and after each test for improved readability.
+ * <p>
+ * Implement this interface in your test classes to automatically log a separator line and test status
+ * (STARTED, SUCCEEDED, FAILED) around each test execution.
+ * </p>
+ */
+@ExtendWith(ExtensionContextParameterResolver.class)
+public interface TestSeparator {
+    /**
+     * Logger instance used for logging separator and test status.
+     */
+    Logger LOGGER = LogManager.getLogger(TestSeparator.class);
+
+    /**
+     * The character used to build the separator line in the log output.
+     */
+    String SEPARATOR_CHAR = "#";
+
+    /**
+     * The length of the separator line.
+     */
+    int SEPARATOR_LENGTH = 76;
+
+    /**
+     * Logs a separator line and the test class/method at the start of each test.
+     *
+     * @param context the JUnit extension context for the test
+     */
+    @BeforeEach
+    default void beforeEachTest(ExtensionContext context) {
+        LOGGER.info(String.join("", Collections.nCopies(SEPARATOR_LENGTH, SEPARATOR_CHAR)));
+        LOGGER.info("{}.{} - STARTED", context.getRequiredTestClass().getName(), context.getRequiredTestMethod().getName());
+    }
+
+    /**
+     * Logs the test result (SUCCEEDED or FAILED) and a separator line at the end of each test.
+     *
+     * @param context the JUnit extension context for the test
+     */
+    @AfterEach
+    default void afterEachTest(ExtensionContext context) {
+        String status = context.getExecutionException().isPresent() ? "FAILED" : "SUCCEEDED";
+        LOGGER.info("{}.{} - {}", context.getRequiredTestClass().getName(), context.getRequiredTestMethod().getName(), status);
+        LOGGER.info(String.join("", Collections.nCopies(SEPARATOR_LENGTH, SEPARATOR_CHAR)));
+    }
+}

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -8,7 +8,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %highlight{%-5p} [%t] %c{1}:%L - %m%n
 
-rootLogger.level = INFO
+rootLogger.level = DEBUG
 rootLogger.appenderRefs = console
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -8,7 +8,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %highlight{%-5p} [%t] %c{1}:%L - %m%n
 
-rootLogger.level = DEBUG
+rootLogger.level = INFO
 rootLogger.appenderRefs = console
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false


### PR DESCRIPTION
Currently, it's challenging to navigate between tests in Azure and troubleshoot issues, including race conditions.  This PR introduces a TestSeparator class, which aims to mitigate this problem. As a result, now we can see clean separation in each test case, f.e.:
```java
2025-06-04 11:52:08 INFO  [vert.x-eventloop-thread-0] AppInfoParser:125 - Kafka version: 4.0.0
2025-06-04 11:52:08 INFO  [vert.x-eventloop-thread-0] AppInfoParser:126 - Kafka commitId: 0ebdee20e38bf984
2025-06-04 11:52:08 INFO  [vert.x-eventloop-thread-0] AppInfoParser:127 - Kafka startTimeMs: 1749030728000
2025-06-04 11:52:08 INFO  [vert.x-eventloop-thread-0] HttpBridge:158 - HTTP-Kafka Bridge started and listening on port 8080
2025-06-04 11:52:08 INFO  [vert.x-eventloop-thread-0] HttpBridge:159 - HTTP-Kafka Bridge bootstrap servers PLAINTEXT://localhost:40537
2025-06-04 11:52:08 INFO  [main] TestSeparator:47 - ############################################################################
2025-06-04 11:52:08 INFO  [main] TestSeparator:48 - io.strimzi.kafka.bridge.http.ConsumerGeneratedNameIT.createConsumerNameIsSetAndBridgeIdIsNotSet - STARTED
2025-06-04 11:52:08 INFO  [vert.x-eventloop-thread-0] createConsumer:49 - [1814316050] CREATE_CONSUMER Request: from 127.0.0.1:59772, method = POST, path = /consumers/my-group
2025-06-04 11:52:08 INFO  [vert.x-eventloop-thread-0] AbstractConfig:371 - ConsumerConfig values: 
	allow.auto.create.topics = true
...
2025-06-04 11:52:08 INFO  [main] HttpBridgeITAbstract:141 - Kafka still contains []
2025-06-04 11:52:08 INFO  [main] TestSeparator:59 - io.strimzi.kafka.bridge.http.ConsumerGeneratedNameIT.createConsumerNameIsSetAndBridgeIdIsNotSet - SUCCEEDED
2025-06-04 11:52:08 INFO  [main] TestSeparator:60 - ############################################################################
2025-06-04 11:52:08 INFO  [main] TestSeparator:47 - ############################################################################
2025-06-04 11:52:08 INFO  [main] TestSeparator:48 - io.strimzi.kafka.bridge.http.ConsumerGeneratedNameIT.createConsumerNameIsNotSetAndBridgeIdNotSet - STARTED
2025-06-04 11:52:08 INFO  [vert.x-eventloop-thread-0] createConsumer:49 - [1191665168] CREATE_CONSUMER Request: from 127.0.0.1:59772, method = POST, path = /consumers/my-group
20
...
```

Moreover, I have fixed the flaky test case `seekToOffsetMultipleTopicsWithNotSuscribedTopic`, as our small VMs on Azure cause those race conditions to occur more frequently than in my local setup. I used 'wait' until I was able to fix it properly, so no race condition is present in this test case anymore.
	