### PR TITLE
Bump OpenTelemetry and SemConv to fix CVE-2026-45292

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0
 
-* Dependency updates (Kafka 4.3.0, Vert.x 5.1.2, Netty 4.2.15.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984))
+* Dependency updates (Kafka 4.3.0, Vert.x 5.1.2, Netty 4.2.15.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha)
 
 ## 1.0.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,9 @@
 		<fasterxml.jackson-databind.version>2.21.2</fasterxml.jackson-databind.version>
 		<strimzi-oauth.version>0.17.1</strimzi-oauth.version>
 		<strimzi-metrics-reporter.version>0.3.0</strimzi-metrics-reporter.version>
-		<opentelemetry.version>1.34.1</opentelemetry.version>
-		<opentelemetry-alpha.version>1.34.1-alpha</opentelemetry-alpha.version>
+		<opentelemetry.version>1.63.0</opentelemetry.version>
 		<opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
-		<opentelemetry-semconv.version>1.21.0-alpha</opentelemetry-semconv.version>
+		<opentelemetry-semconv.version>1.28.0-alpha</opentelemetry-semconv.version>
 		<grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
 		<micrometer.version>1.16.6</micrometer.version>
 		<jmx-prometheus-collector.version>1.6.0</jmx-prometheus-collector.version>
@@ -197,6 +196,11 @@
 			<version>${opentelemetry-semconv.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>io.opentelemetry.semconv</groupId>
+			<artifactId>opentelemetry-semconv-incubating</artifactId>
+			<version>${opentelemetry-semconv.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>io.opentelemetry.instrumentation</groupId>
 			<artifactId>opentelemetry-kafka-clients-2.6</artifactId>
 			<version>${opentelemetry.instrumentation.version}</version>
@@ -220,7 +224,7 @@
 		<dependency>
 			<groupId>io.opentelemetry</groupId>
 			<artifactId>opentelemetry-exporter-sender-jdk</artifactId>
-			<version>${opentelemetry-alpha.version}</version>
+			<version>${opentelemetry.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
@@ -20,7 +20,10 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperation;
 import io.opentelemetry.instrumentation.kafkaclients.v2_6.TracingProducerInterceptor;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.ServerAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
 import io.strimzi.kafka.bridge.config.BridgeConfig;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -47,11 +50,11 @@ class OpenTelemetryHandle implements TracingHandle {
     private Tracer tracer;
 
     static void setCommonAttributes(SpanBuilder builder, RoutingContext routingContext) {
-        builder.setAttribute(SemanticAttributes.PEER_SERVICE, KAFKA_SERVICE);
-        builder.setAttribute(SemanticAttributes.HTTP_REQUEST_METHOD, routingContext.request().method().name());
-        builder.setAttribute(SemanticAttributes.URL_SCHEME, routingContext.request().scheme());
-        builder.setAttribute(SemanticAttributes.URL_PATH, routingContext.request().path());
-        builder.setAttribute(SemanticAttributes.URL_QUERY, routingContext.request().query());
+        builder.setAttribute(ServerAttributes.SERVER_ADDRESS, KAFKA_SERVICE);
+        builder.setAttribute(HttpAttributes.HTTP_REQUEST_METHOD, routingContext.request().method().name());
+        builder.setAttribute(UrlAttributes.URL_SCHEME, routingContext.request().scheme());
+        builder.setAttribute(UrlAttributes.URL_PATH, routingContext.request().path());
+        builder.setAttribute(UrlAttributes.URL_QUERY, routingContext.request().query());
     }
 
     @Override
@@ -96,8 +99,8 @@ class OpenTelemetryHandle implements TracingHandle {
     public <K, V> void handleRecordSpan(ConsumerRecord<K, V> record) {
         String operationName = record.topic() + " " + MessageOperation.RECEIVE.name().toLowerCase(Locale.ROOT);
         SpanBuilder spanBuilder = get().spanBuilder(operationName);
-        spanBuilder.setAttribute(SemanticAttributes.MESSAGING_DESTINATION_NAME, record.topic());
-        spanBuilder.setAttribute(SemanticAttributes.MESSAGING_SYSTEM, "kafka");
+        spanBuilder.setAttribute(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, record.topic());
+        spanBuilder.setAttribute(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "kafka");
         Context parentContext = propagator().extract(Context.current(), TracingUtil.toHeaders(record), MG);
         if (parentContext != null) {
             Span parentSpan = Span.fromContext(parentContext);
@@ -182,7 +185,7 @@ class OpenTelemetryHandle implements TracingHandle {
         @Override
         public void finish(int code) {
             try {
-                span.setAttribute(SemanticAttributes.HTTP_RESPONSE_STATUS_CODE, code);
+                span.setAttribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, code);
                 // OK status is fine for all 2xx HTTP status codes
                 span.setStatus(code >= 200 && code < 300 ? StatusCode.OK : StatusCode.ERROR);
                 scope.close();
@@ -194,7 +197,7 @@ class OpenTelemetryHandle implements TracingHandle {
         @Override
         public void finish(int code, Throwable cause) {
             try {
-                span.setAttribute(SemanticAttributes.HTTP_RESPONSE_STATUS_CODE, code);
+                span.setAttribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, code);
                 span.setStatus(code == HttpResponseStatus.OK.code() ? StatusCode.OK : StatusCode.ERROR);
                 span.recordException(cause);
                 scope.close();


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps OpenTelemetry to latest 1.63.0 to address https://nvd.nist.gov/vuln/detail/CVE-2026-45292 and also the corresponding compatible semconv.
We could argue the bridge is not affected because the CVE is related to the Baggage feature we don't use in the bridge but, because it has been long time using a very old version, I would prefer to finally bump and staying more up to date.

### Checklist

- [x] Update CHANGELOG.md (if present)
- [x] Make sure all tests pass