### PR TITLE
Refactor of Bridge integration tests - `MetricsIT` and `SeekIT`

### DIFF
--- a/src/test/java/io/strimzi/kafka/bridge/clients/Producer.java
+++ b/src/test/java/io/strimzi/kafka/bridge/clients/Producer.java
@@ -45,10 +45,10 @@ public class Producer {
         List<ProducerRecord<String, String>> messages = createMessages();
 
         LOGGER.info("Producer is starting with following properties: {}", properties.toString());
-        KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
-
-        LOGGER.info("Sending messages");
-        messages.forEach(producerRecord -> sendMessage(producer, producerRecord));
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(properties)) {
+            LOGGER.info("Sending messages");
+            messages.forEach(producerRecord -> sendMessage(producer, producerRecord));
+        }
     }
 
     private List<ProducerRecord<String, String>> createMessages() {

--- a/src/test/java/io/strimzi/kafka/bridge/extensions/BridgeExtension.java
+++ b/src/test/java/io/strimzi/kafka/bridge/extensions/BridgeExtension.java
@@ -65,7 +65,7 @@ public class BridgeExtension implements
     private static final String HTTP_SERVICE_KEY = "httpService";
     private static final String BRIDGE_HOST_KEY = "bridgeHost";
     private static final String BRIDGE_PORT_KEY = "bridgePort";
-    private static final String BRIDGE_MANAGEMENT_PORT_KEY = "bridgeManagementPort";
+    private static final String MANAGEMENT_HTTP_SERVICE_KEY = "managementHttpService";
 
     private static final BridgeRunMode BRIDGE_RUN_MODE_ENV = BridgeRunMode.fromString(System.getenv().getOrDefault("BRIDGE_RUN_MODE", BridgeRunMode.IN_MEMORY.name()));
     private static final String DEFAULT_BRIDGE_IMAGE = "quay.io/strimzi/kafka-bridge:latest";
@@ -283,12 +283,13 @@ public class BridgeExtension implements
         int bridgePort = sslEnabled ? Urls.BRIDGE_SSL_PORT : Urls.BRIDGE_PORT;
 
         HttpService httpService = sslEnabled ? null : new HttpService(Urls.BRIDGE_HOST, bridgePort);
+        HttpService managementHttpService = new HttpService(Urls.BRIDGE_HOST, Urls.BRIDGE_MANAGEMENT_PORT);
 
         getStore(extensionContext).put(BRIDGE_BINARY_KEY, vertx);
         getStore(extensionContext).put(HTTP_SERVICE_KEY, httpService);
         getStore(extensionContext).put(BRIDGE_HOST_KEY, Urls.BRIDGE_HOST);
         getStore(extensionContext).put(BRIDGE_PORT_KEY, bridgePort);
-        getStore(extensionContext).put(BRIDGE_MANAGEMENT_PORT_KEY, Urls.BRIDGE_MANAGEMENT_PORT);
+        getStore(extensionContext).put(MANAGEMENT_HTTP_SERVICE_KEY, managementHttpService);
     }
 
     /**
@@ -327,12 +328,13 @@ public class BridgeExtension implements
         bridgeContainer.start();
 
         HttpService httpService = sslEnabled ? null : new HttpService(bridgeContainer.getHost(), bridgeContainer.getMappedPort(httpPort));
+        HttpService managementHttpService = new HttpService(bridgeContainer.getHost(), bridgeContainer.getMappedPort(Urls.BRIDGE_MANAGEMENT_PORT));
 
         getStore(extensionContext).put(BRIDGE_CONTAINER_KEY, bridgeContainer);
         getStore(extensionContext).put(HTTP_SERVICE_KEY, httpService);
         getStore(extensionContext).put(BRIDGE_HOST_KEY, bridgeContainer.getHost());
         getStore(extensionContext).put(BRIDGE_PORT_KEY, bridgeContainer.getMappedPort(httpPort));
-        getStore(extensionContext).put(BRIDGE_MANAGEMENT_PORT_KEY, bridgeContainer.getMappedPort(Urls.BRIDGE_MANAGEMENT_PORT));
+        getStore(extensionContext).put(MANAGEMENT_HTTP_SERVICE_KEY, managementHttpService);
     }
 
     /**
@@ -425,14 +427,14 @@ public class BridgeExtension implements
     }
 
     /**
-     * Returns the bridge management port from the extension context's store.
+     * Method for getting the management {@link HttpService} from the extension context's store.
      *
      * @param extensionContext  context of the test.
      *
-     * @return  the bridge management port.
+     * @return  management {@link HttpService} from the extension context's store.
      */
-    public static int getBridgeManagementPort(ExtensionContext extensionContext) {
-        return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(BRIDGE_MANAGEMENT_PORT_KEY, Integer.class);
+    public static HttpService getManagementHttpService(ExtensionContext extensionContext) {
+        return extensionContext.getStore(ExtensionContext.Namespace.GLOBAL).get(MANAGEMENT_HTTP_SERVICE_KEY, HttpService.class);
     }
 
     /**

--- a/src/test/java/io/strimzi/kafka/bridge/extensions/BridgeExtension.java
+++ b/src/test/java/io/strimzi/kafka/bridge/extensions/BridgeExtension.java
@@ -259,15 +259,16 @@ public class BridgeExtension implements
      * @param configuration     configuration of the Bridge.
      */
     private void deployBridgeInMemory(ExtensionContext extensionContext, Map<String, Object> configuration) {
-        BridgeConfig bridgeConfig = BridgeConfig.fromMap(configuration);
-        HttpBridge httpBridge = new HttpBridge(bridgeConfig);
         LOGGER.info("Deploying in-memory Bridge");
 
         VertxOptions vertxOptions = new VertxOptions();
         if (configuration.get(BridgeConfig.METRICS_TYPE) != null) {
             vertxOptions.setMetricsOptions(metricsOptions());
         }
-        Vertx vertx =  Vertx.vertx(vertxOptions);
+        Vertx vertx = Vertx.vertx(vertxOptions);
+
+        BridgeConfig bridgeConfig = BridgeConfig.fromMap(configuration);
+        HttpBridge httpBridge = new HttpBridge(bridgeConfig);
 
         vertx.deployVerticle(httpBridge)
             .onComplete(ar -> {
@@ -362,20 +363,40 @@ public class BridgeExtension implements
      * @param extensionContext  context of the test.
      */
     private void stopBridge(ExtensionContext extensionContext) {
+        closeHttpServices(extensionContext);
+
         if (BRIDGE_RUN_MODE_ENV.equals(BridgeRunMode.IN_MEMORY)) {
+            LOGGER.info("Stopping in-memory Bridge");
             Vertx bridge = getStore(extensionContext)
                 .get(BRIDGE_BINARY_KEY, Vertx.class);
 
             if (bridge != null) {
-                bridge.close();
+                bridge.close().await();
             }
         } else {
+            LOGGER.info("Stopping container Bridge");
             GenericContainer<?> bridge = getStore(extensionContext)
                 .get(BRIDGE_CONTAINER_KEY, GenericContainer.class);
 
             if (bridge != null) {
                 bridge.stop();
             }
+        }
+    }
+
+    /**
+     * Closes the HTTP client services to release connections before stopping the bridge.
+     *
+     * @param extensionContext  context of the test.
+     */
+    private void closeHttpServices(ExtensionContext extensionContext) {
+        HttpService httpService = getStore(extensionContext).get(HTTP_SERVICE_KEY, HttpService.class);
+        if (httpService != null) {
+            httpService.close();
+        }
+        HttpService managementHttpService = getStore(extensionContext).get(MANAGEMENT_HTTP_SERVICE_KEY, HttpService.class);
+        if (managementHttpService != null) {
+            managementHttpService.close();
         }
     }
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/MetricsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/MetricsIT.java
@@ -6,21 +6,19 @@ package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.codec.BodyCodec;
-import io.vertx.junit5.VertxTestContext;
-import org.apache.kafka.common.KafkaFuture;
-import org.hamcrest.CoreMatchers;
+import io.strimzi.kafka.bridge.extensions.BridgeSuite;
+import io.strimzi.kafka.bridge.http.base.AbstractIT;
+import io.strimzi.kafka.bridge.httpclient.HttpConsumerService;
+import io.strimzi.kafka.bridge.httpclient.HttpProducerService;
+import io.strimzi.kafka.bridge.httpclient.HttpResponseUtils;
+import io.strimzi.kafka.bridge.objects.BridgeTestContext;
+import io.strimzi.kafka.bridge.objects.ReceivedMessage;
 import org.junit.jupiter.api.Test;
 
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,227 +30,158 @@ import static org.hamcrest.Matchers.notNullValue;
 /**
  * Integration tests for the /metrics endpoint functionality
  */
-public class MetricsIT extends HttpBridgeITAbstract {
+@BridgeSuite
+public class MetricsIT extends AbstractIT {
 
     @Test
-    void metricsTest(VertxTestContext context) {
-        internalBaseService()
-                .getRequest("/metrics")
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        assertThat(ar.result().statusCode(), is(HttpResponseStatus.OK.code()));
-                        assertThat(ar.result().getHeader("Content-Type"), is("text/plain; version=0.0.4; charset=utf-8"));
-                        context.completeNow();
-                    });
-                });
+    void metricsTest(BridgeTestContext bridgeTestContext) {
+        HttpResponse<String> response = bridgeTestContext.getManagementHttpService().get("/metrics");
+
+        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+        assertThat(response.headers().firstValue("Content-Type").orElse(""), is("text/plain; version=0.0.4; charset=utf-8"));
     }
 
     @Test
-    void metricsContentTest(VertxTestContext context) {
-        internalBaseService()
-                .getRequest("/metrics")
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        assertThat(ar.result().statusCode(), is(HttpResponseStatus.OK.code()));
-                        assertThat(ar.result().getHeader("Content-Type"), is("text/plain; version=0.0.4; charset=utf-8"));
+    void metricsContentTest(BridgeTestContext bridgeTestContext) {
+        HttpResponse<String> response = bridgeTestContext.getManagementHttpService().get("/metrics");
 
-                        String metricsBody = ar.result().bodyAsString();
-                        assertThat(metricsBody, is(notNullValue()));
-                        assertThat(!metricsBody.isEmpty(), is(true));
+        assertThat(response.statusCode(), is(HttpResponseStatus.OK.code()));
+        assertThat(response.headers().firstValue("Content-Type").orElse(""), is("text/plain; version=0.0.4; charset=utf-8"));
 
-                        // verify Prometheus format containing HELP and TYPE comments
-                        assertThat(metricsBody.contains("# HELP"), is(true));
-                        assertThat(metricsBody.contains("# TYPE"), is(true));
+        String metricsBody = response.body();
+        assertThat(metricsBody, is(notNullValue()));
+        assertThat(!metricsBody.isEmpty(), is(true));
 
-                        // verify JVM and Strimzi bridge specific metrics are present
-                        assertThat(metricsBody.contains("strimzi_bridge_"), is(true));
-                        assertThat(metricsBody.contains("strimzi_bridge_http_"), is(true));
-                        assertThat(metricsBody.contains("jvm_"), is(true));
+        // verify Prometheus format containing HELP and TYPE comments
+        assertThat(metricsBody.contains("# HELP"), is(true));
+        assertThat(metricsBody.contains("# TYPE"), is(true));
 
-                        context.completeNow();
-                    });
-                });
+        // verify JVM and Strimzi bridge specific metrics are present
+        assertThat(metricsBody.contains("strimzi_bridge_"), is(true));
+        assertThat(metricsBody.contains("strimzi_bridge_http_"), is(true));
+        assertThat(metricsBody.contains("jvm_"), is(true));
     }
 
     @Test
