### PR TITLE
Fixed mvn versions set during release artifacts

### DIFF
--- a/.azure/templates/jobs/release_artifacts.yaml
+++ b/.azure/templates/jobs/release_artifacts.yaml
@@ -12,7 +12,7 @@ jobs:
       - template: '../steps/prerequisites/install_java.yaml'
 
       # Change the release version
-      - bash: "mvn versions:set -DnewVersion=$(echo $(RELEASE_VERSION) | tr a-z A-Z)"
+      - bash: "mvn versions:set -DnewVersion=$(echo $RELEASE_VERSION | tr a-z A-Z)"
         displayName: "Configure release version to ${{ parameters.releaseVersion }}"
         env:
           RELEASE_VERSION: '${{ parameters.releaseVersion }}'


### PR DESCRIPTION
This PR fixes a syntax issue when setting the version into mvn pom.xml file during release artifacts. It was causing the failure of the pipeline on the 0.31.x branch (where I already fixed).