### PR TITLE
Increased retries and delay for assigned partitions in STs

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -434,7 +434,7 @@ public class SeekIT extends HttpBridgeITAbstract {
                 .createConsumer(context, groupId, jsonConsumer)
                 .subscribeConsumer(context, groupId, name, topics);
 
-        waitUntilPartitionAssigned(consumerService(), groupId, name, 5, 200);
+        waitUntilPartitionAssigned(consumerService(), groupId, name, 10, 2000);
 
         // seek
         JsonArray partitions = new JsonArray();


### PR DESCRIPTION
Fixing on main the retries and delay used when waiting for partitions assignments during STs. It was already done on the `release-0.31.x` branch (for the release).
The current values drive to a too fast waiting 5 x 200 ms = 1000 ms and in just one second the assignment could not happen easily. 