### PR TITLE
Fixed disabling of metrics for Vert.x pools

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -126,9 +126,9 @@ public class Application {
             .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
             // define the labels on the HTTP server related metrics
             .setLabels(EnumSet.of(Label.HTTP_PATH, Label.HTTP_METHOD, Label.HTTP_CODE))
-            // disable metrics about pool and verticles
+            // disable metrics about Vert.x pools
             .setDisabledMetricsCategories(
-                Set.of(MetricsDomain.NAMED_POOLS.name(), MetricsDomain.VERTICLES.name())
+                Set.of(MetricsDomain.NAMED_POOLS.toCategory())
             ).setJvmMetricsEnabled(true)
             .setEnabled(true);
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes a bug around the disabling of metrics for Vert.x pools.
Disabling such metrics is based on the "category" and not on the "name" (as checked within the internal Vert.x code) but the current code was passing the name.
Also this PR removes filtering for Vert.x verticals metrics because deprecated and marked for removal (or goal was anyway disabling such metrics internally).

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests