### PR TITLE
Bump JMX Prometheus collector 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.34.0
+
+* Dependency updates (JMX Prometheus collector 1.5.0).
+
 ## 0.33.1
 
 * Disabled OpenMetrics exemplars within Prometheus to fix [1023](https://github.com/strimzi/strimzi-kafka-bridge/issues/1023)

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 		<opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version>
 		<grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
 		<micrometer.version>1.14.5</micrometer.version>
-		<jmx-prometheus-collector.version>1.3.0</jmx-prometheus-collector.version>
+		<jmx-prometheus-collector.version>1.5.0</jmx-prometheus-collector.version>
 		<prometheus.version>1.3.6</prometheus.version>
 		<commons-cli.version>1.4</commons-cli.version>
 		<test-container.version>0.112.0</test-container.version>


### PR DESCRIPTION
This trivial PR bumps JMX Prometheus collector to 1.5.0 to align with the Strimzi operator.