### PR TITLE
Refactor `InvalidProducerIT`, `OtherServicesIT`, and `TlsIT` with changes to BridgeExtension due to TLS Bridge

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/extensions/BridgeExtension.java
+++ b/src/test/java/io/strimzi/kafka/bridge/extensions/BridgeExtension.java
@@ -10,7 +10,9 @@ import io.strimzi.kafka.bridge.configuration.BridgeConfiguration;
 import io.strimzi.kafka.bridge.configuration.ConfigEntry;
 import io.strimzi.kafka.bridge.enums.BridgeRunMode;
 import io.strimzi.kafka.bridge.http.HttpBridge;
+import io.strimzi.kafka.bridge.http.HttpConfig;
 import io.strimzi.kafka.bridge.httpclient.HttpService;
+import io.strimzi.kafka.bridge.utils.Urls;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.micrometer.Label;
@@ -61,6 +63,9 @@ public class BridgeExtension implements
     private static final String BRIDGE_CONTAINER_KEY = "bridgeContainer";
     private static final String BRIDGE_BINARY_KEY = "bridgeBinary";
     private static final String HTTP_SERVICE_KEY = "httpService";
+    private static final String BRIDGE_HOST_KEY = "bridgeHost";
+    private static final String BRIDGE_PORT_KEY = "bridgePort";
+    private static final String BRIDGE_MANAGEMENT_PORT_KEY = "bridgeManagementPort";
 
     private static final BridgeRunMode BRIDGE_RUN_MODE_ENV = BridgeRunMode.fromString(System.getenv().getOrDefault("BRIDGE_RUN_MODE", BridgeRunMode.IN_MEMORY.name()));
     private static final String DEFAULT_BRIDGE_IMAGE = "quay.io/strimzi/kafka-bridge:latest";
@@ -274,10 +279,16 @@ public class BridgeExtension implements
                 }
             }).await();
 
-        HttpService httpService = new HttpService("127.0.0.1", 8080);
+        boolean sslEnabled = "true".equals(String.valueOf(configuration.get(HttpConfig.HTTP_SERVER_SSL_ENABLE)));
+        int bridgePort = sslEnabled ? Urls.BRIDGE_SSL_PORT : Urls.BRIDGE_PORT;
+
+        HttpService httpService = sslEnabled ? null : new HttpService(Urls.BRIDGE_HOST, bridgePort);
 
         getStore(extensionContext).put(BRIDGE_BINARY_KEY, vertx);
         getStore(extensionContext).put(HTTP_SERVICE_KEY, httpService);
+        getStore(extensionContext).put(BRIDGE_HOST_KEY, Urls.BRIDGE_HOST);
+        getStore(extensionContext).put(BRIDGE_PORT_KEY, bridgePort);
+        getStore(extensionContext).put(BRIDGE_MANAGEMENT_PORT_KEY, Urls.BRIDGE_MANAGEMENT_PORT);
     }
 
     /**
@@ -293,6 +304,9 @@ public class BridgeExtension implements
         properties.putAll(configuration);
         String propertiesPath = createPropertiesFile(properties);
 
+        boolean sslEnabled = "true".equals(String.valueOf(configuration.get(HttpConfig.HTTP_SERVER_SSL_ENABLE)));
+        int httpPort = sslEnabled ? Urls.BRIDGE_SSL_PORT : Urls.BRIDGE_PORT;
+
         LOGGER.info("Deploying Bridge in container");
 
         GenericContainer<?> bridgeContainer = new GenericContainer<>(BRIDGE_IMAGE_ENV)
@@ -301,19 +315,24 @@ public class BridgeExtension implements
                 "/opt/strimzi/application.properties"
             )
             .withCommand("/opt/strimzi/bin/kafka_bridge_run.sh", "--config-file=/opt/strimzi/application.properties")
-            .withExposedPorts(8080, 8081)
+            .withExposedPorts(httpPort, Urls.BRIDGE_MANAGEMENT_PORT)
             .withNetwork(Network.SHARED)
-            .waitingFor(new WaitAllStrategy()
-                .withStrategy(Wait.forHttp("/").forPort(8080))
-                .withStrategy(Wait.forHttp("/healthy").forPort(8081))
+            .waitingFor(sslEnabled ?
+                Wait.forHttp("/healthy").forPort(Urls.BRIDGE_MANAGEMENT_PORT) :
+                new WaitAllStrategy()
+                    .withStrategy(Wait.forHttp("/").forPort(httpPort))
+                    .withStrategy(Wait.forHttp("/healthy").forPort(Urls.BRIDGE_MANAGEMENT_PORT))
             );
 
         bridgeContainer.start();
 
-        HttpService httpService = new HttpService(bridgeContainer.getHost(), bridgeContainer.getMappedPort(8080));
+        HttpService httpService = sslEnabled ? null : new HttpService(bridgeContainer.getHost(), bridgeContainer.getMappedPort(httpPort));
 
         getStore(extensionContext).put(BRIDGE_CONTAINER_KEY, bridgeContainer);
         getStore(extensionContext).put(HTTP_SERVICE_KEY, httpService);
+        getStore(extensionContext).put(BRIDGE_HOST_KEY, bridgeContainer.getHost());
+        getStore(extensionContext).put(BRIDGE_PORT_KEY, bridgeContainer.getMappedPort(httpPort));
+        getStore(extensionContext).put(BRIDGE_MANAGEMENT_PORT_KEY, bridgeContainer.getMappedPort(Urls.BRIDGE_MANAGEMENT_PORT));
     }
 
     /**
@@ -381,6 +400,39 @@ public class BridgeExtension implements
      */
     public static HttpService getHttpService(ExtensionContext extensionContext) {
         return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(HTTP_SERVICE_KEY, HttpService.class);
+    }
+
+    /**
+     * Returns the bridge host from the extension context's store.
+     *
+     * @param extensionContext  context of the test.
+     *
+     * @return  the bridge host.
+     */
+    public static String getBridgeHost(ExtensionContext extensionContext) {
+        return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(BRIDGE_HOST_KEY, String.class);
+    }
+
+    /**
+     * Returns the bridge main port (HTTP or HTTPS) from the extension context's store.
+     *
+     * @param extensionContext  context of the test.
+     *
+     * @return  the bridge main port.
+     */
+    public static int getBridgePort(ExtensionContext extensionContext) {
+        return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(BRIDGE_PORT_KEY, Integer.class);
+    }
+
+    /**
+     * Returns the bridge management port from the extension context's store.
+     *
+     * @param extensionContext  context of the test.
+     *
+     * @return  the bridge management port.
+     */
+    public static int getBridgeManagementPort(ExtensionContext extensionContext) {
+        return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(BRIDGE_MANAGEMENT_PORT_KEY, Integer.class);
     }
 
     /**

--- a/src/test/java/io/strimzi/kafka/bridge/extensions/BridgeExtension.java
+++ b/src/test/java/io/strimzi/kafka/bridge/extensions/BridgeExtension.java
@@ -279,7 +279,7 @@ public class BridgeExtension implements
                 }
             }).await();
 
-        boolean sslEnabled = "true".equals(String.valueOf(configuration.get(HttpConfig.HTTP_SERVER_SSL_ENABLE)));
+        boolean sslEnabled = Boolean.parseBoolean(String.valueOf(configuration.get(HttpConfig.HTTP_SERVER_SSL_ENABLE)));
         int bridgePort = sslEnabled ? Urls.BRIDGE_SSL_PORT : Urls.BRIDGE_PORT;
 
         HttpService httpService = sslEnabled ? null : new HttpService(Urls.BRIDGE_HOST, bridgePort);
@@ -304,7 +304,7 @@ public class BridgeExtension implements
         properties.putAll(configuration);
         String propertiesPath = createPropertiesFile(properties);
 
-        boolean sslEnabled = "true".equals(String.valueOf(configuration.get(HttpConfig.HTTP_SERVER_SSL_ENABLE)));
+        boolean sslEnabled = Boolean.parseBoolean(String.valueOf(configuration.get(HttpConfig.HTTP_SERVER_SSL_ENABLE)));
         int httpPort = sslEnabled ? Urls.BRIDGE_SSL_PORT : Urls.BRIDGE_PORT;
 
         LOGGER.info("Deploying Bridge in container");

--- a/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/InvalidProducerIT.java
@@ -4,53 +4,47 @@
  */
 package io.strimzi.kafka.bridge.http;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.junit5.VertxTestContext;