-    void metricsAfterProducerSendRecordTest(VertxTestContext context) throws InterruptedException, ExecutionException {
-        KafkaFuture<Void> future = adminClientFacade.createTopic(topic);
+    void metricsAfterProducerSendRecordTest(BridgeTestContext bridgeTestContext) {
+        createTopic(bridgeTestContext, 1);
 
         String value = "test-message-for-metrics";
 
-        JsonArray records = new JsonArray();
-        JsonObject json = new JsonObject();
-        json.put("value", value);
-        records.add(json);
+        Map<String, Object> records = Map.of(
+            "records", List.of(
+                Map.of("value", value)
+            )
+        );
 
-        JsonObject root = new JsonObject();
-        root.put("records", records);
+        HttpProducerService httpProducerService = new HttpProducerService(bridgeTestContext.getHttpService());
+        httpProducerService.sendJsonRecordsRequest(bridgeTestContext.getTopicName(), records, BridgeContentType.KAFKA_JSON_JSON);
 
-        future.get();
-        
-        producerService()
-                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                .sendJsonObject(root)
-                .onComplete(sendResult -> {
-                    context.verify(() -> assertThat(sendResult.succeeded(), is(true)));
-                    
-                    // Check metrics after producer activity
-                    internalBaseService()
-                            .getRequest("/metrics")
-                            .send()
-                            .onComplete(metricsResult -> {
-                                context.verify(() -> {
-                                    assertThat(metricsResult.succeeded(), is(true));
-                                    String metricsBody = metricsResult.result().bodyAsString();
-                                    
-                                    // verify HTTP request metrics
-                                    assertThat(metricsBody.contains("strimzi_bridge_http_client_requests_total"), is(true));
+        // Check metrics after producer activity
+        HttpResponse<String> metricsResponse = bridgeTestContext.getManagementHttpService().get("/metrics");
+        assertThat(metricsResponse.statusCode(), is(HttpResponseStatus.OK.code()));
 
-                                    Optional<Double> requestsTotal = parseMetricValue(metricsBody, "strimzi_bridge_http_client_requests_total");
-                                    assertThat(requestsTotal.isPresent(), is(true));
-                                    assertThat(requestsTotal.get(), greaterThan(0.0));
-                                    
-                                    // verify Kafka producer metrics are present
-                                    assertThat(metricsBody.contains("kafka_producer_"), is(true));
+        String metricsBody = metricsResponse.body();
 
-                                    Optional<Double> recordSend = parseMetricValue(metricsBody, "kafka_producer_producer_metrics_record_send");
-                                    assertThat(recordSend.isPresent(), is(true));
-                                    assertThat(recordSend.get(), greaterThan(0.0));
-                                    
-                                    context.completeNow();
-                                });
-                            });
-                });
+        // verify HTTP server request metrics
+        assertThat(metricsBody.contains("strimzi_bridge_http_server_requests"), is(true));
+
+        // verify Kafka producer metrics are present
+        assertThat(metricsBody.contains("kafka_producer_"), is(true));
+
+        Optional<Double> recordSend = parseMetricValue(metricsBody, "kafka_producer_producer_metrics_record_send");
+        assertThat(recordSend.isPresent(), is(true));
+        assertThat(recordSend.get(), greaterThan(0.0));
     }
 
     @Test
-    void metricsAfterConsumerReceiveRecordTest(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        KafkaFuture<Void> future = adminClientFacade.createTopic(topic);
+    void metricsAfterConsumerReceiveRecordTest(BridgeTestContext bridgeTestContext) {
+        createTopic(bridgeTestContext, 1);
+
         String groupId = generateRandomConsumerGroupName();
-        String name = "my-kafka-consumer";
-        
-        future.get();
+        String name = generateRandomConsumerName();
         String sentBody = "Simple message for consumer metrics";
-        
-        basicKafkaClient.sendJsonMessagesPlain(topic, 1, sentBody, 0, true);
 
-        JsonObject consumerJson = new JsonObject()
-                .put("name", name)
-                .put("format", "json");
+        bridgeTestContext.getBasicKafkaClient().sendJsonMessagesPlain(bridgeTestContext.getTopicName(), 1, sentBody, 0, true);
 
-        // consumer creation
-        consumerService()
-                .createConsumer(context, groupId, consumerJson)
-                .subscribeConsumer(context, groupId, name, topic);
+        HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
 
-        CompletableFuture<Boolean> consume = new CompletableFuture<>();
-        
+        Map<String, Object> consumerConfig = Map.of(
+            "name", name,
+            "format", "json"
+        );
+
+        // consumer creation + subscription
+        httpConsumerService.createConsumer(groupId, consumerConfig);
+        httpConsumerService.subscribeConsumer(groupId, name, bridgeTestContext.getTopicName());
+
         // consume records
-        consumerService()
-                .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
-                .as(BodyCodec.jsonArray())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonArray> response = ar.result();
-                        assertThat(response.statusCode(), CoreMatchers.is(HttpResponseStatus.OK.code()));
+        HttpResponse<String> consumeResponse = httpConsumerService.consumeRecordsRequest(groupId, name);
+        assertThat(consumeResponse.statusCode(), is(HttpResponseStatus.OK.code()));
 
-                        JsonObject jsonResponse = response.body().getJsonObject(0);
-                        assertThat(jsonResponse.getString("value"), is(sentBody));
-                    });
-                    consume.complete(true);
-                });
-
-        consume.get(timeout, TimeUnit.SECONDS);
+        ReceivedMessage[] receivedMessages = HttpResponseUtils.getReceivedMessagesFromResponse(consumeResponse.body());
+        assertThat(receivedMessages.length, greaterThan(0));
+        assertThat(receivedMessages[0].value(), is(sentBody));
 
         // check metrics after consumer activity
-        internalBaseService()
-                .getRequest("/metrics")
-                .send()
-                .onComplete(metricsResult -> {
-                    context.verify(() -> {
-                        assertThat(metricsResult.succeeded(), is(true));
-                        String metricsBody = metricsResult.result().bodyAsString();
+        HttpResponse<String> metricsResponse = bridgeTestContext.getManagementHttpService().get("/metrics");
+        assertThat(metricsResponse.statusCode(), is(HttpResponseStatus.OK.code()));
 
-                        // verify HTTP client request metrics
-                        assertThat(metricsBody.contains("strimzi_bridge_http_client_requests_total"), is(true));
+        String metricsBody = metricsResponse.body();
 
-                        // verify Kafka consumer metrics are present
-                        assertThat(metricsBody.contains("kafka_consumer_"), is(true));
+        // verify HTTP server request metrics
+        assertThat(metricsBody.contains("strimzi_bridge_http_server_requests"), is(true));
 
-                        context.completeNow();
-                    });
-                });
-        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+        // verify Kafka consumer metrics are present
+        assertThat(metricsBody.contains("kafka_consumer_"), is(true));
 
         // consumer deletion
-        consumerService().deleteConsumer(context, groupId, name);
+        httpConsumerService.deleteConsumer(groupId, name);
     }
 
     @Test
