### PR TITLE
Bump Vert.x and Netty versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
 
 		<!-- Runtime dependencies -->
 		<log4j.version>2.25.5</log4j.version>
-		<vertx.version>5.1.5</vertx.version>
-		<netty.version>4.2.16.Final</netty.version>
+		<vertx.version>5.1.6</vertx.version>
+		<netty.version>4.2.17.Final</netty.version>
 		<kafka.version>4.3.1</kafka.version>
 		<kafka-kubernetes-config-provider.version>1.2.2</kafka-kubernetes-config-provider.version>
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

This trivial PR bumps Vert.x 5.1.6 and corresponding Netty 4.2.17.Final with bug and vulnerabilities fixes.