### PR TITLE
[release-0.31.x] Move to the Sonatype Central Portal

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -65,12 +65,13 @@ stages:
           artifactPipeline: ''
           artifactRunVersion: ''
           artifactRunId: ''
+  # Deploy Strimzi Java artifacts -> run only on main branch (where it deploys to OSS snapshot repos)
   - stage: java_deploy
     displayName: Deploy Java
     dependsOn:
       - container_build
       - docs_build
-    condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/heads/release-')))
+    condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
     jobs:
       - template: 'templates/jobs/deploy_java.yaml'
         parameters:

--- a/.azure/release-pipeline.yaml
+++ b/.azure/release-pipeline.yaml
@@ -26,6 +26,18 @@ parameters:
 
 # Stages
 stages:
+  - stage: publish_artifacts
+    displayName: Publish artifacts for ${{ parameters.releaseVersion }}
+    condition: startsWith(variables['build.sourceBranch'], 'refs/heads/release-')
+    jobs:
+      - template: 'templates/jobs/release_artifacts.yaml'
+        parameters:
+          artifactSource: 'current'
+          artifactProject: 'strimzi'
+          artifactPipeline: ''
+          artifactRunVersion: ''
+          artifactRunId: ''
+          releaseVersion: '${{ parameters.releaseVersion }}'
   - stage: containers_publish_with_suffix
     displayName: Publish Containers for ${{ parameters.releaseVersion }}-${{ parameters.releaseSuffix }}
     condition: and(succeeded(), startsWith(variables['build.sourceBranch'], 'refs/heads/release-'), eq('${{ parameters.useSuffix }}', 'true'))

--- a/.azure/scripts/push-to-central.sh
+++ b/.azure/scripts/push-to-central.sh
@@ -18,6 +18,6 @@ export GPG_TTY=$(tty)
 echo $GPG_SIGNING_KEY | base64 -d > signing.gpg
 gpg --batch --import signing.gpg
 
-GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P ossrh verify deploy
+GPG_EXECUTABLE=gpg mvn $MVN_ARGS -DskipTests -s ./.azure/scripts/settings.xml -P central deploy
 
 cleanup

--- a/.azure/scripts/settings.xml
+++ b/.azure/scripts/settings.xml
@@ -1,9 +1,9 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.NEXUS_USERNAME}</username>
-            <password>${env.NEXUS_PASSWORD}</password>
+            <id>central</id>
+            <username>${env.CENTRAL_USERNAME}</username>
+            <password>${env.CENTRAL_PASSWORD}</password>
         </server>
     </servers>
 </settings>

--- a/.azure/templates/jobs/deploy_java.yaml
+++ b/.azure/templates/jobs/deploy_java.yaml
@@ -19,12 +19,12 @@ jobs:
           runId: '${{ parameters.artifactRunId }}'
       - bash: tar -xvf target.tar
         displayName: "Untar the target directory"
-      - bash: "./.azure/scripts/push-to-nexus.sh"
+      - bash: "./.azure/scripts/push-to-central.sh"
         env:
           BUILD_REASON: $(Build.Reason)
           BRANCH: $(Build.SourceBranch)
           GPG_PASSPHRASE: $(GPG_PASSPHRASE)
           GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
-          NEXUS_USERNAME: $(NEXUS_USERNAME)
-          NEXUS_PASSWORD: $(NEXUS_PASSWORD)
+          CENTRAL_USERNAME: $(CENTRAL_USERNAME)
+          CENTRAL_PASSWORD: $(CENTRAL_PASSWORD)
         displayName: "Deploy Java artifacts"

--- a/.azure/templates/jobs/release_artifacts.yaml
+++ b/.azure/templates/jobs/release_artifacts.yaml
@@ -1,0 +1,33 @@
+jobs:
+  - job: 'release_artifacts'
+    displayName: 'Prepare and release artifacts'
+    # Set timeout for jobs
+    timeoutInMinutes: 60
+    # Base system
+    pool:
+      vmImage: 'Ubuntu-22.04'
+    # Pipeline steps
+    steps:
+      # Install Prerequisites
+      - template: '../steps/prerequisites/install_java.yaml'
+
+      # Change the release version
+      - bash: "mvn versions:set -DnewVersion=$(shell echo $(RELEASE_VERSION) | tr a-z A-Z)"
+        displayName: "Configure release version to ${{ parameters.releaseVersion }}"
+        env:
+          RELEASE_VERSION: '${{ parameters.releaseVersion }}'
+
+      - bash: "mvn install -DskipTests"
+        displayName: "Build Java"
+
+      # Deploy to Central
+      - bash: "./.azure/scripts/push-to-central.sh"
+        env:
+          BUILD_REASON: $(Build.Reason)
+          BRANCH: $(Build.SourceBranch)
+          GPG_PASSPHRASE: $(GPG_PASSPHRASE)
+          GPG_SIGNING_KEY: $(GPG_SIGNING_KEY)
+          CENTRAL_USERNAME: $(CENTRAL_USERNAME)
+          CENTRAL_PASSWORD: $(CENTRAL_PASSWORD)
+          MVN_ARGS: "-e -V -B"
+        displayName: "Deploy Java artifacts"

--- a/.azure/templates/steps/prerequisites/install_java.yaml
+++ b/.azure/templates/steps/prerequisites/install_java.yaml
@@ -5,7 +5,7 @@ parameters:
 steps:
   - task: JavaToolInstaller@0
     inputs:
-      versionSpec: $(JDK_VERSION)
+      versionSpec: ${{ parameters.JDK_VERSION }}
       jdkArchitectureOption: 'x64'
       jdkSourceOption: 'PreInstalled'
     displayName: 'Configure Java'

--- a/pom.xml
+++ b/pom.xml
@@ -84,17 +84,6 @@
 		</developer>
 	</developers>
 
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
@@ -119,7 +108,7 @@
 		<maven.source.version>3.2.1</maven.source.version>
 		<maven.dependency.version>3.3.0</maven.dependency.version>
 		<maven.gpg.version>3.0.1</maven.gpg.version>
-		<sonatype.nexus.staging>1.7.0</sonatype.nexus.staging>
+		<central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
 		<openapi.generator.version>7.8.0</openapi.generator.version>
 		<jackson-core.version>2.16.1</jackson-core.version>
 		<jackson-databind.version>2.16.1</jackson-databind.version>
@@ -699,7 +688,7 @@
 			</properties>
 		</profile>
 		<profile>
-			<id>ossrh</id>
+			<id>central</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>
 			</activation>
@@ -733,14 +722,12 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>${sonatype.nexus.staging}</version>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>${central-publishing-maven-plugin.version}</version>
 						<extensions>true</extensions>
 						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+							<publishingServerId>central</publishingServerId>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
This PR adds the changes needed for migrating to the new Central portal on the `release-0.31.x` branch.
It also adds the release of artifacts within the release pipeline in order to release RCs in Maven Central (due to the missing staging area in the new Sonatype system).