### PR TITLE
Update Kubernetes Config Provider to 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.34.0
 
 * Use Java 21 as the runtime in the Bridge container (Java 17 continues to be supported)
-* Dependency updates (Kafka 4.1.1, Vert.x 5.0.7, Netty 4.2.9.Final, JMX Prometheus collector 1.5.0, OAuth 0.17.1, Kubernetes Configuration Provider 1.2.1).
+* Dependency updates (Kafka 4.1.1, Vert.x 5.0.7, Netty 4.2.9.Final, JMX Prometheus collector 1.5.0, OAuth 0.17.1, Kubernetes Configuration Provider 1.2.2).
 * Adding support for [JsonTemplateLayout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html).
 * Add support for TLS/SSL on the HTTP interface
   Set `http.ssl.*` configurations to enable it.

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<vertx-testing.version>5.0.7</vertx-testing.version>
 		<netty.version>4.2.9.Final</netty.version>
 		<kafka.version>4.1.1</kafka.version>
-		<kafka-kubernetes-config-provider.version>1.2.1</kafka-kubernetes-config-provider.version>
+		<kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<maven.checkstyle.version>3.5.0</maven.checkstyle.version>
 		<checkstyle.version>10.18.1</checkstyle.version>


### PR DESCRIPTION
This PR updates the Kubernetes Config Provider to 1.2.2 which fixes the unintended Vert.x dependency.