-import org.apache.kafka.common.KafkaFuture;
+import io.strimzi.kafka.bridge.config.KafkaProducerConfig;
+import io.strimzi.kafka.bridge.configuration.BridgeConfiguration;
+import io.strimzi.kafka.bridge.configuration.ConfigEntry;
+import io.strimzi.kafka.bridge.extensions.BridgeSuite;
+import io.strimzi.kafka.bridge.http.base.AbstractIT;
+import io.strimzi.kafka.bridge.httpclient.HttpProducerService;
+import io.strimzi.kafka.bridge.objects.BridgeTestContext;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
+import java.net.http.HttpResponse;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class InvalidProducerIT extends HttpBridgeITAbstract {
-
-    @Override
-    protected Map<String, Object> overrideConfig() {
-        Map<String, Object> cfg = new HashMap<>();
-        cfg.put("kafka.producer.acks", "5"); // invalid config
-        return cfg;
+@BridgeSuite
+@BridgeConfiguration(
+    additionalProperties = {
+        @ConfigEntry(key = KafkaProducerConfig.KAFKA_PRODUCER_CONFIG_PREFIX + "acks", value = "5")
     }
+)
+public class InvalidProducerIT extends AbstractIT {
 
     @Test
-    void sendSimpleMessage(VertxTestContext context) throws InterruptedException, ExecutionException {
-        KafkaFuture<Void> future = adminClientFacade.createTopic(topic);
+    void sendSimpleMessage(BridgeTestContext bridgeTestContext) {
+        HttpProducerService httpProducerService = new HttpProducerService(bridgeTestContext.getHttpService());
 
-        String value = "message-value";
+        createTopic(bridgeTestContext, 1);
 
-        JsonArray records = new JsonArray();
-        JsonObject json = new JsonObject();
-        json.put("value", value);
-        records.add(json);
+        Map<String, Object> records = Map.of(
+            "records", List.of(
+                Map.of("value", "message-value")
+            )
+        );
 
-        JsonObject root = new JsonObject();
-        root.put("records", records);
+        HttpResponse<String> httpResponse = httpProducerService.sendJsonRecordsRequest(
+            bridgeTestContext.getTopicName(), records, BridgeContentType.KAFKA_JSON_JSON);
 
-        future.get();
-
-        producerService()
-                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                .sendJsonObject(root)
-                .onComplete(ar -> {
-                    assertThat(ar.succeeded(), is(true));
-                    assertThat(ar.result().statusCode(), is(500));
-                    context.completeNow();
-                });
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()));
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
@@ -5,248 +5,219 @@
 package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
+import io.strimzi.kafka.bridge.extensions.BridgeSuite;
+import io.strimzi.kafka.bridge.http.base.AbstractIT;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.codec.BodyCodec;
-import io.vertx.junit5.VertxTestContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import io.strimzi.kafka.bridge.httpclient.HttpResponseUtils;
+import io.strimzi.kafka.bridge.httpclient.HttpService;
+import io.strimzi.kafka.bridge.objects.BridgeTestContext;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class OtherServicesIT extends HttpBridgeITAbstract {
-    private static final Logger LOGGER = LogManager.getLogger(OtherServicesIT.class);
+@BridgeSuite
+public class OtherServicesIT extends AbstractIT {
 
     @Test
-    void readyTest(VertxTestContext context) throws InterruptedException {
+    void readyTest(BridgeTestContext bridgeTestContext) throws InterruptedException {
+        HttpService managementService = new HttpService(bridgeTestContext.getBridgeHost(), bridgeTestContext.getBridgeManagementPort());
+
         int iterations = 5;
-        for (int i = 1; i <= iterations; i++) {
-            int l = i;
-            internalBaseService()
-                    .getRequest("/ready")
-                    .send()
-                    .onComplete(ar -> {
-                        context.verify(() -> {
-                            assertThat(ar.succeeded(), is(true));
-                            assertThat(ar.result().statusCode(), is(HttpResponseStatus.OK.code()));
-                        });
-                        if (l == iterations) {
-                            context.completeNow();
-                        }
-                    });
+        for (int i = 0; i < iterations; i++) {
+            HttpResponse<String> httpResponse = managementService.get("/ready");
+            assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
             Thread.sleep(1000);
         }
     }
 
     @Test
-    void healthyTest(VertxTestContext context) throws InterruptedException {
+    void healthyTest(BridgeTestContext bridgeTestContext) throws InterruptedException {
+        HttpService managementService = new HttpService(bridgeTestContext.getBridgeHost(), bridgeTestContext.getBridgeManagementPort());
+
         int iterations = 5;
-        for (int i = 1; i <= iterations; i++) {
-            int l = i;
-            internalBaseService()
-                    .getRequest("/healthy")
-                    .send()
-                    .onComplete(ar -> {
-                        context.verify(() -> {
-                            LOGGER.info("Verifying that endpoint /healthy is ready {} for  {} time with status code {}",
-                                    ar.succeeded(), l, ar.result().statusCode());
-                            assertThat(ar.succeeded(), is(true));
-                            assertThat(ar.result().statusCode(), is(HttpResponseStatus.OK.code()));
-                        });
-                        if (l == iterations) {
-                            LOGGER.info("Successfully completing the context");
-                            context.completeNow();
-                        }
-                    });
+        for (int i = 0; i < iterations; i++) {
+            HttpResponse<String> httpResponse = managementService.get("/healthy");
+            assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
             Thread.sleep(1000);
         }
     }
 
     @Test
-    void openapiv3Test(VertxTestContext context) {
-        baseService()
-                .getRequest("/openapi/v3")
-                .as(BodyCodec.jsonObject())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
-                        JsonObject bridgeResponse = response.body();
+    void openapiv3Test(BridgeTestContext bridgeTestContext) {
+        HttpResponse<String> httpResponse = bridgeTestContext.getHttpService().get("/openapi/v3");
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
 
-                        String version = bridgeResponse.getString("openapi");
-                        assertThat(version, is("3.1.0"));
-                    });
-                    context.completeNow();
-                });
+        Map<String, Object> responseBody = HttpResponseUtils.getResponseAsMap(httpResponse.body());
+        assertThat(responseBody.get("openapi"), is("3.1.0"));
     }
 
     @Test
-    void openapiTest(VertxTestContext context) {
-        baseService()
-                .getRequest("/openapi")
-                .as(BodyCodec.jsonObject())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
-                        JsonObject bridgeResponse = response.body();
+    void openapiTest(BridgeTestContext bridgeTestContext) {
+        HttpResponse<String> httpResponse = bridgeTestContext.getHttpService().get("/openapi");
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
 
-                        String version = bridgeResponse.getString("openapi");
-                        assertThat(version, is("3.1.0"));
+        Map<String, Object> responseBody = HttpResponseUtils.getResponseAsMap(httpResponse.body());
 
-                        Map<String, Object> paths = bridgeResponse.getJsonObject("paths").getMap();
-                        // subscribe, list subscriptions and unsubscribe are using the same endpoint but different methods (-2)
-                        // getTopic and send are using the same endpoint but different methods (-1)
-                        // getPartition and sendToPartition are using the same endpoint but different methods (-1)
-                        int pathsSize = HttpOpenApiOperations.values().length - 4;
-                        assertThat(paths.size(), is(pathsSize));
-                        assertThat(paths.containsKey("/consumers/{groupid}"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.CREATE_CONSUMER.toString()));
-                        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/positions"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/positions").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SEEK.toString()));
-                        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/positions/beginning"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/positions/beginning").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SEEK_TO_BEGINNING.toString()));
-                        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/positions/end"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/positions/end").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SEEK_TO_END.toString()));
-                        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/subscription"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/subscription").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SUBSCRIBE.toString()));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/subscription").getJsonObject("delete").getString("operationId"), is(HttpOpenApiOperations.UNSUBSCRIBE.toString()));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/subscription").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.LIST_SUBSCRIPTIONS.toString()));
-                        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/assignments"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/assignments").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.ASSIGN.toString()));
-                        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/records"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/records").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.POLL.toString()));
-                        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/offsets"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/consumers/{groupid}/instances/{name}/offsets").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.COMMIT.toString()));
-                        assertThat(paths.containsKey("/topics"), is(true));
-                        assertThat(paths.containsKey("/topics/{topicname}"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/topics/{topicname}").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SEND.toString()));
-                        assertThat(paths.containsKey("/topics/{topicname}/partitions/{partitionid}"), is(true));
-                        assertThat(paths.containsKey("/topics/{topicname}/partitions/{partitionid}/offsets"), is(true));
-                        assertThat(paths.containsKey("/topics/{topicname}/partitions"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/topics/{topicname}/partitions/{partitionid}").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.SEND_TO_PARTITION.toString()));
-                        assertThat(paths.containsKey("/admin/topics"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/admin/topics").getJsonObject("post").getString("operationId"), is(HttpOpenApiOperations.CREATE_TOPIC.toString()));
-                        assertThat(paths.containsKey("/healthy"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/healthy").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.HEALTHY.toString()));
-                        assertThat(paths.containsKey("/ready"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/ready").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.READY.toString()));
-                        assertThat(paths.containsKey("/openapi"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/openapi").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.OPENAPI.toString()));
-                        assertThat(paths.containsKey("/"), is(true));
-                        assertThat(bridgeResponse.getJsonObject("paths").getJsonObject("/").getJsonObject("get").getString("operationId"), is(HttpOpenApiOperations.INFO.toString()));
-                        assertThat(paths.containsKey("/karel"), is(false));
-                        assertThat(bridgeResponse.getJsonObject("components").getJsonObject("schemas").getMap().size(), is(28));
-                        assertThat(bridgeResponse.getJsonArray("tags").size(), is(4));
-                    });
-                    context.completeNow();
-                });
+        assertThat(responseBody.get("openapi"), is("3.1.0"));
+
+        Map<String, Object> paths = (Map<String, Object>) responseBody.get("paths");
+        // subscribe, list subscriptions and unsubscribe are using the same endpoint but different methods (-2)
+        // getTopic and send are using the same endpoint but different methods (-1)
+        // getPartition and sendToPartition are using the same endpoint but different methods (-1)
+        int pathsSize = HttpOpenApiOperations.values().length - 4;
+        assertThat(paths.size(), is(pathsSize));
+
+        assertThat(paths.containsKey("/consumers/{groupid}"), is(true));
+        assertThat(getOperationId(paths, "/consumers/{groupid}", "post"), is(HttpOpenApiOperations.CREATE_CONSUMER.toString()));
+
+        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/positions"), is(true));
+        assertThat(getOperationId(paths, "/consumers/{groupid}/instances/{name}/positions", "post"), is(HttpOpenApiOperations.SEEK.toString()));
+
+        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/positions/beginning"), is(true));
+        assertThat(getOperationId(paths, "/consumers/{groupid}/instances/{name}/positions/beginning", "post"), is(HttpOpenApiOperations.SEEK_TO_BEGINNING.toString()));
+
+        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/positions/end"), is(true));
+        assertThat(getOperationId(paths, "/consumers/{groupid}/instances/{name}/positions/end", "post"), is(HttpOpenApiOperations.SEEK_TO_END.toString()));
+
+        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/subscription"), is(true));
+        assertThat(getOperationId(paths, "/consumers/{groupid}/instances/{name}/subscription", "post"), is(HttpOpenApiOperations.SUBSCRIBE.toString()));
+        assertThat(getOperationId(paths, "/consumers/{groupid}/instances/{name}/subscription", "delete"), is(HttpOpenApiOperations.UNSUBSCRIBE.toString()));
+        assertThat(getOperationId(paths, "/consumers/{groupid}/instances/{name}/subscription", "get"), is(HttpOpenApiOperations.LIST_SUBSCRIPTIONS.toString()));
+
+        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/assignments"), is(true));
+        assertThat(getOperationId(paths, "/consumers/{groupid}/instances/{name}/assignments", "post"), is(HttpOpenApiOperations.ASSIGN.toString()));
+
+        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/records"), is(true));
+        assertThat(getOperationId(paths, "/consumers/{groupid}/instances/{name}/records", "get"), is(HttpOpenApiOperations.POLL.toString()));
+
+        assertThat(paths.containsKey("/consumers/{groupid}/instances/{name}/offsets"), is(true));
+        assertThat(getOperationId(paths, "/consumers/{groupid}/instances/{name}/offsets", "post"), is(HttpOpenApiOperations.COMMIT.toString()));
+
+        assertThat(paths.containsKey("/topics"), is(true));
+        assertThat(paths.containsKey("/topics/{topicname}"), is(true));
+        assertThat(getOperationId(paths, "/topics/{topicname}", "post"), is(HttpOpenApiOperations.SEND.toString()));
+
+        assertThat(paths.containsKey("/topics/{topicname}/partitions/{partitionid}"), is(true));
+        assertThat(paths.containsKey("/topics/{topicname}/partitions/{partitionid}/offsets"), is(true));
+        assertThat(paths.containsKey("/topics/{topicname}/partitions"), is(true));
+        assertThat(getOperationId(paths, "/topics/{topicname}/partitions/{partitionid}", "post"), is(HttpOpenApiOperations.SEND_TO_PARTITION.toString()));
+
+        assertThat(paths.containsKey("/admin/topics"), is(true));
+        assertThat(getOperationId(paths, "/admin/topics", "post"), is(HttpOpenApiOperations.CREATE_TOPIC.toString()));
+
+        assertThat(paths.containsKey("/healthy"), is(true));
+        assertThat(getOperationId(paths, "/healthy", "get"), is(HttpOpenApiOperations.HEALTHY.toString()));
+
+        assertThat(paths.containsKey("/ready"), is(true));
+        assertThat(getOperationId(paths, "/ready", "get"), is(HttpOpenApiOperations.READY.toString()));
+
+        assertThat(paths.containsKey("/openapi"), is(true));
+        assertThat(getOperationId(paths, "/openapi", "get"), is(HttpOpenApiOperations.OPENAPI.toString()));
+
+        assertThat(paths.containsKey("/"), is(true));
+        assertThat(getOperationId(paths, "/", "get"), is(HttpOpenApiOperations.INFO.toString()));
+
+        assertThat(paths.containsKey("/karel"), is(false));
+
+        Map<String, Object> components = (Map<String, Object>) responseBody.get("components");
+        Map<String, Object> schemas = (Map<String, Object>) components.get("schemas");
+        assertThat(schemas.size(), is(28));
+
+        Object[] tags = (Object[]) responseBody.get("tags");
+        assertThat(tags.length, is(4));
     }
 
     @Test
-    void postToNonexistentEndpoint(VertxTestContext context) {
-        baseService()
-                .postRequest("/not-existing-endpoint")
-                .as(BodyCodec.jsonObject())
-                .sendJsonObject(null)
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-                        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
-                    });
-                    context.completeNow();
-                });
+    void postToNonexistentEndpoint(BridgeTestContext bridgeTestContext) {
+        HttpResponse<String> httpResponse = bridgeTestContext.getHttpService().post("/not-existing-endpoint", "");
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
+
+        HttpBridgeError error = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsMap(httpResponse.body()));
+        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
     }
 
     @Test
-    void getVersion(VertxTestContext context) {
-        baseService()
-                .getRequest("/")
-                .as(BodyCodec.jsonObject())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        assertThat(response.body().getString("bridge_version"), is(notNullValue()));
-                    });
-                    context.completeNow();
-                });
+    void getVersion(BridgeTestContext bridgeTestContext) {
+        HttpResponse<String> httpResponse = bridgeTestContext.getHttpService().get("/");
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
+
+        Map<String, Object> responseBody = HttpResponseUtils.getResponseAsMap(httpResponse.body());
+        assertThat(responseBody.get("bridge_version"), is(notNullValue()));
     }
 
     @Test
