### PR TITLE
Update the CHANGELOG and default configuration with the management port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Changes, deprecations and removals
 
+* The `/healthy`, `/ready`, and `/metrics` endpoints are not available on the regular HTTP interface (port 8080 by default) anymore.
+  They are now available on the HTTP management interface (8081 by default).
+  Please update your configurations accordingly. 
 * The `/healthy` and `/ready` endpoints now return an HTTP response with code `200`, instead of the `204`, with an empty body. 
 
 ## 0.33.1

--- a/config/application.properties
+++ b/config/application.properties
@@ -1,4 +1,4 @@
-#Bridge related settings
+# Bridge-related settings
 bridge.id=my-bridge
 
 # uncomment the following line to enable Prometheus JMX Exporter, check the Kafka Bridge documentation for more details
@@ -14,25 +14,28 @@ bridge.id=my-bridge
 # uncomment the following line (bridge.tracing) to enable OpenTelemetry tracing, check the documentation for more details
 #bridge.tracing=opentelemetry
 
-#Apache Kafka common
+# Apache Kafka common
 kafka.bootstrap.servers=localhost:9092
 
-#Apache Kafka producer
+# Apache Kafka producer
 kafka.producer.acks=1
 
-#Apache Kafka consumer
+# Apache Kafka consumer
 kafka.consumer.auto.offset.reset=earliest
 
-#HTTP related settings
+# HTTP-related settings
 http.host=0.0.0.0
 http.port=8080
-#Enable CORS
+# Enable CORS
 http.cors.enabled=false
 http.cors.allowedOrigins=*
 http.cors.allowedMethods=GET,POST,PUT,DELETE,OPTIONS,PATCH
 
-#Enable consumer
+# Enable consumer
 http.consumer.enabled=true
 
-#Enable producer
+# Enable producer
 http.producer.enabled=true
+
+# HTTP management interface
+http.management.port=8081


### PR DESCRIPTION
The move of the metrics and healthcheck endpoints to port 8081 seems to be significant enough to be mentioned in the CHANGELOG. I think it would also be useful to have the default configuration for the HTTP management port in the example config file, similarly to how we have the regular HTTP port there.