### PR TITLE
Bump Vert.x and Netty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0
 
-* Dependency updates (Kafka 4.3.1, Vert.x 5.1.3, Netty 4.2.15.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha)
+* Dependency updates (Kafka 4.3.1, Vert.x 5.1.4, Netty 4.2.16.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha)
 
 ## 1.0.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
 
 		<!-- Runtime dependencies -->
 		<log4j.version>2.25.4</log4j.version>
-		<vertx.version>5.1.3</vertx.version>
-		<netty.version>4.2.15.Final</netty.version>
+		<vertx.version>5.1.4</vertx.version>
+		<netty.version>4.2.16.Final</netty.version>
 		<kafka.version>4.3.1</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This PR bumps Vert.x 5.1.4 and Netty 4.2.16.Final.