### PR TITLE
Use Java 21 in the container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.0
 
+* Use Java 21 as the runtime in the Bridge container (Java 17 continues to be supported)
 * Dependency updates (Kafka 4.1.1, Vert.x 5.0.6, Netty 4.2.9.Final, JMX Prometheus collector 1.5.0, OAuth 0.17.1).
 * Adding support for [JsonTemplateLayout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html).
 * Add support for TLS/SSL on the HTTP interface

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-ARG JAVA_VERSION=17
+ARG JAVA_VERSION=21
 ARG TARGETPLATFORM
 
 USER root
@@ -9,14 +9,14 @@ RUN microdnf update -y \
     && microdnf clean all -y
 
 # Set JAVA_HOME env var
-ENV JAVA_HOME /usr/lib/jvm/jre-${JAVA_VERSION}
+ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}
 
 # Add strimzi user with UID 1001
 # The user is in the group 0 to have access to the mounted volumes and storage
 RUN useradd -r -m -u 1001 -g 0 strimzi
 
 ARG strimzi_kafka_bridge_version=1.0-SNAPSHOT
-ENV STRIMZI_KAFKA_BRIDGE_VERSION ${strimzi_kafka_bridge_version}
+ENV STRIMZI_KAFKA_BRIDGE_VERSION=${strimzi_kafka_bridge_version}
 ENV STRIMZI_HOME=/opt/strimzi
 RUN mkdir -p ${STRIMZI_HOME}
 WORKDIR ${STRIMZI_HOME}
@@ -26,7 +26,7 @@ COPY target/kafka-bridge-${strimzi_kafka_bridge_version}/kafka-bridge-${strimzi_
 #####
 # Add Tini
 #####
-ENV TINI_VERSION v0.19.0
+ENV TINI_VERSION=v0.19.0
 ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
 ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
 ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde


### PR DESCRIPTION
As approved in the [Strimzi Proposal 126](https://github.com/strimzi/proposals/blob/main/126-move-strimzi-operators-to-java-21.md), this PR moves the container image runtime to Java 21. It also addresses some minor warnings in the Dockerfile.