### PR TITLE
Bumping Kafka, Vert.x and Netty to fix several CVEs + fix flaky SeekIT test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.31.2
+
+* Dependency updates (Kafka 3.9.1 [CVE-2025-27817](https://nvd.nist.gov/vuln/detail/CVE-2025-27817), Vert.x 4.5.14, Netty 4.1.118.Final [CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193) [CVE-2025-24970](https://nvd.nist.gov/vuln/detail/CVE-2025-24970)) for fixing CVEs
+
 ## 0.31.1
 
 * Fixed missing SCRAM-SHA-256 support.

--- a/pom.xml
+++ b/pom.xml
@@ -100,10 +100,10 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<log4j.version>2.17.2</log4j.version>
-		<vertx.version>4.5.11</vertx.version>
-		<vertx-testing.version>4.5.11</vertx-testing.version>
-		<netty.version>4.1.115.Final</netty.version>
-		<kafka.version>3.9.0</kafka.version>
+		<vertx.version>4.5.14</vertx.version>
+		<vertx-testing.version>4.5.14</vertx-testing.version>
+		<netty.version>4.1.118.Final</netty.version>
+		<kafka.version>3.9.1</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<maven.checkstyle.version>3.3.0</maven.checkstyle.version>

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -893,8 +893,8 @@ public class ProducerIT extends HttpBridgeITAbstract {
                     String statusMessage = offsets.getJsonObject(0).getString("message");
 
                     assertThat(code, is(HttpResponseStatus.NOT_FOUND.code()));
-                    assertThat(statusMessage, is("Topic " + topic + " not present in metadata after " +
-                                config.get(KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.MAX_BLOCK_MS_CONFIG) + " ms."));
+                    assertThat(statusMessage, is("Partition 1 of topic " + topic + " with partition count 1 is not present in metadata after " +
+                            config.get(KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + ProducerConfig.MAX_BLOCK_MS_CONFIG) + " ms."));
                 });
                 context.completeNow();
             });
@@ -1095,7 +1095,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
                         assertThat(metadata.getLong("offset"), is(0L));
                         HttpBridgeError error = HttpBridgeError.fromJson(offsets.getJsonObject(1));
                         assertThat(error.getCode(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.getMessage(), is("Topic " + topic + " not present in metadata after 10000 ms."));
+                        assertThat(error.getMessage(), is("Partition 500 of topic " + topic + " with partition count 3 is not present in metadata after 10000 ms."));
                     });
                     context.completeNow();
                 });

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -421,7 +421,7 @@ public class SeekIT extends HttpBridgeITAbstract {
             .createConsumer(context, groupId, jsonConsumer)
             .subscribeConsumer(context, groupId, name, topics);
 
-        waitUntilPartitionAssigned(consumerService(), groupId, name, 5, 200);
+        waitUntilPartitionAssigned(consumerService(), groupId, name, 10, 2000);
 
         // seek
         JsonArray partitions = new JsonArray();

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -8,6 +8,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
+import io.strimzi.kafka.bridge.http.services.ConsumerService;
 import io.strimzi.kafka.bridge.utils.Urls;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -395,7 +396,7 @@ public class SeekIT extends HttpBridgeITAbstract {
     }
 
     @Test
-    void seekToBeginningMultipleTopicsWithNotSuscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    void seekToBeginningMultipleTopicsWithNotSuscribedTopic(VertxTestContext context) throws Exception {
         String subscribedTopic = "seekToBeginningSubscribedTopic";
         String notSubscribedTopic = "seekToBeginningNotSubscribedTopic";
 
@@ -420,15 +421,7 @@ public class SeekIT extends HttpBridgeITAbstract {
             .createConsumer(context, groupId, jsonConsumer)
             .subscribeConsumer(context, groupId, name, topics);
 
-        CompletableFuture<Boolean> consume = new CompletableFuture<>();
-
-        // poll to subscribe
-        consumerService()
-            .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
-            .as(BodyCodec.jsonObject())
-            .send(ar -> consume.complete(true));
-
-        consume.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        waitUntilPartitionAssigned(consumerService(), groupId, name, 5, 200);
 
         // seek
         JsonArray partitions = new JsonArray();
@@ -459,6 +452,45 @@ public class SeekIT extends HttpBridgeITAbstract {
 
         context.completeNow();
         assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+    }
+
+    /**
+     * Waits until the Kafka consumer with the given name in the specified group has received
+     * a partition assignment. This method performs repeated polling using
+     * {@link ConsumerService#consumeRecordsRequest} to ensure that group coordination and
+     * partition assignment have completed before the test proceeds.
+     *
+     * @param consumerService   the {@link ConsumerService} instance used to interact with the consumer
+     * @param groupId           the Kafka consumer group ID
+     * @param name              the name of the consumer (within the group)
+     * @param maxRetries        maximum number of poll attempts before giving up
+     * @param delayMs           delay in milliseconds between retries
+     * @throws Exception        if partition assignment doesn't complete in time
+     */
+    void waitUntilPartitionAssigned(final ConsumerService consumerService,
+                                    final String groupId,
+                                    final String name,
+                                    final int maxRetries,
+                                    final int delayMs) throws Exception {
+        int retries = 0;
+        while (retries < maxRetries) {
+            CompletableFuture<Boolean> pollComplete = new CompletableFuture<>();
+            consumerService.consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
+                    .as(BodyCodec.jsonObject())
+                    .send()
+                    .onComplete(ar -> {
+                        // if here poll succeeded, then it means assignment is done
+                        pollComplete.complete(true);
+                    });
+            boolean result = pollComplete.get(10, TimeUnit.SECONDS);
+            if (result) {
+                return;
+            } else {
+                Thread.sleep(delayMs);
+                retries++;
+            }
+        }
+        throw new TimeoutException("Timed out waiting for partition assignment for consumer " + groupId + "/" + name);
     }
 
     @Test


### PR DESCRIPTION
This PR bumps Kafka, Vert.x and Netty dependencies in order to fix the following CVEs:

* CVE-2025-27817
* CVE-2025-25193
* CVE-2025-24970

It also fixes a flaky SeekIT test.
