### PR TITLE
Removed System.out statements from ProducerIT tests to clean up test output.

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -132,7 +132,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
                             HttpResponse<JsonObject> response = ar.result();
                             assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
                             JsonObject bridgeResponse = response.body();
-                            LOGGER.info("Recieved response:\n{}", bridgeResponse);
+                            LOGGER.info("Received response:\n{}", bridgeResponse);
                             JsonArray offsets = bridgeResponse.getJsonArray("offsets");
                             assertThat(offsets.size(), is(3));
                             JsonObject metadata = offsets.getJsonObject(0);

--- a/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ProducerIT.java
@@ -119,7 +119,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
 
         JsonObject root = new JsonObject();
         root.put("records", records);
-        System.out.println(root);
+        LOGGER.info("Sending:\n{}", root);
 
         future.get();
 
@@ -132,7 +132,7 @@ public class ProducerIT extends HttpBridgeITAbstract {
                             HttpResponse<JsonObject> response = ar.result();
                             assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
                             JsonObject bridgeResponse = response.body();
-                            System.out.println(bridgeResponse);
+                            LOGGER.info("Recieved response:\n{}", bridgeResponse);
                             JsonArray offsets = bridgeResponse.getJsonArray("offsets");
                             assertThat(offsets.size(), is(3));
                             JsonObject metadata = offsets.getJsonObject(0);


### PR DESCRIPTION
This PR fixes #1029. Remove System.out statements from ProducerIT tests