### PR TITLE
Bumped log4j version to address CVE-2026-49844

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0
 
-* Dependency updates (Kafka 4.3.1, Vert.x 5.1.5, Netty 4.2.16.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha)
+* Dependency updates (Kafka 4.3.1, Vert.x 5.1.5, Netty 4.2.16.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha, Log4j2 [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844))
 
 ## 1.0.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<spotbugs.version>4.7.3</spotbugs.version>
 
 		<!-- Runtime dependencies -->
-		<log4j.version>2.25.4</log4j.version>
+		<log4j.version>2.25.5</log4j.version>
 		<vertx.version>5.1.5</vertx.version>
 		<netty.version>4.2.16.Final</netty.version>
 		<kafka.version>4.3.1</kafka.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

Trivial PR to bump log4j version to address [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844)