### PR TITLE
Fixed bug on deleting more than one inactive consumers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0
 
 * Dependency updates (Kafka 4.3.1, Vert.x 5.1.5, Netty 4.2.16.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha, Log4j2 [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844))
+* Fixed bug on deleting more than one inactive consumers.
 
 ## 1.0.0
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -207,7 +207,7 @@ public class HttpBridge extends AbstractVerticle {
                         deleteSinkEndpoint.close();
                         this.httpBridgeContext.getHttpSinkEndpoints().remove(item.getKey());
                         LOGGER.warn("Consumer {} deleted after inactivity timeout ({}s).", item.getKey(), timeout);
-                        timestampMap.remove(item.getKey());
+                        it.remove();
                     }
                 }
             }

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -1090,6 +1090,41 @@ public class ConsumerIT extends AbstractIT {
     }
 
     @Test
+    void multipleConsumersDeletedAfterInactivity(BridgeTestContext bridgeTestContext) throws InterruptedException {
+        HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
+
+        String consumer1Name = generateRandomConsumerName();
+        String consumer2Name = generateRandomConsumerName();
+        String consumer3Name = generateRandomConsumerName();
+
+        ObjectNode consumer1Config = MAPPER.createObjectNode().put("name", consumer1Name).put("format", "json");
+        ObjectNode consumer2Config = MAPPER.createObjectNode().put("name", consumer2Name).put("format", "json");
+        ObjectNode consumer3Config = MAPPER.createObjectNode().put("name", consumer3Name).put("format", "json");
+
+        assertThat(httpConsumerService.createConsumerRequest(groupId, consumer1Config).statusCode(), is(HttpResponseStatus.OK.code()));
+        assertThat(httpConsumerService.createConsumerRequest(groupId, consumer2Config).statusCode(), is(HttpResponseStatus.OK.code()));
+        assertThat(httpConsumerService.createConsumerRequest(groupId, consumer3Config).statusCode(), is(HttpResponseStatus.OK.code()));
+
+        Thread.sleep(Constants.DEFAULT_CONSUMER_TIMEOUT * 2 * 1000);
+
+        // All 3 consumers should be gone, trying to delete them should return 404.
+        HttpResponse<String> httpResponse = httpConsumerService.deleteConsumer(groupId, consumer1Name);
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
+        HttpBridgeError httpBridgeError = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsJsonNode(httpResponse.body()));
+        assertThat(httpBridgeError.message(), is("The specified consumer instance was not found."));
+
+        httpResponse = httpConsumerService.deleteConsumer(groupId, consumer2Name);
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
+        httpBridgeError = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsJsonNode(httpResponse.body()));
+        assertThat(httpBridgeError.message(), is("The specified consumer instance was not found."));
+
+        httpResponse = httpConsumerService.deleteConsumer(groupId, consumer3Name);
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.NOT_FOUND.code()));
+        httpBridgeError = HttpBridgeError.fromJson(HttpResponseUtils.getResponseAsJsonNode(httpResponse.body()));
+        assertThat(httpBridgeError.message(), is("The specified consumer instance was not found."));
+    }
+
+    @Test
     void receiveSimpleMessageTopicCreatedAfterAssignTest(BridgeTestContext bridgeTestContext) {
         HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

While doing some tests for the next release, I found the following bug when multiple inactive consumers are detected.
The inactivity timer in `HttpBridge.startInactiveConsumerDeletionTimer()` used `timestampMap.remove()` while iterating over the map's entry set with an Iterator. This throws `ConcurrentModificationException` when more than one stale consumer is found in the same timer tick, because `HashMap.remove()` increments the map's internal modification counter without updating the iterator, so the next `it.next()` call detects the mismatch and throws. As a result, only one stale consumer is deleted per tick, and the rest survive until subsequent ticks clean them up one at a time. Replaced with `it.remove()` to safely remove entries during iteration, so all stale consumers are deleted in a single pass.
In general, when using an Iterator, it should be used for any interaction within the corresponding HashMap and not the map instance itself.

### Checklist

- [x] Update CHANGELOG.md (if present)
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
