### PR TITLE
Bumped Vert.x 5.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.1.0
 
+* Dependency updates (Vert.x 5.0.11)
+
 ## 1.0.0
 
 * Use Java 21 as the runtime in the Bridge container (Java 17 continues to be supported)

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
 		<!-- Runtime dependencies -->
 		<log4j.version>2.25.4</log4j.version>
-		<vertx.version>5.0.10</vertx.version>
+		<vertx.version>5.0.11</vertx.version>
 		<netty.version>4.2.12.Final</netty.version>
 		<kafka.version>4.2.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
@@ -84,7 +84,7 @@
 		<guava.version>32.1.3-jre</guava.version>
 
 		<!-- Test only dependencies -->
-		<vertx-testing.version>5.0.10</vertx-testing.version>
+		<vertx-testing.version>5.0.11</vertx-testing.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<junit.version>6.0.0</junit.version>
 		<mockito.version>5.21.0</mockito.version>


### PR DESCRIPTION
Trivial PR to bump Vert.x. The Netty version stays the same within Vert.x.