-    void metricsExecutorTest(VertxTestContext context) throws InterruptedException, ExecutionException {
-        KafkaFuture<Void> future = adminClientFacade.createTopic(topic);
+    void metricsExecutorTest(BridgeTestContext bridgeTestContext) {
+        createTopic(bridgeTestContext, 1);
 
         String value = "test-message-for-executor-metrics";
 
-        JsonArray records = new JsonArray();
-        JsonObject json = new JsonObject();
-        json.put("value", value);
-        records.add(json);
+        Map<String, Object> records = Map.of(
+            "records", List.of(
+                Map.of("value", value)
+            )
+        );
 
-        JsonObject root = new JsonObject();
-        root.put("records", records);
+        HttpProducerService httpProducerService = new HttpProducerService(bridgeTestContext.getHttpService());
+        httpProducerService.sendJsonRecordsRequest(bridgeTestContext.getTopicName(), records, BridgeContentType.KAFKA_JSON_JSON);
 
-        future.get();
+        // check metrics after producer activity to verify executor metrics
+        HttpResponse<String> metricsResponse = bridgeTestContext.getManagementHttpService().get("/metrics");
+        assertThat(metricsResponse.statusCode(), is(HttpResponseStatus.OK.code()));
 
-        producerService()
-                .sendRecordsRequest(topic, root, BridgeContentType.KAFKA_JSON_JSON)
-                .sendJsonObject(root)
-                .onComplete(sendResult -> {
-                    context.verify(() -> assertThat(sendResult.succeeded(), is(true)));
+        String metricsBody = metricsResponse.body();
 
-                    // check metrics after producer activity to verify executor metrics
-                    internalBaseService()
-                            .getRequest("/metrics")
-                            .send()
-                            .onComplete(metricsResult -> {
-                                context.verify(() -> {
-                                    assertThat(metricsResult.succeeded(), is(true));
-                                    String metricsBody = metricsResult.result().bodyAsString();
+        // verify executor metrics are present with correct tags
+        assertThat(metricsBody.contains("executor_active_threads"), is(true));
+        assertThat(metricsBody.contains("executor_queued_tasks"), is(true));
+        assertThat(metricsBody.contains("executor_queue_remaining_tasks"), is(true));
+        assertThat(metricsBody.contains("executor_pool_size_threads"), is(true));
+        assertThat(metricsBody.contains("executor_completed_tasks_total"), is(true));
 
-                                    // verify executor metrics are present with correct tags
-                                    assertThat(metricsBody.contains("executor_active_threads"), is(true));
-                                    assertThat(metricsBody.contains("executor_queued_tasks"), is(true));
-                                    assertThat(metricsBody.contains("executor_queue_remaining_tasks"), is(true));
-                                    assertThat(metricsBody.contains("executor_pool_size_threads"), is(true));
-                                    assertThat(metricsBody.contains("executor_completed_tasks_total"), is(true));
+        // verify executor metrics have the expected tags
+        assertThat(metricsBody.contains("name=\"kafka-bridge\""), is(true));
 
-                                    // verify executor metrics have the expected tags
-                                    assertThat(metricsBody.contains("name=\"kafka-bridge\""), is(true));
+        // verify executor completed tasks counter is > 0 (at least one task completed)
+        Optional<Double> completedTotal = parseMetricValue(metricsBody, "executor_completed_tasks_total");
+        assertThat(completedTotal.isPresent(), is(true));
+        assertThat(completedTotal.get(), greaterThan(0.0));
 
-                                    // verify executor completed tasks counter is > 0 (at least one task completed)
-                                    Optional<Double> completedTotal = parseMetricValue(metricsBody, "executor_completed_tasks_total");
-                                    assertThat(completedTotal.isPresent(), is(true));
-                                    assertThat(completedTotal.get(), greaterThan(0.0));
-
-                                    // verify pool size gauge has a reasonable value
-                                    Optional<Double> poolSize = parseMetricValue(metricsBody, "executor_pool_size_threads");
-                                    assertThat(poolSize.isPresent(), is(true));
-                                    assertThat(poolSize.get(), greaterThan(0.0));
-
-                                    context.completeNow();
-                                });
-                            });
-                });
+        // verify pool size gauge has a reasonable value
+        Optional<Double> poolSize = parseMetricValue(metricsBody, "executor_pool_size_threads");
+        assertThat(poolSize.isPresent(), is(true));
+        assertThat(poolSize.get(), greaterThan(0.0));
     }
 
     private Optional<Double> parseMetricValue(String metricsBody, String metricName) {
-        // Look for the metric line that starts with the metric name, optionally has tags in {}, and contains a numeric value
         Pattern pattern = Pattern.compile("^" + Pattern.quote(metricName) + "(?:\\{[^}]*})?\\s+(\\d+(?:\\.\\d+)?)\\s*$", Pattern.MULTILINE);
         Matcher matcher = pattern.matcher(metricsBody);
         return matcher.find() ? Optional.of(Double.parseDouble(matcher.group(1))) : Optional.empty();

--- a/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/OtherServicesIT.java
@@ -9,7 +9,6 @@ import io.strimzi.kafka.bridge.extensions.BridgeSuite;
 import io.strimzi.kafka.bridge.http.base.AbstractIT;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
 import io.strimzi.kafka.bridge.httpclient.HttpResponseUtils;
-import io.strimzi.kafka.bridge.httpclient.HttpService;
 import io.strimzi.kafka.bridge.objects.BridgeTestContext;
 import org.junit.jupiter.api.Test;
 
@@ -28,11 +27,9 @@ public class OtherServicesIT extends AbstractIT {
 
     @Test
     void readyTest(BridgeTestContext bridgeTestContext) throws InterruptedException {
-        HttpService managementService = new HttpService(bridgeTestContext.getBridgeHost(), bridgeTestContext.getBridgeManagementPort());
-
         int iterations = 5;
         for (int i = 0; i < iterations; i++) {
-            HttpResponse<String> httpResponse = managementService.get("/ready");
+            HttpResponse<String> httpResponse = bridgeTestContext.getManagementHttpService().get("/ready");
             assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
             Thread.sleep(1000);
         }
@@ -40,11 +37,9 @@ public class OtherServicesIT extends AbstractIT {
 
     @Test
     void healthyTest(BridgeTestContext bridgeTestContext) throws InterruptedException {
-        HttpService managementService = new HttpService(bridgeTestContext.getBridgeHost(), bridgeTestContext.getBridgeManagementPort());
-
         int iterations = 5;
         for (int i = 0; i < iterations; i++) {
-            HttpResponse<String> httpResponse = managementService.get("/healthy");
+            HttpResponse<String> httpResponse = bridgeTestContext.getManagementHttpService().get("/healthy");
             assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
             Thread.sleep(1000);
         }

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -6,575 +6,327 @@ package io.strimzi.kafka.bridge.http;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
-import io.strimzi.kafka.bridge.http.base.HttpBridgeITAbstract;
+import io.strimzi.kafka.bridge.extensions.BridgeSuite;
+import io.strimzi.kafka.bridge.http.base.AbstractIT;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
-import io.strimzi.kafka.bridge.http.services.ConsumerService;
-import io.strimzi.kafka.bridge.utils.Urls;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.codec.BodyCodec;
-import io.vertx.junit5.VertxTestContext;
-import org.apache.kafka.common.KafkaFuture;
+import io.strimzi.kafka.bridge.httpclient.HttpConsumerService;
+import io.strimzi.kafka.bridge.httpclient.HttpResponseUtils;
+import io.strimzi.kafka.bridge.httpclient.HttpSeekService;
+import io.strimzi.kafka.bridge.objects.BridgeTestContext;
+import io.strimzi.kafka.bridge.objects.ReceivedMessage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.http.HttpResponse;
+import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
-import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class SeekIT extends HttpBridgeITAbstract {
+@BridgeSuite
+public class SeekIT extends AbstractIT {
     private static final Logger LOGGER = LogManager.getLogger(SeekIT.class);
 
-    private final String name = "my-kafka-consumer";
-    private final String groupId = "my-group";
-    private final JsonObject jsonConsumer = new JsonObject()
-        .put("name", name)
-        .put("format", "json");
+    private String name;
+    private String groupId;
 
-    @Test
-    void seekToNotExistingConsumer(VertxTestContext context) throws InterruptedException {
-        JsonObject root = new JsonObject();
-
-        seekService()
-                .positionsBeginningRequest(groupId, name, root)
-                .sendJsonObject(root)
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-                        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.message(), is("The specified consumer instance was not found."));
-                        context.completeNow();
-                    });
-                });
-        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
-    }
-
-    @Disabled // This test was disabled because of known issue described in https://github.com/strimzi/strimzi-kafka-bridge/issues/320
-    @Test
-    void seekToNotExistingPartitionInSubscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        adminClientFacade.createTopic(topic);
-
-        // create consumer
-        consumerService()
-                .createConsumer(context, groupId, jsonConsumer)
-                .subscribeTopic(context, groupId, name, new JsonObject().put("topic", topic).put("partition", 0));
-
-        int notExistingPartition = 2;
-        JsonArray notExistingPartitionJSON = new JsonArray();
-        notExistingPartitionJSON.add(new JsonObject().put("topic", topic).put("partition", notExistingPartition));
-
-        JsonObject partitionsJSON = new JsonObject();
-        partitionsJSON.put("partitions", notExistingPartitionJSON);
-
-        seekService()
-                .positionsBeginningRequest(groupId, name, partitionsJSON)
-                .sendJsonObject(partitionsJSON)
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-                        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.message(), is("No current assignment for partition " + topic + "-" + notExistingPartition));
-                        context.completeNow();
-                    });
-                });
-        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
-
-        // consumer deletion
-        consumerService()
-                .deleteConsumer(context, groupId, name);
+    @BeforeEach
+    void setUp() {
+        name = generateRandomConsumerName();
+        groupId = generateRandomConsumerGroupName();
     }
 
     @Test
