### PR TITLE
Git ignore Claude local configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ hs_err_pid*
 documentation/html/**
 documentation/htmlnoheader/**
 documentation/book/build/**
+
+# Claude configuration
+.claude/
+CLAUDE.md
+.mcp.json


### PR DESCRIPTION
Trivial PR adds Git ignore for local Claude configuration, similarly as was done in the operator here https://github.com/strimzi/strimzi-kafka-operator/pull/12349