### PR TITLE
More Java cleanups

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -191,8 +191,8 @@ public class HttpBridge extends AbstractVerticle {
                 });
     }
 
-    private void startInactiveConsumerDeletionTimer(Long timeout) {
-        Long timeoutInMs = timeout * 1000L;
+    private void startInactiveConsumerDeletionTimer(long timeout) {
+        long timeoutInMs = timeout * 1000L;
         vertx.setPeriodic(timeoutInMs / 2, ignore -> {
             LOGGER.debug("Looking for stale consumers in {} entries", timestampMap.size());
             Iterator<Map.Entry<ConsumerInstanceId, Long>> it = timestampMap.entrySet().iterator();

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
@@ -179,7 +179,7 @@ public class HttpConfig extends AbstractConfig {
      *
      * @return if SSL is enabled
      */
-    public Boolean isSslEnabled() {
+    public boolean isSslEnabled() {
         return Boolean.parseBoolean(this.config.getOrDefault(HTTP_SERVER_SSL_ENABLE, "false").toString());
     }
 

--- a/src/test/java/io/strimzi/kafka/bridge/clients/BasicKafkaClient.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/BasicKafkaClient.java
@@ -4,14 +4,11 @@
  */
 package io.strimzi.kafka.bridge.clients;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.strimzi.kafka.bridge.utils.KafkaJsonSerializer;
 import io.vertx.kafka.client.producer.KafkaHeader;
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.time.Duration;
@@ -52,9 +49,8 @@ public class BasicKafkaClient {
         IntPredicate msgCntPredicate = x -> x == messageCount;
 
         Properties properties = new Properties();
-
-        properties.setProperty("key.serializer", StringSerializer.class.getName());
-        properties.setProperty("value.serializer", StringSerializer.class.getName());
+        properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServer);
         properties.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "producer-sender-plain-");
         properties.setProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name);
@@ -112,8 +108,8 @@ public class BasicKafkaClient {
 
         Properties properties = new Properties();
 
-        properties.setProperty("key.serializer", KafkaJsonSerializer.class.getName());
-        properties.setProperty("value.serializer", KafkaJsonSerializer.class.getName());
+        properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaJsonSerializer.class.getName());
+        properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaJsonSerializer.class.getName());
         properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServer);
         properties.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "producer-sender-plain-" + new Random().nextInt(Integer.MAX_VALUE));
         properties.setProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name);
@@ -187,41 +183,5 @@ public class BasicKafkaClient {
     public int sendJsonMessagesPlain(String topicName, int messageCount, String message, int partition) {
         return sendJsonMessagesPlain(Duration.ofMinutes(2).toMillis(), topicName, messageCount, List.of(),
             message, partition, null, false);
-    }
-
-    /**
-     * Receive messages to entry-point of the kafka cluster with PLAINTEXT security protocol setting
-     *
-     * @param timeoutMs    timeout for the receiving messages
-     * @param topicName    topic name from messages are received
-     * @param messageCount message count
-     * @return received message count
-     */
-    @SuppressWarnings("Regexp") // for the `.toLowerCase()` because kafka needs this property as lower-case
-    @SuppressFBWarnings("DM_CONVERT_CASE")
-    public int receiveStringMessagesPlain(long timeoutMs, String topicName, int messageCount) {
-
-        CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
-        IntPredicate msgCntPredicate = x -> x == messageCount;
-
-        Properties properties = new Properties();
-
-        properties.setProperty("key.serializer", StringDeserializer.class.getName());
-        properties.setProperty("value.serializer", StringDeserializer.class.getName());
-        properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServer);
-        properties.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "consumer-sender-plain-");
-        properties.setProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name);
-        properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "consumer-group" + new Random().nextInt(Integer.MAX_VALUE));
-
-        try (Consumer plainConsumer = new Consumer(properties, resultPromise, msgCntPredicate, topicName)) {
-
-            plainConsumer.getVertx().deployVerticle(plainConsumer);
-
-            return plainConsumer.getResultPromise().get(timeoutMs, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/clients/Consumer.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/Consumer.java
@@ -4,7 +4,6 @@
  */
 package io.strimzi.kafka.bridge.clients;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.Vertx;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -78,13 +77,11 @@ public class Consumer extends ClientHandlerBase<Integer> implements AutoCloseabl
         }
     }
 
-    @SuppressWarnings("Regexp") // for the `.toLowerCase()` because kafka needs this property as lower-case
-    @SuppressFBWarnings("DM_CONVERT_CASE")
     public static Properties fillDefaultProperties() {
         Properties properties = new Properties();
 
-        properties.setProperty("key.deserializer", StringDeserializer.class.getName());
-        properties.setProperty("value.deserializer", StringDeserializer.class.getName());
+        properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         properties.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "consumer-sender-plain-" + new Random().nextInt(Integer.MAX_VALUE));
         properties.setProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name);
         properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/HttpCorsIT.java
