### PR TITLE
Disabled OpenMetrics exemplars within Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.33.1
+
+* Disabled OpenMetrics exemplars within Prometheus to fix [1023](https://github.com/strimzi/strimzi-kafka-bridge/issues/1023)
+
 ## 0.33.0
 
 * Dependency updates (Kafka 4.1.0, Vert.x 5.0.4, Netty 4.2.5.Final, JMX Prometheus collector 1.3.0, OAuth 0.17.0).

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -43,6 +43,10 @@ public class Application {
      * @param args command line arguments
      */
     public static void main(String[] args) {
+        // disabling OpenMetrics exemplars added within newer Prometheus client (see https://github.com/strimzi/strimzi-kafka-bridge/issues/1023)
+        // via https://github.com/prometheus/client_java/blob/main/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/MetricsProperties.java#L14
+        System.setProperty("io.prometheus.metrics.exemplarsEnabled", "false");
+
         LOGGER.info("Strimzi Kafka Bridge {} is starting", Application.class.getPackage().getImplementationVersion());
         try {
             CommandLine commandLine = new DefaultParser().parse(generateOptions(), args);


### PR DESCRIPTION
This PR fixes https://github.com/strimzi/strimzi-kafka-bridge/issues/1023 by disabling the usage of OpenMetrics exemplars within Prometheus (used by the JMX Exporter).