### PR TITLE
Make HttpBridgeITAbstract parametrized to run tests against multiple Kafka versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,11 @@
 		<maven.checkstyle.version>3.3.0</maven.checkstyle.version>
 		<checkstyle.version>10.12.2</checkstyle.version>
 		<hamcrest.version>2.2</hamcrest.version>
-		<junit.version>5.9.3</junit.version>
+		<junit.version>6.0.0</junit.version>
 		<mockito.version>4.11.0</mockito.version>
 		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-		<maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
-		<maven-failsafe-plugin.version>3.0.0-M7</maven-failsafe-plugin.version>
+		<maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
+		<maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
 		<maven.compiler.version>3.10.1</maven.compiler.version>
 		<maven.assembly.version>3.4.2</maven.assembly.version>
 		<maven.javadoc.version>3.4.1</maven.javadoc.version>
@@ -77,6 +77,7 @@
 		<jmx-prometheus-collector.version>1.5.0</jmx-prometheus-collector.version>
 		<prometheus.version>1.3.6</prometheus.version>
 		<commons-cli.version>1.4</commons-cli.version>
+        <!-- Update also list of Kafka version in HttpBridgeITAbstract.java together with test-container version! -->
 		<test-container.version>0.114.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>2.4</snakeyaml.version>
@@ -360,6 +361,12 @@
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-kafka-client</artifactId>
@@ -570,6 +577,8 @@
 									<ignoredUnusedDeclaredDependency>io.prometheus:prometheus-metrics-exporter-httpserver</ignoredUnusedDeclaredDependency>
 									<!-- Added direct dependency because of the old version 2.16.x brought by Vert.x 4.5.x -->
 									<ignoredUnusedDeclaredDependency>com.fasterxml.jackson.core:jackson-core</ignoredUnusedDeclaredDependency>
+                                    <!-- Needed by junit 6 -->
+                                    <ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine</ignoredUnusedDeclaredDependency>
 								</ignoredUnusedDeclaredDependencies>
 						</configuration>
 					</execution>

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -25,3 +25,7 @@ logger.healthy.name = http.openapi.operation.healthy
 logger.healthy.level = WARN
 logger.ready.name = http.openapi.operation.ready
 logger.ready.level = WARN
+
+# Suppress verbose Kafka AdminClient rebootstrapping logs
+logger.kafkaAdmin.name = org.apache.kafka.clients.admin
+logger.kafkaAdmin.level = WARN


### PR DESCRIPTION
This PR bump several dependencies to allow us use `@ParametrizedClass` from junit6 to run our ITs against multiple Kafka versions.

Closes https://github.com/strimzi/strimzi-kafka-bridge/issues/1037