### PR TITLE
Bump vertx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0
 
-* Dependency updates (Kafka 4.3.0, Vert.x 5.1.1, Netty 4.2.15.Final, JMX Prometheus collector 1.6.0)
+* Dependency updates (Kafka 4.3.0, Vert.x 5.1.2, Netty 4.2.15.Final, JMX Prometheus collector 1.6.0)
 
 ## 1.0.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
 		<!-- Runtime dependencies -->
 		<log4j.version>2.25.4</log4j.version>
-		<vertx.version>5.1.1</vertx.version>
+		<vertx.version>5.1.2</vertx.version>
 		<netty.version>4.2.15.Final</netty.version>
 		<kafka.version>4.3.0</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps Vert.x 5.1.2. No need for Netty which stays the same.