### PR TITLE
Fixed the script to get GC options and Terabytes to `to_byte` script

### DIFF
--- a/bin/docker/kafka_bridge_run.sh
+++ b/bin/docker/kafka_bridge_run.sh
@@ -39,13 +39,7 @@ export MALLOC_ARENA_MAX=2
 # Configure GC logging for memory tracking
 function get_gc_opts {
   if [ "${STRIMZI_GC_LOG_ENABLED}" == "true" ]; then
-    # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
-    JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-    if [ "$JAVA_MAJOR_VERSION" -ge "9" ] ; then
-      echo "-Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
-    else
-      echo "-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:NativeMemoryTracking=summary"
-    fi
+    echo "-Xlog:gc*:stdout:time -XX:NativeMemoryTracking=summary"
   else
     # no gc options
     echo ""

--- a/bin/docker/to_bytes.gawk
+++ b/bin/docker/to_bytes.gawk
@@ -4,8 +4,9 @@ BEGIN {
   suffixes["K"]=1024
   suffixes["M"]=1024**2
   suffixes["G"]=1024**3
+  suffixes["T"]=1024**4
 }
 
-match($0, /([0-9.]*)([kKmMgG]?)/, a) {
+match($0, /([0-9.]*)([kKmMgGtT]?)/, a) {
   printf("%d", a[1] * suffixes[toupper(a[2])])
 }


### PR DESCRIPTION
### Type of change

- Task

### Description

The `get_gc_opts` still had an old check on Java 9 which is not supported anymore.
This PR aligns the function to what we use within the Strimzi operator without such check.
It also add the support for Terabytes to the 'to_byte.gawk` script as for the Strimzi operator.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests