### PR TITLE
Use Kafka's Admin instead of AdminClient

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeAdmin.java
+++ b/src/main/java/io/strimzi/kafka/bridge/KafkaBridgeAdmin.java
@@ -6,7 +6,7 @@
 package io.strimzi.kafka.bridge;
 
 import io.strimzi.kafka.bridge.config.KafkaConfig;
-import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -33,7 +33,7 @@ public class KafkaBridgeAdmin {
     private static final Logger LOGGER = LogManager.getLogger(KafkaBridgeAdmin.class);
 
     private final KafkaConfig kafkaConfig;
-    private AdminClient adminClient;
+    private Admin adminClient;
 
     /**
      * Constructor
@@ -53,7 +53,7 @@ public class KafkaBridgeAdmin {
         props.putAll(this.kafkaConfig.getConfig());
         props.putAll(this.kafkaConfig.getAdminConfig().getConfig());
 
-        this.adminClient = AdminClient.create(props);
+        this.adminClient = Admin.create(props);
     }
 
     /**

--- a/src/test/java/io/strimzi/kafka/bridge/facades/AdminClientFacade.java
+++ b/src/test/java/io/strimzi/kafka/bridge/facades/AdminClientFacade.java
@@ -4,7 +4,7 @@
  */
 package io.strimzi.kafka.bridge.facades;
 
-import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
@@ -24,7 +24,7 @@ import java.util.concurrent.ExecutionException;
  */
 public class AdminClientFacade {
     private static final Logger LOGGER = LogManager.getLogger(AdminClientFacade.class);
-    private static AdminClient adminClient;
+    private static Admin adminClient;
     private static AdminClientFacade adminClientFacade;
 
     private AdminClientFacade() {}
@@ -35,7 +35,7 @@ public class AdminClientFacade {
 
             Properties properties = new Properties();
             properties.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
-            adminClient = AdminClient.create(properties);
+            adminClient = Admin.create(properties);
             adminClientFacade = new AdminClientFacade();
         }
         return adminClientFacade;


### PR DESCRIPTION
As per the [AdminClient](https://kafka.apache.org/42/javadoc/org/apache/kafka/clients/admin/AdminClient.html) javadoc:

> Client code should use the newer Admin interface in preference to this class.