### PR TITLE
Added checkstyle rule on not using fully qualified names

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -41,6 +41,14 @@
             <property name="separateLineBetweenGroups" value="false"/>
         </module>
 
+        <!-- Require imports instead of inline fully-qualified class names -->
+        <module name="RegexpSinglelineJava">
+            <property name="id" value="NoFullyQualifiedClassNames"/>
+            <property name="format" value="^(?!\s*(?:import|package)\b).*?(?&lt;![\w.&quot;])(?:[a-z][a-zA-Z0-9_]*\.){2,}[A-Z][a-zA-Z0-9_]*"/>
+            <property name="message" value="Use an import instead of a fully qualified class name in code."/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
         <!-- style -->
         <module name="DefaultComesLast"/>
         <module name="EmptyStatement"/>

--- a/src/test/java/io/strimzi/kafka/bridge/config/ConfigTest.java
+++ b/src/test/java/io/strimzi/kafka/bridge/config/ConfigTest.java
@@ -145,6 +145,7 @@ public class ConfigTest {
     }
 
     @Test
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     public void testStrimziReporterMetricsType() {
         // using HashMap because with metrics configuration additional properties will be added on load
         // NOTE: Map.of() is immutable so can't be used directly in this case
@@ -164,6 +165,7 @@ public class ConfigTest {
     }
 
     @Test
+    @SuppressWarnings("checkstyle:NoFullyQualifiedClassNames") // False positive, fully qualified class name used in a string
     public void testStrimziReporterWithCustomConfig() {
         // using HashMap because with metrics configuration additional properties will be added on load
         // NOTE: Map.of() is immutable so can't be used directly in this case


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR was inspired by a corresponding one on the operator https://github.com/strimzi/strimzi-kafka-operator/pull/12869  and adds a check for use of fully qualified class names in the code instead of importing them to the Checkstyle configuration.

### Checklist

- [x] Make sure all tests pass