### PR TITLE
Refactored pom structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,33 +39,35 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>17</maven.compiler.release>
-		<log4j.version>2.25.3</log4j.version>
-		<vertx.version>5.0.8</vertx.version>
-		<vertx-testing.version>5.0.8</vertx-testing.version>
-		<netty.version>4.2.10.Final</netty.version>
-		<kafka.version>4.2.0</kafka.version>
-		<kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
-		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
-		<maven.checkstyle.version>3.5.0</maven.checkstyle.version>
-		<checkstyle.version>10.18.1</checkstyle.version>
-		<hamcrest.version>2.2</hamcrest.version>
-		<junit.version>6.0.0</junit.version>
-		<mockito.version>5.21.0</mockito.version>
-		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-		<maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
-		<maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
+
+		<!-- Maven plugin versions -->
 		<maven.compiler.version>3.10.1</maven.compiler.version>
+		<maven.surefire.version>3.5.4</maven.surefire.version>
+		<maven.failsafe.version>3.5.4</maven.failsafe.version>
 		<maven.assembly.version>3.4.2</maven.assembly.version>
 		<maven.javadoc.version>3.10.0</maven.javadoc.version>
 		<maven.source.version>3.2.1</maven.source.version>
 		<maven.dependency.version>3.9.0</maven.dependency.version>
 		<maven.gpg.version>3.0.1</maven.gpg.version>
+		<maven.checkstyle.version>3.5.0</maven.checkstyle.version>
+		<maven.jar.version>3.3.0</maven.jar.version>
 		<central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
-		<openapi.generator.version>7.8.0</openapi.generator.version>
-		<jackson-core.version>2.18.3</jackson-core.version>
-		<jackson-databind.version>2.18.3</jackson-databind.version>
-		<spotbugs.version>4.7.3</spotbugs.version>
 		<maven.spotbugs.version>4.7.3.4</maven.spotbugs.version>
+		<openapi.generator.version>7.8.0</openapi.generator.version>
+
+		<!-- Build tools -->
+		<checkstyle.version>10.18.1</checkstyle.version>
+		<spotbugs.version>4.7.3</spotbugs.version>
+
+		<!-- Runtime dependencies -->
+		<log4j.version>2.25.3</log4j.version>
+		<vertx.version>5.0.8</vertx.version>
+		<netty.version>4.2.10.Final</netty.version>
+		<kafka.version>4.2.0</kafka.version>
+		<kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
+		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
+		<fasterxml.jackson-core.version>2.18.3</fasterxml.jackson-core.version>
+		<fasterxml.jackson-databind.version>2.18.3</fasterxml.jackson-databind.version>
 		<strimzi-oauth.version>0.17.1</strimzi-oauth.version>
 		<strimzi-metrics-reporter.version>0.3.0</strimzi-metrics-reporter.version>
 		<opentelemetry.version>1.34.1</opentelemetry.version>
@@ -77,11 +79,17 @@
 		<jmx-prometheus-collector.version>1.5.0</jmx-prometheus-collector.version>
 		<prometheus.version>1.3.6</prometheus.version>
 		<commons-cli.version>1.4</commons-cli.version>
-        <!-- Update also list of Kafka version in HttpBridgeITAbstract.java together with test-container version! -->
-		<test-container.version>0.114.0</test-container.version>
 		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>2.5</snakeyaml.version>
 		<guava.version>32.1.3-jre</guava.version>
+
+		<!-- Test only dependencies -->
+		<vertx-testing.version>5.0.8</vertx-testing.version>
+		<hamcrest.version>2.2</hamcrest.version>
+		<junit.version>6.0.0</junit.version>
+		<mockito.version>5.21.0</mockito.version>
+		<!-- Update also list of Kafka version in HttpBridgeITAbstract.java together with test-container version! -->
+		<test-container.version>0.114.0</test-container.version>
 		<!-- property to skip surefire tests during failsafe execution -->
 		<!--suppress UnresolvedMavenProperty -->
 		<skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -325,13 +333,13 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>${jackson-core.version}</version>
+			<version>${fasterxml.jackson-core.version}</version>
 		</dependency>
 		<!-- Used only for test in the bridge, but needs to be here because OAuth brings it but a potential Maven bug remove it as runtime if only for test -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson-databind.version}</version>
+			<version>${fasterxml.jackson-databind.version}</version>
 		</dependency>
 		<!--
 			Direct dependency to Guava to bring the jre version in and not the android one
@@ -491,7 +499,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>${maven-surefire-plugin.version}</version>
+				<version>${maven.surefire.version}</version>
 				<configuration>
 					<trimStackTrace>false</trimStackTrace>
 					<skipTests>${skip.surefire.tests}</skipTests>
@@ -500,7 +508,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>${maven-failsafe-plugin.version}</version>
+				<version>${maven.failsafe.version}</version>
 				<executions>
 					<execution>
 						<goals>
@@ -619,7 +627,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>${maven-jar-plugin.version}</version>
+				<version>${maven.jar.version}</version>
 				<configuration>
 					<archive>
 						<manifest>


### PR DESCRIPTION
This trivial PR just refactor the pom to have a similar structure as the one within the strimzi-kafka-operator repository.
It's grouping properties based on their scope and also rename some of them.