### PR TITLE
Add Log4j JSON Template Layout as runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.0
 
 * Dependency updates (Vert.x 5.0.5, Netty 4.2.7.Final, JMX Prometheus collector 1.5.0, OAuth 0.17.1).
+* Adding support for [JsonTemplateLayout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html).
 
 ## 0.33.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,12 @@
 			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-layout-template-json</artifactId>
+			<version>${log4j.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.strimzi</groupId>
 			<artifactId>kafka-oauth-client</artifactId>
 			<version>${strimzi-oauth.version}</version>
@@ -546,6 +552,8 @@
 									<ignoredUnusedDeclaredDependency>io.strimzi:kafka-oauth-client</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
+									<!-- Needed for adding new appender JsonTemplateLayout support for logging, it's a runtime dep -->
+									<ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-layout-template-json</ignoredUnusedDeclaredDependency>
 									<ignoredUnusedDeclaredDependency>org.yaml:snakeyaml</ignoredUnusedDeclaredDependency> <!-- CVE override -->
 									<!-- OpenTelemetry - used via classpath configuration -->
 									<ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-otlp</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
Add the Apache Log4j JSON Template Layout to allow emitting structured log messages in well-known JSON-based formats such as ECS.

Other components of Strimzi already contain this dependency:
https://github.com/strimzi/strimzi-kafka-operator/pull/11543

Thread in CNCF Slack:
https://cloud-native.slack.com/archives/CMH3Q3SNP/p1762438028032649