### PR TITLE
Bumped Vert.x 5.0.1 with Netty 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.33.0
 
-* Dependency updates (Vert.x 5.0.0, Netty 4.2.1.Final, JMX Prometheus collector 1.3.0).
+* Dependency updates (Vert.x 5.0.1, Netty 4.2.2.Final, JMX Prometheus collector 1.3.0).
 * Updated OpenAPI specification to 3.1.0.
 * Added `validation_errors` field within the JSON object, as part of the `Error` OpenAPI component, returned by the bridge when there is a schema validation error.
   Such field is omitted when the error is not schema validation related.

--- a/pom.xml
+++ b/pom.xml
@@ -94,9 +94,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>
 		<log4j.version>2.17.2</log4j.version>
-		<vertx.version>5.0.0</vertx.version>
-		<vertx-testing.version>5.0.0</vertx-testing.version>
-		<netty.version>4.2.1.Final</netty.version>
+		<vertx.version>5.0.1</vertx.version>
+		<vertx-testing.version>5.0.1</vertx-testing.version>
+		<netty.version>4.2.2.Final</netty.version>
 		<kafka.version>4.0.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
This PR bumps Vert.x 5.0.1 together with corresponding Netty 4.2.2.