### PR TITLE
Fix skipping checkstyle for tests

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -15,5 +15,5 @@
               files="io[/\\]strimzi[/\\].*"/>
 
     <!-- Skip Javadoc checks for tests-->
-    <suppress checks="[JavadocMethod|JavaDocType|JavaDocVariable|MissingJavadocType|MissingJavadocMethod]" files="src[/\\]test[/\\]java[/\\].*"/>
+    <suppress checks="JavadocMethod|JavaDocType|JavadocVariable|MissingJavadocType|MissingJavadocMethod" files="src[/\\]test[/\\]java[/\\].*"/>
 </suppressions>

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -2,7 +2,6 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-
 package io.strimzi.kafka.bridge.http.base;
 
 import io.strimzi.kafka.bridge.clients.BasicKafkaClient;

--- a/src/test/java/io/strimzi/kafka/bridge/utils/Utils.java
+++ b/src/test/java/io/strimzi/kafka/bridge/utils/Utils.java
@@ -17,7 +17,8 @@ public class Utils {
      *
      * @param releaseFile The name of the file that contains the release version
      * @return The version of the Kafka Bridge
-     * @throws Exception
+     *
+     * @throws Exception exception if file is not found, unable to open, or get version from the file
      */
 
     public static String getKafkaBridgeVersionFromFile(String releaseFile) throws Exception {


### PR DESCRIPTION
This PR fixes issue with checkstyle being skipped for tests.
That is because of the `[]` in the `checks` field, which says something like "skip every check containing characters from this set". So it skipped really everything, not just those mentioned in the field.