### PR TITLE
Added AI assistant Bob folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ documentation/html/**
 documentation/htmlnoheader/**
 documentation/book/build/**
 
-# Claude configuration
+# AI assistants configuration
 .claude/
 .mcp.json
+.bob/


### PR DESCRIPTION
Trivial PR to have the `./bob` folder being ignored by Git.
As Claude Code from Anthropic (and we are already ignoring `./claude` folder right now), Bob is an AI code assistant by IBM.