### PR TITLE
Bumped Docker version in CI

### DIFF
--- a/.azure/templates/steps/prerequisites/install_docker.yaml
+++ b/.azure/templates/steps/prerequisites/install_docker.yaml
@@ -4,7 +4,7 @@ steps:
     displayName: Install Docker
     inputs:
       # Versions can be found from https://download.docker.com/linux/static/stable/x86_64/
-      dockerVersion: 24.0.5
+      dockerVersion: 29.2.0
       releaseType: stable
   - bash: |
       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
This PR bumps the Docker version in the CI as done for the operator because of pipeline failing with following error:

```shell
docker: Error response from daemon: client version 1.43 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
```