### PR TITLE
Bumped Vert.x 5.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.34.0
 
 * Use Java 21 as the runtime in the Bridge container (Java 17 continues to be supported)
-* Dependency updates (Kafka 4.1.1, Vert.x 5.0.6, Netty 4.2.9.Final, JMX Prometheus collector 1.5.0, OAuth 0.17.1).
+* Dependency updates (Kafka 4.1.1, Vert.x 5.0.7, Netty 4.2.9.Final, JMX Prometheus collector 1.5.0, OAuth 0.17.1).
 * Adding support for [JsonTemplateLayout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html).
 * Add support for TLS/SSL on the HTTP interface
   Set `http.ssl.*` configurations to enable it.

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>
 		<log4j.version>2.25.3</log4j.version>
-		<vertx.version>5.0.6</vertx.version>
-		<vertx-testing.version>5.0.6</vertx-testing.version>
+		<vertx.version>5.0.7</vertx.version>
+		<vertx-testing.version>5.0.7</vertx-testing.version>
 		<netty.version>4.2.9.Final</netty.version>
 		<kafka.version>4.1.1</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.0</kafka-kubernetes-config-provider.version>


### PR DESCRIPTION
This trivial PR bumps Vert.x to 5.0.7 with some bugs and CVE fixed https://vertx.io/blog/eclipse-vert-x-5-0-7/
The Netty version stays the same.