-    void seekToNotExistingTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        // create consumer
-        consumerService()
-                .createConsumer(context, groupId, jsonConsumer);
+    void seekToNotExistingConsumer(BridgeTestContext bridgeTestContext) {
+        HttpSeekService httpSeekService = new HttpSeekService(bridgeTestContext.getHttpService());
 
-        // Specified consumer instance did not have one of the specified topics.
-        CompletableFuture<Boolean> consumerInstanceDontHaveTopic = new CompletableFuture<>();
+        Map<String, Object> emptyBody = Map.of();
+
+        HttpResponse<String> response = httpSeekService.seekToBeginningRequest(groupId, name, emptyBody);
+        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
+
+        HttpBridgeError error = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsMap(response.body()));
+        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
+        assertThat(error.message(), is("The specified consumer instance was not found."));
+    }
+
+    @Test
+    void seekToNotExistingTopic(BridgeTestContext bridgeTestContext) {
+        HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
+        HttpSeekService httpSeekService = new HttpSeekService(bridgeTestContext.getHttpService());
+
+        Map<String, Object> consumerConfig = Map.of("name", name, "format", "json");
+
+        // create consumer
+        httpConsumerService.createConsumer(groupId, consumerConfig);
 
         String notExistingTopic = "notExistingTopic";
-        JsonArray notExistingTopicJSON = new JsonArray();
-        notExistingTopicJSON.add(new JsonObject().put("topic", notExistingTopic).put("partition", 0));
 
-        JsonObject partitionsWithWrongTopic = new JsonObject();
-        partitionsWithWrongTopic.put("partitions", notExistingTopicJSON);
+        Map<String, Object> partitionsBody = Map.of(
+            "partitions", List.of(
+                Map.of("topic", notExistingTopic, "partition", 0)
+            )
+        );
 
-        seekService()
-                .positionsBeginningRequest(groupId, name, partitionsWithWrongTopic)
-                .sendJsonObject(partitionsWithWrongTopic)
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-                        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.message(), is("No current assignment for partition " + notExistingTopic + "-" + 0));
-                        context.completeNow();
-                    });
-                    consumerInstanceDontHaveTopic.complete(true);
-                });
-        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+        HttpResponse<String> response = httpSeekService.seekToBeginningRequest(groupId, name, partitionsBody);
+        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
+
+        HttpBridgeError error = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsMap(response.body()));
+        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
+        assertThat(error.message(), is("No current assignment for partition " + notExistingTopic + "-0"));
 
         // consumer deletion
-        consumerService()
-                .deleteConsumer(context, groupId, name);
-
-        consumerInstanceDontHaveTopic.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        httpConsumerService.deleteConsumer(groupId, name);
     }
 
     @Test
-    void seekToBeginningAndReceive(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        KafkaFuture<Void> future = adminClientFacade.createTopic(topic);
-        future.get();
+    void seekToBeginningAndReceive(BridgeTestContext bridgeTestContext) {
+        String topic = bridgeTestContext.getTopicName();
+        createTopic(bridgeTestContext, 1);
 
-        basicKafkaClient.sendStringMessagesPlain(topic, 10);
+        HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
+        HttpSeekService httpSeekService = new HttpSeekService(bridgeTestContext.getHttpService());
 
-        JsonObject jsonConsumer = new JsonObject();
-        jsonConsumer.put("name", name);
+        bridgeTestContext.getBasicKafkaClient().sendStringMessagesPlain(topic, 10);
 
-        JsonObject topics = new JsonObject();
-        topics.put("topics", new JsonArray().add(topic));
-        //create consumer
-        // subscribe to a topic
-        consumerService()
-                .createConsumer(context, groupId, jsonConsumer)
-                .subscribeConsumer(context, groupId, name, topics);
+        Map<String, Object> consumerConfig = Map.of("name", name);
 
-        CompletableFuture<Boolean> consume = new CompletableFuture<>();
+        // create consumer, subscribe to a topic
+        httpConsumerService.createConsumer(groupId, consumerConfig);
+        httpConsumerService.subscribeConsumer(groupId, name, topic);
+
         // consume records
-        consumerService()
-                .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_BINARY)
-                .as(BodyCodec.jsonArray())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        JsonArray body = ar.result().body();
-                        assertThat(body.size(), is(10));
-                    });
-                    consume.complete(true);
-                });
+        HttpResponse<String> consumeResponse = httpConsumerService.consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_BINARY);
+        ReceivedMessage[] messages = HttpResponseUtils.getReceivedMessagesFromResponse(consumeResponse.body());
+        assertThat(messages.length, is(10));
 
-        consume.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        // seek to beginning
+        Map<String, Object> partitionsBody = Map.of(
+            "partitions", List.of(
+                Map.of("topic", topic, "partition", 0)
+            )
+        );
 
-        // seek
-        JsonArray partitions = new JsonArray();
-        partitions.add(new JsonObject().put("topic", topic).put("partition", 0));
+        httpSeekService.seekToBeginning(groupId, name, partitionsBody);
 
-        JsonObject root = new JsonObject();
-        root.put("partitions", partitions);
-
-
-        CompletableFuture<Boolean> seek = new CompletableFuture<>();
-        seekService()
-                .positionsBeginningRequest(groupId, name, root)
-                .sendJsonObject(root)
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
-                    });
-                    seek.complete(true);
-                });
-
-        seek.get(TEST_TIMEOUT, TimeUnit.SECONDS);
-
-        CompletableFuture<Boolean> consumeSeek = new CompletableFuture<>();
-        // consume records
-        baseService()
-                .getRequest(Urls.consumerInstanceRecords(groupId, name))
-                .putHeader(ACCEPT.toString(), BridgeContentType.KAFKA_JSON_BINARY)
-                .as(BodyCodec.jsonArray())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        JsonArray body = ar.result().body();
-                        assertThat(body.size(), is(10));
-                    });
-                    consumeSeek.complete(true);
-                });
-
-        consumeSeek.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        // consume records again after seek
+        consumeResponse = httpConsumerService.consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_BINARY);
+        messages = HttpResponseUtils.getReceivedMessagesFromResponse(consumeResponse.body());
+        assertThat(messages.length, is(10));
 
         // consumer deletion
-        consumerService()
-                .deleteConsumer(context, groupId, name);
-
-        context.completeNow();
-        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+        httpConsumerService.deleteConsumer(groupId, name);
     }
 
     @Test
-    void seekToEndAndReceive(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        KafkaFuture<Void> future = adminClientFacade.createTopic(topic);
+    void seekToEndAndReceive(BridgeTestContext bridgeTestContext) {
+        String topic = bridgeTestContext.getTopicName();
+        createTopic(bridgeTestContext, 1);
 
-        JsonObject topics = new JsonObject();
-        topics.put("topics", new JsonArray().add(topic));
+        HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
+        HttpSeekService httpSeekService = new HttpSeekService(bridgeTestContext.getHttpService());
 
-        JsonObject jsonConsumer = new JsonObject();
-        jsonConsumer.put("name", name);
+        Map<String, Object> consumerConfig = Map.of("name", name);
 
-        future.get();
+        // create consumer, subscribe to a topic
+        httpConsumerService.createConsumer(groupId, consumerConfig);
+        httpConsumerService.subscribeConsumer(groupId, name, topic);
 
-        // create consumer
-        // subscribe to a topic
-        consumerService()
-                .createConsumer(context, groupId, jsonConsumer)
-                .subscribeConsumer(context, groupId, name, topic);
-
-        CompletableFuture<Boolean> dummy = new CompletableFuture<>();
         // dummy poll for having re-balancing starting
-        consumerService()
-                .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_BINARY)
-                .as(BodyCodec.jsonArray())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> assertThat(ar.succeeded(), is(true)));
-                    dummy.complete(true);
-                });
+        httpConsumerService.consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_BINARY);
 
-        dummy.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        bridgeTestContext.getBasicKafkaClient().sendStringMessagesPlain(topic, 10);
 
-        basicKafkaClient.sendStringMessagesPlain(topic, 10);
+        // seek to end
+        Map<String, Object> partitionsBody = Map.of(
+            "partitions", List.of(
+                Map.of("topic", topic, "partition", 0)
+            )
+        );
 
-        // seek
-        JsonArray partitions = new JsonArray();
-        partitions.add(new JsonObject().put("topic", topic).put("partition", 0));
+        httpSeekService.seekToEnd(groupId, name, partitionsBody);
 
-        JsonObject root = new JsonObject();
-        root.put("partitions", partitions);
-
-        CompletableFuture<Boolean> seek = new CompletableFuture<>();
-        seekService()
-                .positionsBeginningEnd(groupId, name, root)
-                .sendJsonObject(root)
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
-                    });
-                    seek.complete(true);
-                });
-
-        seek.get(TEST_TIMEOUT, TimeUnit.SECONDS);
-
-        CompletableFuture<Boolean> consumeSeek = new CompletableFuture<>();
-        // consume records
-        baseService()
-                .getRequest(Urls.consumerInstanceRecords(groupId, name))
-                .putHeader(ACCEPT.toString(), BridgeContentType.KAFKA_JSON_BINARY)
-                .as(BodyCodec.jsonArray())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> assertThat(ar.succeeded(), is(true)));
-
-                    JsonArray body = ar.result().body();
-                    assertThat(body.size(), is(0));
-                    consumeSeek.complete(true);
-                });
-
-        consumeSeek.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        // consume records after seek - should get nothing since we seeked to end
+        HttpResponse<String> consumeResponse = httpConsumerService.consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_BINARY);
+        ReceivedMessage[] messages = HttpResponseUtils.getReceivedMessagesFromResponse(consumeResponse.body());
+        assertThat(messages.length, is(0));
 
         // consumer deletion
-        consumerService()
-                .deleteConsumer(context, groupId, name);
-
-        context.completeNow();
+        httpConsumerService.deleteConsumer(groupId, name);
     }
 
     @Test
     @SuppressWarnings("checkstyle:MethodLength")
