### PR TITLE
Used Base64 class for encoding/decoding messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
 		<jmx-prometheus-collector.version>1.6.0</jmx-prometheus-collector.version>
 		<prometheus.version>1.3.6</prometheus.version>
 		<commons-cli.version>1.4</commons-cli.version>
-		<jakarta.version>2.3.2</jakarta.version>
 		<snakeyaml.version>2.5</snakeyaml.version>
 		<guava.version>32.1.3-jre</guava.version>
 
@@ -169,11 +168,6 @@
 			<groupId>io.strimzi</groupId>
 			<artifactId>kafka-oauth-client</artifactId>
 			<version>${strimzi-oauth.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.xml.bind</groupId>
-			<artifactId>jakarta.xml.bind-api</artifactId>
-			<version>${jakarta.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
@@ -17,8 +17,8 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -40,10 +40,10 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
 
         if (!json.isEmpty()) {
             if (json.has("key")) {
-                key = DatatypeConverter.parseBase64Binary(json.get("key").asText());
+                key = Base64.getDecoder().decode(json.get("key").asText());
             }
             if (json.has("value")) {
-                value = DatatypeConverter.parseBase64Binary(json.get("value").asText());
+                value = Base64.getDecoder().decode(json.get("value").asText());
             }
             if (json.has("timestamp")) {
                 timestamp = json.get("timestamp").asLong();
@@ -51,7 +51,7 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
             if (json.has("headers")) {
                 ArrayNode jsonArray = (ArrayNode) json.get("headers");
                 for (JsonNode jsonObject: jsonArray) {
-                    headers.add(new RecordHeader(jsonObject.get("key").asText(), DatatypeConverter.parseBase64Binary(jsonObject.get("value").asText())));
+                    headers.add(new RecordHeader(jsonObject.get("key").asText(), Base64.getDecoder().decode(jsonObject.get("value").asText())));
                 }
             }
             if (json.has("partition")) {
@@ -98,9 +98,9 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
 
             jsonObject.put("topic", record.topic());
             jsonObject.put("key", record.key() != null ?
-                    DatatypeConverter.printBase64Binary(record.key()) : null);
+                    Base64.getEncoder().encodeToString(record.key()) : null);
             jsonObject.put("value", record.value() != null ?
-                    DatatypeConverter.printBase64Binary(record.value()) : null);
+                    Base64.getEncoder().encodeToString(record.value()) : null);
             jsonObject.put("partition", record.partition());
             jsonObject.put("offset", record.offset());
             jsonObject.put("timestamp", record.timestamp());
@@ -111,7 +111,7 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
                 ObjectNode header = JsonUtils.createObjectNode();
 
                 header.put("key", kafkaHeader.key());
-                header.put("value", DatatypeConverter.printBase64Binary(kafkaHeader.value()));
+                header.put("value", Base64.getEncoder().encodeToString(kafkaHeader.value()));
 
                 headers.add(header);
             }

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
@@ -17,8 +17,8 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -51,7 +51,7 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
             if (json.has("headers")) {
                 ArrayNode jsonArray = (ArrayNode) json.get("headers");
                 for (JsonNode jsonObject : jsonArray) {
-                    headers.add(new RecordHeader(jsonObject.get("key").asText(), DatatypeConverter.parseBase64Binary(jsonObject.get("value").asText())));
+                    headers.add(new RecordHeader(jsonObject.get("key").asText(), Base64.getDecoder().decode(jsonObject.get("value").asText())));
                 }
             }
             if (json.has("partition")) {
@@ -110,7 +110,7 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
                 ObjectNode header = JsonUtils.createObjectNode();
 
                 header.put("key", kafkaHeader.key());
-                header.put("value", DatatypeConverter.printBase64Binary(kafkaHeader.value()));
+                header.put("value", Base64.getEncoder().encodeToString(kafkaHeader.value()));
 
                 headers.add(header);
             }

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
@@ -17,9 +17,9 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
-import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -58,7 +58,7 @@ public class HttpTextMessageConverter implements MessageConverter<byte[], byte[]
             if (json.has("headers")) {
                 ArrayNode jsonArray = (ArrayNode) json.get("headers");
                 for (JsonNode jsonObject : jsonArray) {
-                    headers.add(new RecordHeader(jsonObject.get("key").asText(), DatatypeConverter.parseBase64Binary(jsonObject.get("value").asText())));
+                    headers.add(new RecordHeader(jsonObject.get("key").asText(), Base64.getDecoder().decode(jsonObject.get("value").asText())));
                 }
             }
             if (json.has("partition")) {
@@ -113,7 +113,7 @@ public class HttpTextMessageConverter implements MessageConverter<byte[], byte[]
                 ObjectNode header = JsonUtils.createObjectNode();
 
                 header.set("key", new TextNode(kafkaHeader.key()));
-                header.put("value", DatatypeConverter.printBase64Binary(kafkaHeader.value()));
+                header.put("value", Base64.getEncoder().encodeToString(kafkaHeader.value()));
                 headers.add(header);
             }
             if (!headers.isEmpty()) {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.DatatypeConverter;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -517,15 +517,15 @@ public class ConsumerIT extends AbstractIT {
         JsonNode messageHeaders = receivedMessage.get("headers");
         assertThat(messageHeaders.size(), is(3));
         assertThat(messageHeaders.get(0).get("key").asText(), is("key1"));
-        assertThat(new String(DatatypeConverter.parseBase64Binary(
+        assertThat(new String(Base64.getDecoder().decode(
             messageHeaders.get(0).get("value").asText())), is("value1"));
 
         assertThat(messageHeaders.get(1).get("key").asText(), is("key2"));
-        assertThat(new String(DatatypeConverter.parseBase64Binary(
+        assertThat(new String(Base64.getDecoder().decode(
             messageHeaders.get(1).get("value").asText())), is("value2"));
 
         assertThat(messageHeaders.get(2).get("key").asText(), is("key3"));
-        assertThat(new String(DatatypeConverter.parseBase64Binary(
+        assertThat(new String(Base64.getDecoder().decode(
             messageHeaders.get(2).get("value").asText())), is("value3"));
 
         // consumer deletion


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The three message converters use `javax.xml.bind.DatatypeConverter` for Base64 encoding and decoding.
This class was part of the `javax.xml.bind` package, which was deprecated in Java 9 and removed from the JDK in Java 11. The project carried the `jakarta.xml.bind-api` dependency solely to provide this class.

This PR replaces all usages with `java.util.Base64`, allowing to remove the `jakarta.xml.bind-api` dependency.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests