### PR TITLE
[release-0.31.x] Bump OAuth 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.31.2
 
-* Dependency updates (Kafka 3.9.1 [CVE-2025-27817](https://nvd.nist.gov/vuln/detail/CVE-2025-27817), Vert.x 4.5.14, Netty 4.1.118.Final [CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193) [CVE-2025-24970](https://nvd.nist.gov/vuln/detail/CVE-2025-24970)) for fixing CVEs
+* Dependency updates (Kafka 3.9.1 [CVE-2025-27817](https://nvd.nist.gov/vuln/detail/CVE-2025-27817), Vert.x 4.5.14, Netty 4.1.118.Final [CVE-2025-25193](https://nvd.nist.gov/vuln/detail/CVE-2025-25193) [CVE-2025-24970](https://nvd.nist.gov/vuln/detail/CVE-2025-24970), OAuth 0.15.1) for fixing CVEs
 
 ## 0.31.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 		<jackson-databind.version>2.16.1</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
-		<strimzi-oauth.version>0.15.0</strimzi-oauth.version>
+		<strimzi-oauth.version>0.15.1-RC1</strimzi-oauth.version>
 		<opentelemetry.version>1.34.1</opentelemetry.version>
 		<opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
 		<opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 		<jackson-databind.version>2.16.1</jackson-databind.version>
 		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
-		<strimzi-oauth.version>0.15.1-RC1</strimzi-oauth.version>
+		<strimzi-oauth.version>0.15.1</strimzi-oauth.version>
 		<opentelemetry.version>1.34.1</opentelemetry.version>
 		<opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
 		<opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>


### PR DESCRIPTION
This PR bumps the OAuth version to the new 0.15.1.