### PR TITLE
Bumped Vert.x 5.0.5 and Netty 4.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.34.0
 
-* Dependency updates (JMX Prometheus collector 1.5.0).
+* Dependency updates (Vert.x 5.0.5, Netty 4.2.7.Final, JMX Prometheus collector 1.5.0).
 
 ## 0.33.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>
 		<log4j.version>2.17.2</log4j.version>
-		<vertx.version>5.0.4</vertx.version>
-		<vertx-testing.version>5.0.4</vertx-testing.version>
-		<netty.version>4.2.5.Final</netty.version>
+		<vertx.version>5.0.5</vertx.version>
+		<vertx-testing.version>5.0.5</vertx-testing.version>
+		<netty.version>4.2.7.Final</netty.version>
 		<kafka.version>4.1.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
This PR bumps Vert.x and Netty to the latest releases. It replaces https://github.com/strimzi/strimzi-kafka-bridge/pull/1035