-    void openApiTestWithForwardedPath(VertxTestContext context) {
+    void openApiTestWithForwardedPath(BridgeTestContext bridgeTestContext) throws Exception {
         String forwardedPath = "/app/kafka-bridge";
-        baseService()
-                .getRequest("/openapi")
-                .putHeader("x-Forwarded-Path", forwardedPath)
-                .as(BodyCodec.jsonObject())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
-                        JsonObject bridgeResponse = response.body();
-                        assertThat(bridgeResponse.getString("basePath"), is(forwardedPath));
-                    });
-                    context.completeNow();
-                });
+
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+            .uri(new URI(bridgeTestContext.getHttpService().getUri("/openapi")))
+            .version(HttpClient.Version.HTTP_1_1)
+            .GET()
+            .header("x-Forwarded-Path", forwardedPath)
+            .build();
+
+        HttpResponse<String> httpResponse = bridgeTestContext.getHttpService().getClient()
+            .send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
+
+        Map<String, Object> responseBody = HttpResponseUtils.getResponseAsMap(httpResponse.body());
+        assertThat(responseBody.get("basePath"), is(forwardedPath));
     }
 
     @Test
-    void openApiTestWithForwardedPrefix(VertxTestContext context) {
+    void openApiTestWithForwardedPrefix(BridgeTestContext bridgeTestContext) throws Exception {
         String forwardedPrefix = "/app/kafka-bridge";
-        baseService()
-                .getRequest("/openapi")
-                .putHeader("x-Forwarded-Prefix", forwardedPrefix)
-                .as(BodyCodec.jsonObject())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
-                        JsonObject bridgeResponse = response.body();
-                        assertThat(bridgeResponse.getString("basePath"), is(forwardedPrefix));
-                    });
-                    context.completeNow();
-                });
+
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+            .uri(new URI(bridgeTestContext.getHttpService().getUri("/openapi")))
+            .version(HttpClient.Version.HTTP_1_1)
+            .GET()
+            .header("x-Forwarded-Prefix", forwardedPrefix)
+            .build();
+
+        HttpResponse<String> httpResponse = bridgeTestContext.getHttpService().getClient()
+            .send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
+
+        Map<String, Object> responseBody = HttpResponseUtils.getResponseAsMap(httpResponse.body());
+        assertThat(responseBody.get("basePath"), is(forwardedPrefix));
     }
 
     @Test
