### PR TITLE
Bump central-publishing-maven-plugin due to Maven Central API changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<maven.gpg.version>3.0.1</maven.gpg.version>
 		<maven.checkstyle.version>3.5.0</maven.checkstyle.version>
 		<maven.jar.version>3.3.0</maven.jar.version>
-		<central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+		<central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
 		<maven.spotbugs.version>4.7.3.4</maven.spotbugs.version>
 		<openapi.generator.version>7.8.0</openapi.generator.version>
 


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps version for central-publishing-maven-plugin after some JSON schema changes on the Maven Central API.