@@ -52,7 +52,7 @@ public class HttpCorsIT extends HttpBridgeITAbstract {
 
     @AfterEach
     void afterEach(VertxTestContext context) {
-        if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
+        if (!BRIDGE_EXTERNAL_ENV) {
             vertx.close().onComplete(context.succeeding(arg -> context.completeNow()));
         } else {
             // if we are running an external bridge
@@ -65,7 +65,7 @@ public class HttpCorsIT extends HttpBridgeITAbstract {
         createWebClient();
         configureBridge(false, null);
 
-        if ("FALSE".equalsIgnoreCase(BRIDGE_EXTERNAL_ENV)) {
+        if (!BRIDGE_EXTERNAL_ENV) {
             vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/consumers/1/instances/1/subscription")
                     .putHeader("Origin", "https://evil.io")
@@ -94,7 +94,7 @@ public class HttpCorsIT extends HttpBridgeITAbstract {
         createWebClient();
         configureBridge(true, null);
 
-        if ("FALSE".equalsIgnoreCase(BRIDGE_EXTERNAL_ENV)) {
+        if (!BRIDGE_EXTERNAL_ENV) {
             vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/consumers/1/instances/1/subscription")
                     .putHeader("Origin", "https://evil.io")
@@ -134,7 +134,7 @@ public class HttpCorsIT extends HttpBridgeITAbstract {
 
         final String origin = "https://strimzi.io";
 
-        if ("FALSE".equalsIgnoreCase(BRIDGE_EXTERNAL_ENV)) {
+        if (!BRIDGE_EXTERNAL_ENV) {
             vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/consumers/1/instances/1/subscription")
                     .putHeader("Origin", "https://strimzi.io")
@@ -185,7 +185,7 @@ public class HttpCorsIT extends HttpBridgeITAbstract {
 
         final String origin = "https://strimzi.io";
 
-        if ("FALSE".equalsIgnoreCase(BRIDGE_EXTERNAL_ENV)) {
+        if (!BRIDGE_EXTERNAL_ENV) {
             vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/topics/my-topic")
                     .putHeader("Origin", "https://strimzi.io")
@@ -222,7 +222,7 @@ public class HttpCorsIT extends HttpBridgeITAbstract {
 
         final String origin = "https://strimzi.io";
 
-        if ("FALSE".equalsIgnoreCase(BRIDGE_EXTERNAL_ENV)) {
+        if (!BRIDGE_EXTERNAL_ENV) {
             vertx.deployVerticle(httpBridge).onComplete(context.succeeding(id -> client
                     .request(HttpMethod.OPTIONS, 8080, "localhost", "/consumers/1/instances/1/subscription")
                     .putHeader("Origin", "https://strimzi.io")
@@ -249,7 +249,7 @@ public class HttpCorsIT extends HttpBridgeITAbstract {
     }
 
     private void configureBridge(boolean corsEnabled, String methodsAllowed) {
-        if ("FALSE".equalsIgnoreCase(BRIDGE_EXTERNAL_ENV)) {
+        if (!BRIDGE_EXTERNAL_ENV) {
             config.put(KafkaConfig.KAFKA_CONFIG_PREFIX + ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUri);
             config.put(HttpConfig.HTTP_CORS_ENABLED, String.valueOf(corsEnabled));
             config.put(HttpConfig.HTTP_CORS_ALLOWED_ORIGINS, "https://strimzi.io");

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/HttpBridgeITAbstract.java
@@ -103,8 +103,8 @@ public abstract class HttpBridgeITAbstract implements TestSeparator {
     protected String kafkaVersion;
 
     public static StrimziKafkaCluster kafkaCluster = null;
-    protected static final String BRIDGE_EXTERNAL_ENV = System.getenv().getOrDefault("EXTERNAL_BRIDGE", "FALSE");
-    protected static final String KAFKA_EXTERNAL_ENV = System.getenv().getOrDefault("EXTERNAL_KAFKA", "FALSE");
+    protected static final boolean BRIDGE_EXTERNAL_ENV = Boolean.parseBoolean(System.getenv().get("EXTERNAL_BRIDGE"));
+    protected static final boolean KAFKA_EXTERNAL_ENV = Boolean.parseBoolean(System.getenv().get("EXTERNAL_KAFKA"));
 
     protected static String kafkaUri;
 
@@ -131,7 +131,7 @@ public abstract class HttpBridgeITAbstract implements TestSeparator {
     // kafkaVersion is not used, but it is required as AfterParameterizedClassInvocation requires the injected fields
     @AfterParameterizedClassInvocation
     static void afterAll(String kafkaVersion, VertxTestContext context) {
-        if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
+        if (!BRIDGE_EXTERNAL_ENV) {
             vertx.close().onComplete(context.succeeding(arg -> context.completeNow()));
         } else {
             // if we are running an external bridge
@@ -181,7 +181,7 @@ public abstract class HttpBridgeITAbstract implements TestSeparator {
     }
 
     private void configureDefaults() {
-        kafkaUri = "FALSE".equals(KAFKA_EXTERNAL_ENV)
+        kafkaUri = !KAFKA_EXTERNAL_ENV
             ? kafkaCluster.getBootstrapServers()
             : "localhost:9092";
 
@@ -236,7 +236,7 @@ public abstract class HttpBridgeITAbstract implements TestSeparator {
     // ===== Overridable Hooks =====
 
     protected void setupKafkaCluster(String kafkaVersion) {
-        if ("FALSE".equals(KAFKA_EXTERNAL_ENV)) {
+        if (!KAFKA_EXTERNAL_ENV) {
             StrimziKafkaCluster.StrimziKafkaClusterBuilder builder = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
                 .withNumberOfBrokers(1)
                 .withSharedNetwork();
@@ -254,7 +254,7 @@ public abstract class HttpBridgeITAbstract implements TestSeparator {
     }
 
     protected void deployBridge(VertxTestContext context) {
-        if ("FALSE".equals(BRIDGE_EXTERNAL_ENV)) {
+        if (!BRIDGE_EXTERNAL_ENV) {
             bridgeConfig = BridgeConfig.fromMap(config);
             httpBridge = new HttpBridge(bridgeConfig);
             LOGGER.info("Deploying in-memory bridge");


### PR DESCRIPTION
- Use primitive types were possible
- Use constants for Kafka client configs
- Delete unused method