-    void seekToOffsetAndReceive(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
+    void seekToOffsetAndReceive(BridgeTestContext bridgeTestContext) {
+        String topic = "seekToOffsetAndReceive-" + bridgeTestContext.getTopicName();
+        createTopic(topic, bridgeTestContext.getAdminClientFacade(), 2);
 
-        String name = "my-kafka-consumer-SeekOffset";
-        JsonObject jsonConsumer = new JsonObject()
-            .put("name", name)
-            .put("format", "json");
+        HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
+        HttpSeekService httpSeekService = new HttpSeekService(bridgeTestContext.getHttpService());
 
-        final String topic = "seekToOffsetAndReceive";
+        bridgeTestContext.getBasicKafkaClient().sendJsonMessagesPlain(topic, 10, "value", 0);
+        bridgeTestContext.getBasicKafkaClient().sendJsonMessagesPlain(topic, 10, "value", 1);
 
-        KafkaFuture<Void> future = adminClientFacade.createTopic(topic, 2, 1);
-        future.get();
+        Map<String, Object> consumerConfig = Map.of("name", name, "format", "json");
 
-        basicKafkaClient.sendJsonMessagesPlain(topic, 10, "value", 0);
-        basicKafkaClient.sendJsonMessagesPlain(topic, 10, "value", 1);
+        // create consumer, subscribe to a topic
+        httpConsumerService.createConsumer(groupId, consumerConfig);
+        httpConsumerService.subscribeConsumer(groupId, name, topic);
 
-        JsonObject topics = new JsonObject();
-        topics.put("topics", new JsonArray().add(topic));
-        // create consumer
-        // subscribe to a topic
-        consumerService()
-                .createConsumer(context, groupId, jsonConsumer)
-                .subscribeConsumer(context, groupId, name, topics);
-
-        CompletableFuture<Boolean> dummy = new CompletableFuture<>();
         // dummy poll for having re-balancing starting
-        consumerService()
-                .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
-                .as(BodyCodec.jsonArray())
-                .send()
-                .onComplete(ar -> {
-                    assertThat(ar.succeeded(), is(true));
-                    dummy.complete(true);
-                });
-        dummy.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        httpConsumerService.consumeRecordsRequest(groupId, name);
 
-        CompletableFuture<Boolean> seek = new CompletableFuture<>();
-        // seek
-        JsonArray offsets = new JsonArray();
-        offsets.add(new JsonObject().put("topic", topic).put("partition", 0).put("offset", 9));
-        offsets.add(new JsonObject().put("topic", topic).put("partition", 1).put("offset", 5));
+        // seek to specific offsets
+        Map<String, Object> offsetsBody = Map.of(
+            "offsets", List.of(
+                Map.of("topic", topic, "partition", 0, "offset", 9),
+                Map.of("topic", topic, "partition", 1, "offset", 5)
+            )
+        );
 
-        JsonObject root = new JsonObject();
-        root.put("offsets", offsets);
+        httpSeekService.seekToPositions(groupId, name, offsetsBody);
 
-        seekService()
-                .positionsRequest(groupId, name, root)
-                .sendJsonObject(root)
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        assertThat(ar.result().statusCode(), is(HttpResponseStatus.NO_CONTENT.code()));
-                    });
-                    seek.complete(true);
-                });
-        seek.get(TEST_TIMEOUT, TimeUnit.SECONDS);
-
-        CompletableFuture<Boolean> consume = new CompletableFuture<>();
         // consume records
-        consumerService()
-                .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
-                .as(BodyCodec.jsonArray())
-                .send()
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        JsonArray body = ar.result().body();
+        HttpResponse<String> consumeResponse = httpConsumerService.consumeRecordsRequest(groupId, name);
+        ReceivedMessage[] messages = HttpResponseUtils.getReceivedMessagesFromResponse(consumeResponse.body());
 
-                        // check it read from partition 0, at offset 9, just one message
-                        List<JsonObject> metadata = body.stream()
-                                .map(JsonObject.class::cast)
-                                .filter(jo -> jo.getInteger("partition") == 0 && jo.getLong("offset") == 9)
-                                .collect(Collectors.toList());
-                        assertThat(metadata.isEmpty(), is(false));
-                        assertThat(metadata.size(), is(1));
+        // check it read from partition 0, at offset 9, just one message
+        List<ReceivedMessage> partition0Messages = Arrays.stream(messages)
+            .filter(m -> m.partition() == 0 && m.offset() == 9)
+            .toList();
+        assertThat(partition0Messages.isEmpty(), is(false));
+        assertThat(partition0Messages.size(), is(1));
 
-                        assertThat(metadata.get(0).getString("topic"), is(topic));
-                        assertThat(metadata.get(0).getString("value"), is("value-9"));
-                        assertThat(metadata.get(0).getString("key"), is("key-9"));
+        assertThat(partition0Messages.get(0).topic(), is(topic));
+        assertThat(partition0Messages.get(0).value(), is("value-9"));
+        assertThat(partition0Messages.get(0).key(), is("key-9"));
 
-                        // check it read from partition 1, starting from offset 5, the last 5 messages
-                        metadata = body.stream()
-                                .map(JsonObject.class::cast)
-                                .filter(jo -> jo.getInteger("partition") == 1)
-                                .toList();
-                        assertThat(metadata.isEmpty(), is(false));
-                        assertThat(metadata.size(), is(5));
+        // check it read from partition 1, starting from offset 5, the last 5 messages
+        List<ReceivedMessage> partition1Messages = Arrays.stream(messages)
+            .filter(m -> m.partition() == 1)
+            .toList();
+        assertThat(partition1Messages.isEmpty(), is(false));
+        assertThat(partition1Messages.size(), is(5));
 
-                        for (int i = 0; i < metadata.size(); i++) {
-                            assertThat(metadata.get(i).getString("topic"), is(topic));
-                            assertThat(metadata.get(i).getString("value"), is("value-" + (i + metadata.size())));
-                            assertThat(metadata.get(i).getString("key"), is("key-" + (i + metadata.size())));
-                        }
-                    });
-                    consume.complete(true);
-                });
-        consume.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        for (int i = 0; i < partition1Messages.size(); i++) {
+            assertThat(partition1Messages.get(i).topic(), is(topic));
+            assertThat(partition1Messages.get(i).value(), is("value-" + (i + partition1Messages.size())));
+            assertThat(partition1Messages.get(i).key(), is("key-" + (i + partition1Messages.size())));
+        }
 
         // consumer deletion
-        consumerService()
-                .deleteConsumer(context, groupId, name);
-
-        context.completeNow();
-        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+        httpConsumerService.deleteConsumer(groupId, name);
     }
 
     @Test
-    void seekToBeginningMultipleTopicsWithNotSubscribedTopic(VertxTestContext context) throws Exception {
-        String subscribedTopic = "seekToBeginningSubscribedTopic";
-        String notSubscribedTopic = "seekToBeginningNotSubscribedTopic";
+    void seekToBeginningMultipleTopicsWithNotSubscribedTopic(BridgeTestContext bridgeTestContext) throws Exception {
+        String subscribedTopic = "seekToBeginningSubscribedTopic-" + bridgeTestContext.getTopicName();
+        String notSubscribedTopic = "seekToBeginningNotSubscribedTopic-" + bridgeTestContext.getTopicName();
 
         LOGGER.info("Creating topics {}, {}", subscribedTopic, notSubscribedTopic);
 
-        KafkaFuture<Void> future1 = adminClientFacade.createTopic(subscribedTopic);
-        KafkaFuture<Void> future2 = adminClientFacade.createTopic(notSubscribedTopic);
+        createTopic(subscribedTopic, bridgeTestContext.getAdminClientFacade(), 1);
+        createTopic(notSubscribedTopic, bridgeTestContext.getAdminClientFacade(), 1);
 
-        JsonObject jsonConsumer = new JsonObject()
-                                    .put("name", name)
-                                    .put("format", "json");
+        HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
+        HttpSeekService httpSeekService = new HttpSeekService(bridgeTestContext.getHttpService());
 
-        JsonObject topics = new JsonObject()
-                                    .put("topics", new JsonArray().add(subscribedTopic));
+        Map<String, Object> consumerConfig = Map.of("name", name, "format", "json");
 
-        future1.get();
-        future2.get();
+        // create consumer, subscribe to a topic
+        httpConsumerService.createConsumer(groupId, consumerConfig);
+        httpConsumerService.subscribeConsumer(groupId, name, subscribedTopic);
 
-        // create consumer
-        // subscribe to a topic
-        consumerService()
-                .createConsumer(context, groupId, jsonConsumer)
-                .subscribeConsumer(context, groupId, name, topics);
+        waitUntilPartitionAssigned(httpConsumerService, groupId, name, 10, 2000);
 
-        waitUntilPartitionAssigned(consumerService(), groupId, name, 10, 2000);
+        // seek with subscribed and not-subscribed topic
+        Map<String, Object> partitionsBody = Map.of(
+            "partitions", List.of(
+                Map.of("topic", subscribedTopic, "partition", 0),
+                Map.of("topic", notSubscribedTopic, "partition", 0)
+            )
+        );
 
-        // seek
-        JsonArray partitions = new JsonArray();
-        partitions.add(new JsonObject().put("topic", subscribedTopic).put("partition", 0));
-        partitions.add(new JsonObject().put("topic", notSubscribedTopic).put("partition", 0));
+        HttpResponse<String> response = httpSeekService.seekToBeginningRequest(groupId, name, partitionsBody);
+        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
 
-        JsonObject root = new JsonObject();
-        root.put("partitions", partitions);
-
-        CompletableFuture<Boolean> seek = new CompletableFuture<>();
-        seekService()
-                .positionsBeginningRequest(groupId, name, root)
-                .sendJsonObject(root)
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-                        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.message(), is("No current assignment for partition " + notSubscribedTopic + "-0"));
-                    });
-                    seek.complete(true);
-                });
-        seek.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        HttpBridgeError error = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsMap(response.body()));
+        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
+        assertThat(error.message(), is("No current assignment for partition " + notSubscribedTopic + "-0"));
 
         // consumer deletion
