### PR TITLE
[release-0.31.x] Bumped test-container 0.109.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 		<jmx-prometheus-collector.version>1.0.1</jmx-prometheus-collector.version>
 		<prometheus-client.version>1.3.1</prometheus-client.version>
 		<commons-cli.version>1.4</commons-cli.version>
-		<test-container.version>0.109.2-RC1</test-container.version>
+		<test-container.version>0.109.2</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>2.2</snakeyaml.version>
 		<guava.version>32.1.3-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 		<jmx-prometheus-collector.version>1.0.1</jmx-prometheus-collector.version>
 		<prometheus-client.version>1.3.1</prometheus-client.version>
 		<commons-cli.version>1.4</commons-cli.version>
-		<test-container.version>0.109.0</test-container.version>
+		<test-container.version>0.109.2-RC1</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>2.2</snakeyaml.version>
 		<guava.version>32.1.3-jre</guava.version>


### PR DESCRIPTION
This PR bumps the test-container version to the new 0.109.2