### PR TITLE
Bumped grpc-netty-shaded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<opentelemetry.version>1.63.0</opentelemetry.version>
 		<opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>
 		<opentelemetry-semconv.version>1.28.0-alpha</opentelemetry-semconv.version>
-		<grpc-netty-shaded.version>1.75.0</grpc-netty-shaded.version>
+		<grpc-netty-shaded.version>1.79.0</grpc-netty-shaded.version>
 		<micrometer.version>1.16.6</micrometer.version>
 		<jmx-prometheus-collector.version>1.6.0</jmx-prometheus-collector.version>
 		<prometheus.version>1.3.6</prometheus.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

Trivial PR to bump to a most up to date grpc-netty-shaded to be aligned with other grpc deps brought by new OTel.

### Checklist

- [x] Make sure all tests pass