-        consumerService()
-                .deleteConsumer(context, groupId, name);
-
-        context.completeNow();
-        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+        httpConsumerService.deleteConsumer(groupId, name);
     }
 
     /**
      * Waits until the Kafka consumer with the given name in the specified group has received
-     * a partition assignment. This method performs repeated polling using
-     * {@link ConsumerService#consumeRecordsRequest} to ensure that group coordination and
-     * partition assignment have completed before the test proceeds.
+     * a partition assignment by performing repeated polling.
      *
-     * @param consumerService   the {@link ConsumerService} instance used to interact with the consumer
-     * @param groupId           the Kafka consumer group ID
-     * @param name              the name of the consumer (within the group)
-     * @param maxRetries        maximum number of poll attempts before giving up
-     * @param delayMs           delay in milliseconds between retries
-     * @throws Exception        if partition assignment doesn't complete in time
+     * @param httpConsumerService   the {@link HttpConsumerService} instance used to interact with the consumer
+     * @param groupId               the Kafka consumer group ID
+     * @param name                  the name of the consumer (within the group)
+     * @param maxRetries            maximum number of poll attempts before giving up
+     * @param delayMs               delay in milliseconds between retries
+     * @throws Exception            if partition assignment doesn't complete in time
      */
-    void waitUntilPartitionAssigned(final ConsumerService consumerService,
+    void waitUntilPartitionAssigned(final HttpConsumerService httpConsumerService,
                                     final String groupId,
                                     final String name,
                                     final int maxRetries,
                                     final int delayMs) throws Exception {
-        int retries = 0;
-        while (retries < maxRetries) {
-            CompletableFuture<Boolean> pollComplete = new CompletableFuture<>();
-            consumerService.consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
-                .as(BodyCodec.jsonObject())
-                .send()
-                .onComplete(ar -> {
-                    // if here poll succeeded, then it means assignment is done
-                    pollComplete.complete(true);
-                });
-            boolean result = pollComplete.get(10, TimeUnit.SECONDS);
-            if (result) {
+        for (int retries = 0; retries < maxRetries; retries++) {
+            HttpResponse<String> response = httpConsumerService.consumeRecordsRequest(groupId, name);
+            if (response.statusCode() == HttpResponseStatus.OK.code()) {
                 return;
-            } else {
-                Thread.sleep(delayMs);
-                retries++;
             }
+            Thread.sleep(delayMs);
         }
         throw new TimeoutException("Timed out waiting for partition assignment for consumer " + groupId + "/" + name);
     }
 
     @Test
-    void seekToOffsetMultipleTopicsWithNotSubscribedTopic(VertxTestContext context) throws InterruptedException, ExecutionException, TimeoutException {
-        String subscribedTopic = "seekToOffsetSubscribedTopic";
-        String notSubscribedTopic = "seekToOffsetNotSubscribedTopic";
+    void seekToOffsetMultipleTopicsWithNotSubscribedTopic(BridgeTestContext bridgeTestContext) {
+        String subscribedTopic = "seekToOffsetSubscribedTopic-" + bridgeTestContext.getTopicName();
+        String notSubscribedTopic = "seekToOffsetNotSubscribedTopic-" + bridgeTestContext.getTopicName();
 
         LOGGER.info("Creating topics {}, {}", subscribedTopic, notSubscribedTopic);
 
-        KafkaFuture<Void> future1 = adminClientFacade.createTopic(subscribedTopic);
-        KafkaFuture<Void> future2 = adminClientFacade.createTopic(notSubscribedTopic);
+        createTopic(subscribedTopic, bridgeTestContext.getAdminClientFacade(), 1);
+        createTopic(notSubscribedTopic, bridgeTestContext.getAdminClientFacade(), 1);
 
-        JsonObject jsonConsumer = new JsonObject()
-                                    .put("name", name)
-                                    .put("format", "json");
+        HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
+        HttpSeekService httpSeekService = new HttpSeekService(bridgeTestContext.getHttpService());
 
-        JsonObject topics = new JsonObject()
-                                    .put("topics", new JsonArray().add(subscribedTopic));
+        Map<String, Object> consumerConfig = Map.of("name", name, "format", "json");
 
-        future1.get();
-        future2.get();
-
-        // create consumer
-        // subscribe to a topic
-        consumerService()
-                .createConsumer(context, groupId, jsonConsumer)
-                .subscribeConsumer(context, groupId, name, topics);
-
-        CompletableFuture<Boolean> consume = new CompletableFuture<>();
+        // create consumer, subscribe to a topic
+        httpConsumerService.createConsumer(groupId, consumerConfig);
+        httpConsumerService.subscribeConsumer(groupId, name, subscribedTopic);
 
         // poll to subscribe
-        consumerService()
-                .consumeRecordsRequest(groupId, name, BridgeContentType.KAFKA_JSON_JSON)
-                .as(BodyCodec.jsonObject())
-                .send()
-                .onComplete(ar -> consume.complete(true));
+        httpConsumerService.consumeRecordsRequest(groupId, name);
 
-        consume.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        // seek with subscribed and not-subscribed topic
+        Map<String, Object> offsetsBody = Map.of(
+            "offsets", List.of(
+                Map.of("topic", subscribedTopic, "partition", 0, "offset", 0),
+                Map.of("topic", notSubscribedTopic, "partition", 0, "offset", 0)
+            )
+        );
 
-        CompletableFuture<Boolean> seek = new CompletableFuture<>();
-        // seek
-        JsonArray offsets = new JsonArray();
-        offsets.add(new JsonObject().put("topic", subscribedTopic).put("partition", 0).put("offset", 0));
-        offsets.add(new JsonObject().put("topic", notSubscribedTopic).put("partition", 0).put("offset", 0));
+        HttpResponse<String> response = httpSeekService.seekToPositionsRequest(groupId, name, offsetsBody);
+        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
 
-        JsonObject root = new JsonObject();
-        root.put("offsets", offsets);
-
-        seekService()
-                .positionsRequest(groupId, name, root)
-                .sendJsonObject(root)
-                .onComplete(ar -> {
-                    context.verify(() -> {
-                        assertThat(ar.succeeded(), is(true));
-                        HttpResponse<JsonObject> response = ar.result();
-                        HttpBridgeError error = HttpBridgeError.fromJson(response.body());
-                        assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
-                        assertThat(error.message(), is("No current assignment for partition " + notSubscribedTopic + "-0"));
-                    });
-                    seek.complete(true);
-                });
-        seek.get(TEST_TIMEOUT, TimeUnit.SECONDS);
+        HttpBridgeError error = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsMap(response.body()));
+        assertThat(error.code(), is(HttpResponseStatus.NOT_FOUND.code()));
+        assertThat(error.message(), is("No current assignment for partition " + notSubscribedTopic + "-0"));
 
         // consumer deletion
-        consumerService()
-                .deleteConsumer(context, groupId, name);
-
-        context.completeNow();
-        assertThat(context.awaitCompletion(TEST_TIMEOUT, TimeUnit.SECONDS), is(true));
+        httpConsumerService.deleteConsumer(groupId, name);
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/SeekIT.java
@@ -4,6 +4,9 @@
  */
 package io.strimzi.kafka.bridge.http;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.extensions.BridgeSuite;
@@ -45,7 +48,7 @@ public class SeekIT extends AbstractIT {
     void seekToNotExistingConsumer(BridgeTestContext bridgeTestContext) {
         HttpSeekService httpSeekService = new HttpSeekService(bridgeTestContext.getHttpService());
 
-        Map<String, Object> emptyBody = Map.of();
+        JsonNode emptyBody = MAPPER.createObjectNode();
 
         HttpResponse<String> response = httpSeekService.seekToBeginningRequest(groupId, name, emptyBody);
         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
@@ -67,11 +70,9 @@ public class SeekIT extends AbstractIT {
 
         String notExistingTopic = "notExistingTopic";
 
-        Map<String, Object> partitionsBody = Map.of(
-            "partitions", List.of(
-                Map.of("topic", notExistingTopic, "partition", 0)
-            )
-        );
+        ObjectNode partitionsBody = MAPPER.createObjectNode();
+        partitionsBody.putArray("partitions")
+            .add(MAPPER.createObjectNode().put("topic", notExistingTopic).put("partition", 0));
 
         HttpResponse<String> response = httpSeekService.seekToBeginningRequest(groupId, name, partitionsBody);
         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
@@ -106,11 +107,9 @@ public class SeekIT extends AbstractIT {
         assertThat(messages.length, is(10));
 
         // seek to beginning
-        Map<String, Object> partitionsBody = Map.of(
-            "partitions", List.of(
-                Map.of("topic", topic, "partition", 0)
-            )
-        );
+        ObjectNode partitionsBody = MAPPER.createObjectNode();
+        partitionsBody.putArray("partitions")
+            .add(MAPPER.createObjectNode().put("topic", topic).put("partition", 0));
 
         httpSeekService.seekToBeginning(groupId, name, partitionsBody);
 
@@ -143,11 +142,9 @@ public class SeekIT extends AbstractIT {
         bridgeTestContext.getBasicKafkaClient().sendStringMessagesPlain(topic, 10);
 
         // seek to end
-        Map<String, Object> partitionsBody = Map.of(
-            "partitions", List.of(
-                Map.of("topic", topic, "partition", 0)
-            )
-        );
+        ObjectNode partitionsBody = MAPPER.createObjectNode();
+        partitionsBody.putArray("partitions")
+            .add(MAPPER.createObjectNode().put("topic", topic).put("partition", 0));
 
         httpSeekService.seekToEnd(groupId, name, partitionsBody);
 
@@ -182,12 +179,10 @@ public class SeekIT extends AbstractIT {
         httpConsumerService.consumeRecordsRequest(groupId, name);
 
         // seek to specific offsets
-        Map<String, Object> offsetsBody = Map.of(
-            "offsets", List.of(
-                Map.of("topic", topic, "partition", 0, "offset", 9),
-                Map.of("topic", topic, "partition", 1, "offset", 5)
-            )
-        );
+        ObjectNode offsetsBody = MAPPER.createObjectNode();
+        ArrayNode offsets = offsetsBody.putArray("offsets");
+        offsets.add(MAPPER.createObjectNode().put("topic", topic).put("partition", 0).put("offset", 9));
+        offsets.add(MAPPER.createObjectNode().put("topic", topic).put("partition", 1).put("offset", 5));
 
         httpSeekService.seekToPositions(groupId, name, offsetsBody);
 
@@ -245,12 +240,10 @@ public class SeekIT extends AbstractIT {
         waitUntilPartitionAssigned(httpConsumerService, groupId, name, 10, 2000);
 
         // seek with subscribed and not-subscribed topic
-        Map<String, Object> partitionsBody = Map.of(
-            "partitions", List.of(
-                Map.of("topic", subscribedTopic, "partition", 0),
-                Map.of("topic", notSubscribedTopic, "partition", 0)
-            )
-        );
+        ObjectNode partitionsBody = MAPPER.createObjectNode();
+        ArrayNode partitions = partitionsBody.putArray("partitions");
+        partitions.add(MAPPER.createObjectNode().put("topic", subscribedTopic).put("partition", 0));
+        partitions.add(MAPPER.createObjectNode().put("topic", notSubscribedTopic).put("partition", 0));
 
         HttpResponse<String> response = httpSeekService.seekToBeginningRequest(groupId, name, partitionsBody);
         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
@@ -312,12 +305,10 @@ public class SeekIT extends AbstractIT {
         httpConsumerService.consumeRecordsRequest(groupId, name);
 
         // seek with subscribed and not-subscribed topic
-        Map<String, Object> offsetsBody = Map.of(
-            "offsets", List.of(
-                Map.of("topic", subscribedTopic, "partition", 0, "offset", 0),
-                Map.of("topic", notSubscribedTopic, "partition", 0, "offset", 0)
-            )
-        );
+        ObjectNode offsetsBody = MAPPER.createObjectNode();
+        ArrayNode offsets = offsetsBody.putArray("offsets");
+        offsets.add(MAPPER.createObjectNode().put("topic", subscribedTopic).put("partition", 0).put("offset", 0));
+        offsets.add(MAPPER.createObjectNode().put("topic", notSubscribedTopic).put("partition", 0).put("offset", 0));
 
         HttpResponse<String> response = httpSeekService.seekToPositionsRequest(groupId, name, offsetsBody);
         assertThat(response.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));

--- a/src/test/java/io/strimzi/kafka/bridge/http/TlsIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/TlsIT.java
@@ -119,9 +119,7 @@ public class TlsIT extends AbstractIT {
 
     @Test
     void testManagementEndpointWhenSslEnabled(BridgeTestContext bridgeTestContext) {
-        HttpService managementService = new HttpService(bridgeTestContext.getBridgeHost(), bridgeTestContext.getBridgeManagementPort());
-
-        HttpResponse<String> httpResponse = managementService.get("/healthy");
+        HttpResponse<String> httpResponse = bridgeTestContext.getManagementHttpService().get("/healthy");
         assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
     }
 

--- a/src/test/java/io/strimzi/kafka/bridge/http/base/AbstractIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/base/AbstractIT.java
@@ -21,6 +21,7 @@ import java.util.Random;
 public abstract class AbstractIT {
     private static final Logger LOGGER = LogManager.getLogger(AbstractIT.class);
     protected static final int TEST_TIMEOUT = 60;
+    protected static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * The {@link Parameter} kafkaVersion here is needed because of the

--- a/src/test/java/io/strimzi/kafka/bridge/httpclient/HttpClientBaseService.java
+++ b/src/test/java/io/strimzi/kafka/bridge/httpclient/HttpClientBaseService.java
@@ -4,7 +4,8 @@
  */
 package io.strimzi.kafka.bridge.httpclient;
 
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Map;
 
@@ -41,5 +42,20 @@ public class HttpClientBaseService {
         }
 
         return jsonBody;
+    }
+
+    /**
+     * Serializes a {@link JsonNode} to a JSON string for use in HTTP request bodies.
+     *
+     * @param jsonNode   JsonNode to serialize.
+     *
+     * @return  JSON string representation.
+     */
+    protected String toJsonString(JsonNode jsonNode) {
+        try {
+            return objectMapper.writeValueAsString(jsonNode);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize JsonNode to JSON string");
+        }
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/httpclient/HttpSeekService.java
+++ b/src/test/java/io/strimzi/kafka/bridge/httpclient/HttpSeekService.java
@@ -4,13 +4,13 @@
  */
 package io.strimzi.kafka.bridge.httpclient;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.strimzi.kafka.bridge.BridgeContentType;
 import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
 import io.strimzi.kafka.bridge.utils.Endpoints;
 
 import java.net.http.HttpResponse;
-import java.util.Map;
 
 /**
  * Class containing methods for HTTP seek operations - for seeking consumer positions via the HTTP Bridge.
@@ -33,7 +33,7 @@ public class HttpSeekService extends HttpClientBaseService {
      * @param consumerName  name of the consumer.
      * @param body          request body containing offsets.
      */
-    public void seekToPositions(String groupId, String consumerName, Map<String, Object> body) {
+    public void seekToPositions(String groupId, String consumerName, JsonNode body) {
         HttpResponse<String> httpResponse = seekToPositionsRequest(groupId, consumerName, body);
 
         if (httpResponse.statusCode() != HttpResponseStatus.NO_CONTENT.code()) {
@@ -51,8 +51,8 @@ public class HttpSeekService extends HttpClientBaseService {
      *
      * @return  the response in {@link HttpResponse}.
      */
-    public HttpResponse<String> seekToPositionsRequest(String groupId, String consumerName, Map<String, Object> body) {
-        return httpService.post(Endpoints.consumerPositions(groupId, consumerName), parseJsonFromMap(body), null, BridgeContentType.KAFKA_JSON);
+    public HttpResponse<String> seekToPositionsRequest(String groupId, String consumerName, JsonNode body) {
+        return httpService.post(Endpoints.consumerPositions(groupId, consumerName), toJsonString(body), null, BridgeContentType.KAFKA_JSON);
     }
 
     /**
@@ -63,7 +63,7 @@ public class HttpSeekService extends HttpClientBaseService {
      * @param consumerName  name of the consumer.
      * @param body          request body containing partitions.
      */
-    public void seekToBeginning(String groupId, String consumerName, Map<String, Object> body) {
+    public void seekToBeginning(String groupId, String consumerName, JsonNode body) {
         HttpResponse<String> httpResponse = seekToBeginningRequest(groupId, consumerName, body);
 
         if (httpResponse.statusCode() != HttpResponseStatus.NO_CONTENT.code()) {
@@ -81,8 +81,8 @@ public class HttpSeekService extends HttpClientBaseService {
      *
      * @return  the response in {@link HttpResponse}.
      */
-    public HttpResponse<String> seekToBeginningRequest(String groupId, String consumerName, Map<String, Object> body) {
-        return httpService.post(Endpoints.consumerPositionsBeginning(groupId, consumerName), parseJsonFromMap(body), null, BridgeContentType.KAFKA_JSON);
+    public HttpResponse<String> seekToBeginningRequest(String groupId, String consumerName, JsonNode body) {
+        return httpService.post(Endpoints.consumerPositionsBeginning(groupId, consumerName), toJsonString(body), null, BridgeContentType.KAFKA_JSON);
     }
 
     /**
@@ -93,7 +93,7 @@ public class HttpSeekService extends HttpClientBaseService {
      * @param consumerName  name of the consumer.
      * @param body          request body containing partitions.
      */
-    public void seekToEnd(String groupId, String consumerName, Map<String, Object> body) {
+    public void seekToEnd(String groupId, String consumerName, JsonNode body) {
         HttpResponse<String> httpResponse = seekToEndRequest(groupId, consumerName, body);
 
         if (httpResponse.statusCode() != HttpResponseStatus.NO_CONTENT.code()) {
@@ -111,7 +111,7 @@ public class HttpSeekService extends HttpClientBaseService {
      *
      * @return  the response in {@link HttpResponse}.
      */
-    public HttpResponse<String> seekToEndRequest(String groupId, String consumerName, Map<String, Object> body) {
-        return httpService.post(Endpoints.consumerPositionsEnd(groupId, consumerName), parseJsonFromMap(body), null, BridgeContentType.KAFKA_JSON);
+    public HttpResponse<String> seekToEndRequest(String groupId, String consumerName, JsonNode body) {
+        return httpService.post(Endpoints.consumerPositionsEnd(groupId, consumerName), toJsonString(body), null, BridgeContentType.KAFKA_JSON);
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/httpclient/HttpSeekService.java
+++ b/src/test/java/io/strimzi/kafka/bridge/httpclient/HttpSeekService.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.kafka.bridge.httpclient;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.strimzi.kafka.bridge.BridgeContentType;
+import io.strimzi.kafka.bridge.http.model.HttpBridgeError;
+import io.strimzi.kafka.bridge.utils.Endpoints;
+
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+/**
+ * Class containing methods for HTTP seek operations - for seeking consumer positions via the HTTP Bridge.
+ */
+public class HttpSeekService extends HttpClientBaseService {
+    /**
+     * Default constructor for the {@link HttpSeekService}.
+     *
+     * @param httpService   {@link HttpService} pointing to running Bridge instance.
+     */
+    public HttpSeekService(HttpService httpService) {
+        super(httpService);
+    }
+
+    /**
+     * Seeks consumer to specified positions (offsets).
+     * Verifies that the response status is 204 NO_CONTENT.
+     *
+     * @param groupId       group ID to which consumer belongs to.
+     * @param consumerName  name of the consumer.
+     * @param body          request body containing offsets.
+     */
+    public void seekToPositions(String groupId, String consumerName, Map<String, Object> body) {
+        HttpResponse<String> httpResponse = seekToPositionsRequest(groupId, consumerName, body);
+
+        if (httpResponse.statusCode() != HttpResponseStatus.NO_CONTENT.code()) {
+            HttpBridgeError httpBridgeError = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsMap(httpResponse.body()));
+            throw new RuntimeException("Failed to seek to positions due to: " + httpBridgeError.message());
+        }
+    }
+
+    /**
+     * Sends a seek-to-positions request and returns the raw response.
+     *
+     * @param groupId       group ID to which consumer belongs to.
+     * @param consumerName  name of the consumer.
+     * @param body          request body containing offsets.
+     *
+     * @return  the response in {@link HttpResponse}.
+     */
+    public HttpResponse<String> seekToPositionsRequest(String groupId, String consumerName, Map<String, Object> body) {
+        return httpService.post(Endpoints.consumerPositions(groupId, consumerName), parseJsonFromMap(body), null, BridgeContentType.KAFKA_JSON);
+    }
+
+    /**
+     * Seeks consumer to the beginning of specified partitions.
+     * Verifies that the response status is 204 NO_CONTENT.
+     *
+     * @param groupId       group ID to which consumer belongs to.
+     * @param consumerName  name of the consumer.
+     * @param body          request body containing partitions.
+     */
+    public void seekToBeginning(String groupId, String consumerName, Map<String, Object> body) {
+        HttpResponse<String> httpResponse = seekToBeginningRequest(groupId, consumerName, body);
+
+        if (httpResponse.statusCode() != HttpResponseStatus.NO_CONTENT.code()) {
+            HttpBridgeError httpBridgeError = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsMap(httpResponse.body()));
+            throw new RuntimeException("Failed to seek to beginning due to: " + httpBridgeError.message());
+        }
+    }
+
+    /**
+     * Sends a seek-to-beginning request and returns the raw response.
+     *
+     * @param groupId       group ID to which consumer belongs to.
+     * @param consumerName  name of the consumer.
+     * @param body          request body containing partitions.
+     *
+     * @return  the response in {@link HttpResponse}.
+     */
+    public HttpResponse<String> seekToBeginningRequest(String groupId, String consumerName, Map<String, Object> body) {
+        return httpService.post(Endpoints.consumerPositionsBeginning(groupId, consumerName), parseJsonFromMap(body), null, BridgeContentType.KAFKA_JSON);
+    }
+
+    /**
+     * Seeks consumer to the end of specified partitions.
+     * Verifies that the response status is 204 NO_CONTENT.
+     *
+     * @param groupId       group ID to which consumer belongs to.
+     * @param consumerName  name of the consumer.
+     * @param body          request body containing partitions.
+     */
+    public void seekToEnd(String groupId, String consumerName, Map<String, Object> body) {
+        HttpResponse<String> httpResponse = seekToEndRequest(groupId, consumerName, body);
+
+        if (httpResponse.statusCode() != HttpResponseStatus.NO_CONTENT.code()) {
+            HttpBridgeError httpBridgeError = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsMap(httpResponse.body()));
+            throw new RuntimeException("Failed to seek to end due to: " + httpBridgeError.message());
+        }
+    }
+
+    /**
+     * Sends a seek-to-end request and returns the raw response.
+     *
+     * @param groupId       group ID to which consumer belongs to.
+     * @param consumerName  name of the consumer.
+     * @param body          request body containing partitions.
+     *
+     * @return  the response in {@link HttpResponse}.
+     */
+    public HttpResponse<String> seekToEndRequest(String groupId, String consumerName, Map<String, Object> body) {
+        return httpService.post(Endpoints.consumerPositionsEnd(groupId, consumerName), parseJsonFromMap(body), null, BridgeContentType.KAFKA_JSON);
+    }
+}

--- a/src/test/java/io/strimzi/kafka/bridge/httpclient/HttpService.java
+++ b/src/test/java/io/strimzi/kafka/bridge/httpclient/HttpService.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-public class HttpService {
+public class HttpService implements AutoCloseable {
     private static final Logger LOGGER = LogManager.getLogger(HttpService.class);
 
     private HttpClient client;
@@ -144,5 +144,12 @@ public class HttpService {
 
     public String getUri(String endpoint) {
         return baseUri + endpoint;
+    }
+
+    @Override
+    public void close() {
+        if (client != null) {
+            client.close();
+        }
     }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/objects/BridgeTestContext.java
+++ b/src/test/java/io/strimzi/kafka/bridge/objects/BridgeTestContext.java
@@ -21,11 +21,11 @@ public class BridgeTestContext {
 
     private String topicName;
     private HttpService httpService;
+    private HttpService managementHttpService;
     private AdminClientFacade adminClientFacade;
     private BasicKafkaClient basicKafkaClient;
     private String bridgeHost;
     private int bridgePort;
-    private int bridgeManagementPort;
 
     /**
      * Constructor for creating variables and services for particular {@param extensionContext}.
@@ -35,11 +35,11 @@ public class BridgeTestContext {
     public BridgeTestContext(ExtensionContext extensionContext) {
         topicName = "my-topic-" + RNG.nextInt(Integer.MAX_VALUE);
         httpService = BridgeExtension.getHttpService(extensionContext);
+        managementHttpService = BridgeExtension.getManagementHttpService(extensionContext);
         adminClientFacade = AdminClientFacade.create(KafkaExtension.getKafkaCluster(extensionContext).getBootstrapServers());
         basicKafkaClient = new BasicKafkaClient(KafkaExtension.getKafkaCluster(extensionContext).getBootstrapServers());
         bridgeHost = BridgeExtension.getBridgeHost(extensionContext);
         bridgePort = BridgeExtension.getBridgePort(extensionContext);
-        bridgeManagementPort = BridgeExtension.getBridgeManagementPort(extensionContext);
     }
 
     /**
@@ -56,6 +56,14 @@ public class BridgeTestContext {
      */
     public HttpService getHttpService() {
         return httpService;
+    }
+
+    /**
+     * Returns management {@link HttpService}.
+     * @return management {@link HttpService}.
+     */
+    public HttpService getManagementHttpService() {
+        return managementHttpService;
     }
 
     /**
@@ -86,11 +94,4 @@ public class BridgeTestContext {
         return bridgePort;
     }
 
-    /**
-     * Returns the bridge management port.
-     * @return the bridge management port.
-     */
-    public int getBridgeManagementPort() {
-        return bridgeManagementPort;
-    }
 }

--- a/src/test/java/io/strimzi/kafka/bridge/utils/Endpoints.java
+++ b/src/test/java/io/strimzi/kafka/bridge/utils/Endpoints.java
@@ -13,6 +13,9 @@ public class Endpoints {
     private static final String RECORDS_ENDPOINT = "/records";
     private static final String ASSIGNMENTS_ENDPOINT = "/assignments";
     private static final String OFFSETS_ENDPOINT = "/offsets";
+    private static final String POSITIONS_ENDPOINT = "/positions";
+    private static final String POSITIONS_BEGINNING_ENDPOINT = "/positions/beginning";
+    private static final String POSITIONS_END_ENDPOINT = "/positions/end";
 
     public static String consumerInstance(String groupId, String consumerName) {
         return CONSUMERS_ENDPOINT + groupId + INSTANCES_ENDPOINT + consumerName;
@@ -44,6 +47,18 @@ public class Endpoints {
 
     public static String consumerOffsets(String groupId, String consumerName) {
         return consumerInstance(groupId, consumerName) + OFFSETS_ENDPOINT;
+    }
+
+    public static String consumerPositions(String groupId, String consumerName) {
+        return consumerInstance(groupId, consumerName) + POSITIONS_ENDPOINT;
+    }
+
+    public static String consumerPositionsBeginning(String groupId, String consumerName) {
+        return consumerInstance(groupId, consumerName) + POSITIONS_BEGINNING_ENDPOINT;
+    }
+
+    public static String consumerPositionsEnd(String groupId, String consumerName) {
+        return consumerInstance(groupId, consumerName) + POSITIONS_END_ENDPOINT;
     }
 
     public static String topic(String topicName) {


### PR DESCRIPTION
This PR refactors `MetricsIT` and `SeekIT`. 
The only class left now is the `ProducerIT` which will be done in separate PR.
It also adds the separate `HttpSeekService` (similar to how it is done until now), to not add more of the methods to the `HttpConsumerService` class.
Also, because I decided to have the management service in the `BridgeTestContext` (as it is used in the SeekIT) I decided to remove the management port key etc. and change it in the previous classes (OtherServicesIT and TlsIT)

It also fixes some issues with leaking connections to the Bridge and Kafka, which weren't closed in Kafka clients and HTTP services.