-    void openApiTestWithForwardedPathAndPrefix(VertxTestContext context) {
+    void openApiTestWithForwardedPathAndPrefix(BridgeTestContext bridgeTestContext) throws Exception {
         String forwardedPath = "/app/kafka-bridge-path";
         String forwardedPrefix = "/app/kafka-bridge-prefix";
-        baseService()
-                .getRequest("/openapi")
-                .putHeader("x-Forwarded-Path", forwardedPath)
-                .putHeader("x-Forwarded-Prefix", forwardedPrefix)
-                .as(BodyCodec.jsonObject())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
-                        JsonObject bridgeResponse = response.body();
-                        assertThat(bridgeResponse.getString("basePath"), is(forwardedPath));
-                    });
-                    context.completeNow();
-                });
+
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+            .uri(new URI(bridgeTestContext.getHttpService().getUri("/openapi")))
+            .version(HttpClient.Version.HTTP_1_1)
+            .GET()
+            .header("x-Forwarded-Path", forwardedPath)
+            .header("x-Forwarded-Prefix", forwardedPrefix)
+            .build();
+
+        HttpResponse<String> httpResponse = bridgeTestContext.getHttpService().getClient()
+            .send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
+
+        Map<String, Object> responseBody = HttpResponseUtils.getResponseAsMap(httpResponse.body());
+        assertThat(responseBody.get("basePath"), is(forwardedPath));
+    }
+
+    private String getOperationId(Map<String, Object> paths, String path, String method) {
+        Map<String, Object> pathObj = (Map<String, Object>) paths.get(path);
+        Map<String, Object> methodObj = (Map<String, Object>) pathObj.get(method);
+        return (String) methodObj.get("operationId");
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/http/TlsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/TlsIT.java
@@ -6,128 +6,139 @@
 package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
-import io.strimzi.kafka.bridge.utils.Urls;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.net.PemTrustOptions;
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
+import io.strimzi.kafka.bridge.configuration.BridgeConfiguration;
+import io.strimzi.kafka.bridge.configuration.ConfigEntry;
+import io.strimzi.kafka.bridge.extensions.BridgeSuite;
+import io.strimzi.kafka.bridge.http.base.AbstractIT;
+import io.strimzi.kafka.bridge.httpclient.HttpService;
+import io.strimzi.kafka.bridge.objects.BridgeTestContext;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.HashMap;
-import java.util.Map;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@ExtendWith(VertxExtension.class)
-public class TlsIT extends HttpBridgeITAbstract {
+@BridgeSuite
+@BridgeConfiguration(
+    additionalProperties = {
+        @ConfigEntry(key = HttpConfig.HTTP_SERVER_SSL_ENABLE, value = "true"),
+        @ConfigEntry(key = HttpConfig.HTTP_SERVER_SSL_CERTIFICATE, value = TlsIT.SSL_CERT),
+        @ConfigEntry(key = HttpConfig.HTTP_SERVER_SSL_KEY, value = TlsIT.SSL_KEY)
+    }
+)
+public class TlsIT extends AbstractIT {
 
-    // self-signed cert with 100 years validity
-    private static final String SSL_CERT = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIDczCCAlugAwIBAgIUHt1AoJ7RM/GO5SrrmDXkdO5TJQowDQYJKoZIhvcNAQEL\n" +
+    // self-signed cert with 100 years validity, SANs: DNS:localhost, IP:127.0.0.1
+    static final String SSL_CERT = "-----BEGIN CERTIFICATE-----\n" +
+            "MIIDjzCCAnegAwIBAgIUB7HBN7iKDBEw7e7nwJkit/6mLf8wDQYJKoZIhvcNAQEL\n" +
             "BQAwSDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxEDAOBgNVBAoM\n" +
-            "B1N0cmltemkxEjAQBgNVBAMMCWxvY2FsaG9zdDAgFw0yNTEwMDYxMTA1NDdaGA8y\n" +
-            "MTI1MTAwNzExMDU0N1owSDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3Rh\n" +
+            "B1N0cmltemkxEjAQBgNVBAMMCWxvY2FsaG9zdDAgFw0yNjA1MTMxMDMzMzNaGA8y\n" +
+            "MTI2MDQxOTEwMzMzM1owSDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3Rh\n" +
             "dGUxEDAOBgNVBAoMB1N0cmltemkxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJ\n" +
-            "KoZIhvcNAQEBBQADggEPADCCAQoCggEBAN/CUTo/i1NLITtFYx0dmkXV+zzgqIpC\n" +
-            "MUhAZry753xO2bs1aZHLkosrtocdwnPLRhHJMjC3xfZy1P0pcykdhQnfG/d5flZ6\n" +
-            "tvF8TIOUd+N/4alQC+Jp7YCry7fpNrTROL0e1VanysOEUnSabvcSUr/Ccrqv0L1N\n" +
-            "ibuhLgUlDYNpIr8U1M7eL/ATzijXBJLGJ/ozUx4jVBDZOW3vVYzp1h/uW0E6D0cg\n" +
-            "tjnp/d0elyE+2x/RjElYbfxCFEcJv4gjVDmbNf6ICN3w2G6thWTXagvpPlk5pKY/\n" +
-            "xHl37FzlsoSVt1go9U+6KP3/WKlKbGgurjbSJ8GGZoXOICVQA7DM0icCAwEAAaNT\n" +
-            "MFEwHQYDVR0OBBYEFHsEM5yMsAqZ3gj95yHIyC/bTQvRMB8GA1UdIwQYMBaAFHsE\n" +
-            "M5yMsAqZ3gj95yHIyC/bTQvRMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL\n" +
-            "BQADggEBAHaWcTRppYds2sQNEL3mXRgQOImjdzBgSf0/akQBPQB53L06IC2AKjHl\n" +
-            "chrnnXj0FdLAlOokpPAgEULSugSL5uVEmcg/7A8hP+Tf1YfOTHnY5iv121r3+5yr\n" +
-            "2t8A99tFOLF+S0gH3b4o4ZKh+IFg4QocqVQeDLgJUgS40fIzfdeHcdbrekvBAjRE\n" +
-            "sOerVSW9iO4qI+T+tPa5lUHxIksZbeNx8YygvXq1SKt1KWIiHAhJejJY1bkkKhiU\n" +
-            "RXKs0cKn3pSYR3ClzclxxYVwYqBHajgPGgj5Jp//lGXwCPYXsByaFKnXloMby+D9\n" +
-            "ouquxThA4toTNTI++ISUAh2/8X4IsU8=\n" +
+            "KoZIhvcNAQEBBQADggEPADCCAQoCggEBAMLN26vhcgtjwNmyfSyyp93FzbL/HeQa\n" +
+            "6LtdG5393Lu99pHjFXdRFR9ao6gY3LTrPQcxIaol46jD75u0EILn/CECxNHLwWY/\n" +
+            "npVSdMneId3zcQLwwL5LxCHLTtS3hbGi1uptylXr7Yw429C+W2ySHtpFav6kfrpW\n" +
+            "Omu91Z27x9CqvV3DIlv9UPwvcJGVjNGvnVrSbm6nhei0NDe1IMbuSsI4mgXtTlIa\n" +
+            "ajeJ88r6GhbeFTTNoOXcrvsdv/UJLDaQrLQGZLCDLw2HY0FjgurfsswLN11nWmyD\n" +
+            "3HJq5L1bsjGLU6Ku10XEJz2XK4DNYCMzXNi60Zy69J/K6PL99Ntq8+kCAwEAAaNv\n" +
+            "MG0wHQYDVR0OBBYEFJG6JUX2OLhbXJGwZfB4hlendT4KMB8GA1UdIwQYMBaAFJG6\n" +
+            "JUX2OLhbXJGwZfB4hlendT4KMA8GA1UdEwEB/wQFMAMBAf8wGgYDVR0RBBMwEYIJ\n" +
+            "bG9jYWxob3N0hwR/AAABMA0GCSqGSIb3DQEBCwUAA4IBAQBgkLIraAAyUtiLTe3y\n" +
+            "MJgarhGXf+Lgl/gedhML/CTTLcvzilICf9SKoUW28D6NLrT18taNp3FJ4fukbC5N\n" +
+            "hVfsPWa4Boqe2jJDMCg/9Mve1xpTPhbnwxd+N4kZHBTA4mz64W8djq72o/kcTE8S\n" +
+            "T/in0pAPvjPLJnsc3QL1sYQ2lH7Cv+37Xu0A+YbH4N9Jg6NG2wdlDXb02RjN448Y\n" +
+            "dq0UjEHt0TJikJ9soQRhKBdY/n9NWnibG6Ge6I0HEPyUfLUbdlK0ZReDG49ZFDZ9\n" +
+            "Lx8yroxJg2Tlg/Fejpcm+BTvrYaxABU5zlU66JGXccqTamUg0OtkRr8gj+ybjgIh\n" +
+            "bpUK\n" +
             "-----END CERTIFICATE-----";
 
-    private static final String SSL_KEY = "-----BEGIN PRIVATE KEY-----\n" +
-            "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDfwlE6P4tTSyE7\n" +
-            "RWMdHZpF1fs84KiKQjFIQGa8u+d8Ttm7NWmRy5KLK7aHHcJzy0YRyTIwt8X2ctT9\n" +
-            "KXMpHYUJ3xv3eX5WerbxfEyDlHfjf+GpUAviae2Aq8u36Ta00Ti9HtVWp8rDhFJ0\n" +
-            "mm73ElK/wnK6r9C9TYm7oS4FJQ2DaSK/FNTO3i/wE84o1wSSxif6M1MeI1QQ2Tlt\n" +
-            "71WM6dYf7ltBOg9HILY56f3dHpchPtsf0YxJWG38QhRHCb+II1Q5mzX+iAjd8Nhu\n" +
-            "rYVk12oL6T5ZOaSmP8R5d+xc5bKElbdYKPVPuij9/1ipSmxoLq420ifBhmaFziAl\n" +
-            "UAOwzNInAgMBAAECggEAHLvSJ3s309iO1L1/0UzXCJxxDgEW045VesmTsoJ6DaCo\n" +
-            "iB2p8rLOx41eUUff4R5w3zbUJE/CcvfjDvwkJtr8wGbvVfO65rW3yWyPUh7zgvo4\n" +
-            "ixVVjrEl8m3dPr7gK2Rp91XpdR5zRMaOD3LcyLXd0h8mZtUjUTPkTye5sP0a7k1e\n" +
-            "p75URGj2jdlz5PHae8hW/PLoS2ia51zcfsucMpqDl6v5j+TCZqBHwZX9oSmzhUbp\n" +
-            "ZNDYJBK/EZ/YhaZKG4XN/4MKVwcxL6qN8H3Xz5IU1ou37Qg/SjfHKLR7722yXztR\n" +
-            "MILOW0AyAVrRTUK8FuoMyILH8PJgMpbAJb24pqXZuQKBgQDzYRamGQyHz7ipvbop\n" +
-            "B7zPMbpq5jfx/+xZUyub2YnTcfrMdhdBXKsQtjFSu1esc+PHYAXZ8HZQLc9Ws5v+\n" +
-            "pP/2vrH18WZguAHU/BJNJxQ711wPqwN9N72Zrl/J4ac0DsymKIvBGdhX5kGg3F2l\n" +
-            "ckMSBWC7K9xmCpAejhNGg/wqaQKBgQDrXMQ4ER/RryrRzxojJRu6DcZSHLAAQ/Hi\n" +
-            "NXV+TnLws40uXA6KoLVnKPL1rHoX59U/0GrcDIPdRtqLpLuOnFDKPkUdVMbrx1bC\n" +
-            "Qji8CeQz81jSfRHW3k+W5G8T4MIJR1mw3rM3TSQLyM3yXVJ07oEJZ7VV8OVRvxfR\n" +
-            "e82u2gzmDwKBgQCZFDcPr++uuJt4wCoIRqKeW7PaKwWDRCpfoK1sMG69PRK3aYuF\n" +
-            "BAlg0IfDdqxVfusE60Oi6dkw4y9nZD848oVAqH78p6JyMSqN0SKdvne+j92KyVC/\n" +
-            "gMDTmdcL/s+RMcHMvPHyOhRWbTBYQmLwfibrfdByycqtr/UoEsrS7o88CQKBgD0p\n" +
-            "y1gioxkzozYI0usFLrJn9/zItbgr8ATwDYt4SYhhsLO2epTt9JZNXu4XF1d1CMbf\n" +
-            "m5V5rx7m1c5qTc9eseQM0Jsxt8v37oTm/qVnEKWrfI6er+8dsKMu0+rfgq00nItJ\n" +
-            "JFufsVlaoqJ0PARlIqVWDRq7Umyu8zqeKLJiue1jAoGBAI3DYclNMI5r4v0j87uj\n" +
-            "Hj8X7DsZb8c/9Q89w53NUChnbrWKl5Zf78xOqcc/EezKdhsuMPrv0NfEnMtjhO24\n" +
-            "Xnw30cezds8GpHS8+UJr+6EJKxcg3dBDSYiF5Gdj46y/g/SoUKFAGlTdLgFS8gPE\n" +
-            "+6W/aNisaI3LPr2tXvgPuPQy\n" +
+    static final String SSL_KEY = "-----BEGIN PRIVATE KEY-----\n" +
+            "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDCzdur4XILY8DZ\n" +
+            "sn0ssqfdxc2y/x3kGui7XRud/dy7vfaR4xV3URUfWqOoGNy06z0HMSGqJeOow++b\n" +
+            "tBCC5/whAsTRy8FmP56VUnTJ3iHd83EC8MC+S8Qhy07Ut4WxotbqbcpV6+2MONvQ\n" +
+            "vltskh7aRWr+pH66VjprvdWdu8fQqr1dwyJb/VD8L3CRlYzRr51a0m5up4XotDQ3\n" +
+            "tSDG7krCOJoF7U5SGmo3ifPK+hoW3hU0zaDl3K77Hb/1CSw2kKy0BmSwgy8Nh2NB\n" +
+            "Y4Lq37LMCzddZ1psg9xyauS9W7Ixi1OirtdFxCc9lyuAzWAjM1zYutGcuvSfyujy\n" +
+            "/fTbavPpAgMBAAECggEAHRMnjcRUxrFpR7S1rRWvK1EKDgS4u+JuSQSxCggpSVYl\n" +
+            "dom7mvbdnbPkCENJsbEIh0nEegY0r+wql4UtD7S7M1wb7yonn/Cv5R6M8tI2IM/k\n" +
+            "VqmDQwPA7sBO8D3B9QzWYd/oGqHfbxXPbRz0PUSj2TUSLpZzmbEkAA+x0dyEiram\n" +
+            "J/M+yKVuNSmT7E7V8PjvkagZH0xOFCm2IDC8II+rhvvmLzArW/D9yj/+xAjfWEwj\n" +
+            "odZW7OjVHPpCZyc1UD4kLJKuYAcQ0Ij+C3eHixnDBNLAV62/cvDwE1VrD66lJWUa\n" +
+            "J9hSDR6RoZKRHuOpD84b11spS4oxnZRToFEHCLMAjwKBgQDz7kCp/jyrKFFVWnTg\n" +
+            "k70MlRSZ+AGwmNC8guHg0jBCRZF2qAVqzkJGjo/TNAEwFa1OXUfOsdoBz6xTBk50\n" +
+            "RP1okJPRTMA8+7fpdU6qUMbEe4v+WllSSmoE7oQuFBeX5NMjqMpDC/fj5kyA5B1p\n" +
+            "uXQ6Z6anw28QP76vhBdl1SwQ7wKBgQDMcVghjpjAqhcAbnK6Z+4uPv3JYeU5hmJD\n" +
+            "P1foGjnI0eIqE96VWZFMks1SF9AQHphT1+cpEvmOEcWVkQ6xGdrciBUGmxchqRNj\n" +
+            "v5vNDocp5HcvAMaG5EKDMgyFggC6UDhSz/ClnljWr1DFxDnFkG/vRtMBMttZWzHD\n" +
+            "Mrbj/EKYpwKBgBTD5HdUMD/1x663a5mumfpXOpC83w/0glh539aurfMGTxLFzOhB\n" +
+            "tLyi6DV3iN5aCg3QvQsocsGStz2+HLGjKdtb62l22iqW1xolpVO0WqdhSRKXCGGL\n" +
+            "+ih/UXtGtJd2oE650LYSb8DT2xFh2eslIXLTXgmMBolgk9AHM6K0mfK7AoGBAJuk\n" +
+            "9vmlPDoBxD052PJ9SWG/5yq38vGWk5yqztwPi0qOL2bldaGybOIlKVeEdYywHjxG\n" +
+            "tOAaaA93DDvQEaVXD76xg4Bh9nxT4kUgjRbSJqkIHIyWRI5RnSmQouPJk5BEnny9\n" +
+            "fnI4WV4oXpAR0gHM8srx2pahB0nCGeKH66EqXfElAoGBAIwYxQs3vf9N33S9dKmT\n" +
+            "z+ZI3Mx7eGznXyVc4ze4kI8hsHMmDRQokA3beSYO8XfXgJgPzaJ6uuEf9dDiYHWu\n" +
+            "F9OYFN7F+V/+bn7Hm/zYa5ItyhEnrBd552v4L0mSJajDB+de0ZP0TcUkUK4W0quH\n" +
+            "CLGu/I81PuXZ/gBbVGyj8R43\n" +
             "-----END PRIVATE KEY-----";
 
     @Test
-    public void testSslEnabled(VertxTestContext context) {
-        // we have to recreate the client to enable SSL
-        WebClient sslClient = WebClient.create(vertx, new WebClientOptions()
-                .setDefaultHost(Urls.BRIDGE_HOST)
-                .setDefaultPort(Urls.BRIDGE_SSL_PORT)
-                .setSsl(true)
-                .setTrustOptions(new PemTrustOptions()
-                        .addCertValue(Buffer.buffer(SSL_CERT)))
-                .setVerifyHost(false));
+    void testSslEnabled(BridgeTestContext bridgeTestContext) throws Exception {
+        SSLContext sslContext = createSslContext();
 
-        sslClient
-                .get("/")
-                .send()
-                .onComplete(ar -> context.verify(() -> {
-                    assertThat(ar.result().statusCode(), is(HttpResponseStatus.OK.code()));
-                    context.completeNow();
-                }));
+        HttpClient sslClient = HttpClient.newBuilder()
+            .sslContext(sslContext)
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
+
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+            .uri(new URI("https://" + bridgeTestContext.getBridgeHost() + ":" + bridgeTestContext.getBridgePort() + "/"))
+            .GET()
+            .build();
+
+        HttpResponse<String> httpResponse = sslClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
     }
 
     @Test
-    public void testUnencryptedConnection(VertxTestContext context) {
-        // Once SSL is enabled, HTTP Bridge server should reject unencrypted connections
-        baseService()
-                .getRequest("/")
-                .send()
-                .onFailure(t -> {
-                    assertThat(t.getCause().getMessage(), is("Connection refused"));
-                    context.completeNow();
-                });
+    void testUnencryptedConnection(BridgeTestContext bridgeTestContext) {
+        HttpService plainHttpService = new HttpService(bridgeTestContext.getBridgeHost(), bridgeTestContext.getBridgePort());
+
+        assertThrows(RuntimeException.class, () -> plainHttpService.get("/"));
     }
 
     @Test
-    public void testManagementEndpointWhenSslEnabled(VertxTestContext context) {
-        // When SSL is enabled, connections to the management endpoints should stay unencrypted
-        internalBaseService()
-                .getRequest("/healthy")
-                .send()
-                .onComplete(ar -> context.verify(() -> {
-                    assertThat(ar.result().statusCode(), is(HttpResponseStatus.OK.code()));
-                    context.completeNow();
-                }));
+    void testManagementEndpointWhenSslEnabled(BridgeTestContext bridgeTestContext) {
+        HttpService managementService = new HttpService(bridgeTestContext.getBridgeHost(), bridgeTestContext.getBridgeManagementPort());
+
+        HttpResponse<String> httpResponse = managementService.get("/healthy");
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
     }
 
-    @Override
-    protected Map<String, Object> overrideConfig() {
-        Map<String, Object> configs = new HashMap<>();
-        configs.put(HttpConfig.HTTP_SERVER_SSL_ENABLE, true);
-        configs.put(HttpConfig.HTTP_SERVER_SSL_CERTIFICATE, SSL_CERT);
-        configs.put(HttpConfig.HTTP_SERVER_SSL_KEY, SSL_KEY);
-        return configs;
+    private SSLContext createSslContext() throws Exception {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        X509Certificate cert = (X509Certificate) cf.generateCertificate(
+            new ByteArrayInputStream(SSL_CERT.getBytes()));
+
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, null);
+        trustStore.setCertificateEntry("bridge", cert);
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustStore);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, tmf.getTrustManagers(), null);
+        return sslContext;
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/objects/BridgeTestContext.java
+++ b/src/test/java/io/strimzi/kafka/bridge/objects/BridgeTestContext.java
@@ -23,6 +23,9 @@ public class BridgeTestContext {
     private HttpService httpService;
     private AdminClientFacade adminClientFacade;
     private BasicKafkaClient basicKafkaClient;
+    private String bridgeHost;
+    private int bridgePort;
+    private int bridgeManagementPort;
 
     /**
      * Constructor for creating variables and services for particular {@param extensionContext}.
@@ -34,6 +37,9 @@ public class BridgeTestContext {
         httpService = BridgeExtension.getHttpService(extensionContext);
         adminClientFacade = AdminClientFacade.create(KafkaExtension.getKafkaCluster(extensionContext).getBootstrapServers());
         basicKafkaClient = new BasicKafkaClient(KafkaExtension.getKafkaCluster(extensionContext).getBootstrapServers());
+        bridgeHost = BridgeExtension.getBridgeHost(extensionContext);
+        bridgePort = BridgeExtension.getBridgePort(extensionContext);
+        bridgeManagementPort = BridgeExtension.getBridgeManagementPort(extensionContext);
     }
 
     /**
@@ -62,5 +68,29 @@ public class BridgeTestContext {
 
     public BasicKafkaClient getBasicKafkaClient() {
         return basicKafkaClient;
+    }
+
+    /**
+     * Returns the bridge host.
+     * @return the bridge host.
+     */
+    public String getBridgeHost() {
+        return bridgeHost;
+    }
+
+    /**
+     * Returns the bridge main port (HTTP or HTTPS depending on SSL configuration).
+     * @return the bridge main port.
+     */
+    public int getBridgePort() {
+        return bridgePort;
+    }
+
+    /**
+     * Returns the bridge management port.
+     * @return the bridge management port.
+     */
+    public int getBridgeManagementPort() {
+        return bridgeManagementPort;
     }
 }


### PR DESCRIPTION
This PR continues with refactoring the integration tests, now with `InvalidProducerIT`, `OtherServicesIT`, and `TlsIT`.
There were needed changes for the `TlsIT`, as the handling of the Bridge stuff in container (and also in-memory Bridge) is a bit different (in terms of the HTTP ports etc.), so I had to add changes to the `BridgeExtension` as well.

Also, I had to generate correct certificate for the `TlsIT` with SANs, that are required when doing the HTTP requests with the Java's HTTP client - that could be disabled with `.setVerifyHost(false)` in the VertX's Webclient.