### PR TITLE
Bumped Micrometere to fix CVE-2026-40984

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0
 
-* Dependency updates (Kafka 4.3.0, Vert.x 5.1.2, Netty 4.2.15.Final, JMX Prometheus collector 1.6.0)
+* Dependency updates (Kafka 4.3.0, Vert.x 5.1.2, Netty 4.2.15.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984))
 
 ## 1.0.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
 		<opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version>
 		<grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
-		<micrometer.version>1.14.5</micrometer.version>
+		<micrometer.version>1.16.6</micrometer.version>
 		<jmx-prometheus-collector.version>1.6.0</jmx-prometheus-collector.version>
 		<prometheus.version>1.3.6</prometheus.version>
 		<commons-cli.version>1.4</commons-cli.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR aligns the Micrometer version to what is used within Vert.x Micrometer, so 1.16.6. The alignment allows to fix the [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984) as well.