### PR TITLE
Fixed Java constructor warnings

### DIFF
--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -77,6 +77,8 @@
         <module name="StaticVariableName"/>
         <module name="TypeName"/>
         <module name="AvoidStarImport"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="MissingCtor"/>
 
         <!-- dependencies -->
         <!--<module name="ImportControl">

--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -16,4 +16,7 @@
 
     <!-- Skip Javadoc checks for tests-->
     <suppress checks="JavadocMethod|JavaDocType|JavadocVariable|MissingJavadocType|MissingJavadocMethod" files="src[/\\]test[/\\]java[/\\].*"/>
+
+    <!-- Do not require constructors in test classes -->
+    <suppress checks="MissingCtor|HideUtilityClassConstructor" files="src[/\\]test[/\\]java[/\\].*"/>
 </suppressions>

--- a/src/main/java/io/strimzi/kafka/bridge/Application.java
+++ b/src/main/java/io/strimzi/kafka/bridge/Application.java
@@ -37,6 +37,8 @@ import java.util.Set;
 public class Application {
     private static final Logger LOGGER = LogManager.getLogger(Application.class);
 
+    private Application() { }
+
     /**
      * Bridge entrypoint
      *

--- a/src/main/java/io/strimzi/kafka/bridge/BridgeContentType.java
+++ b/src/main/java/io/strimzi/kafka/bridge/BridgeContentType.java
@@ -24,4 +24,6 @@ public class BridgeContentType {
 
     /** JSON encoding */
     public static final String JSON = "application/json";
+
+    private BridgeContentType() { }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/LoggingPartitionsRebalance.java
+++ b/src/main/java/io/strimzi/kafka/bridge/LoggingPartitionsRebalance.java
@@ -19,6 +19,11 @@ import java.util.Collection;
 public class LoggingPartitionsRebalance implements ConsumerRebalanceListener {
     private static final Logger LOGGER = LogManager.getLogger(LoggingPartitionsRebalance.class);
 
+    /**
+     * Constructor
+     */
+    public LoggingPartitionsRebalance() { }
+
     @Override
     public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
         LOGGER.debug("Partitions revoked {}", partitions.size());

--- a/src/main/java/io/strimzi/kafka/bridge/config/ConfigRetriever.java
+++ b/src/main/java/io/strimzi/kafka/bridge/config/ConfigRetriever.java
@@ -18,6 +18,8 @@ import java.util.stream.Collectors;
  */
 public class ConfigRetriever {
 
+    private ConfigRetriever() { }
+
     /**
      * Retrieve the bridge configuration from the properties file provided as parameter
      * and adding environment variables

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
@@ -26,6 +26,11 @@ public class HttpBridgeContext<K, V> {
     private HttpOpenApiOperations openApiOperation;
 
     /**
+     * Constructor
+     */
+    public HttpBridgeContext() { }
+
+    /**
      * Get the map of the HTTP sink endpoints.
      *
      * @return map of the HTTP sink endpoints

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeExecutor.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeExecutor.java
@@ -35,6 +35,8 @@ public class HttpBridgeExecutor {
     private static class HttpBridgeThreadFactory implements ThreadFactory {
         private final AtomicInteger counter = new AtomicInteger(0);
 
+        HttpBridgeThreadFactory() { }
+
         @Override
         public Thread newThread(Runnable r) {
             Thread t = new Thread(r);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeExecutor.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeExecutor.java
@@ -26,6 +26,8 @@ public class HttpBridgeExecutor {
 
     private static Counter rejectedTasksCounter;
 
+    private HttpBridgeExecutor() { }
+
     /**
      * Custom ThreadFactory for Kafka-related asynchronous operations.
      * Creates named, non-daemon threads with uncaught exception handling.

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpUtils.java
@@ -18,6 +18,8 @@ import org.apache.logging.log4j.Logger;
 public class HttpUtils {
     private static final Logger LOGGER = LogManager.getLogger(HttpUtils.class);
 
+    private HttpUtils() { }
+
     /**
      * Send an HTTP response
      *

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
@@ -27,6 +27,11 @@ import java.util.List;
 @SuppressWarnings("checkstyle:NPathComplexity")
 public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte[], byte[], byte[]> {
 
+    /**
+     * Constructor
+     */
+    public HttpBinaryMessageConverter() { }
+
     @Override
     public ProducerRecord<byte[], byte[]> toKafkaRecord(String kafkaTopic, Integer partition, byte[] message) {
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
@@ -27,6 +27,11 @@ import java.util.List;
 @SuppressWarnings("checkstyle:NPathComplexity")
 public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[], byte[], byte[]> {
 
+    /**
+     * Constructor
+     */
+    public HttpJsonMessageConverter() { }
+
     @Override
     public ProducerRecord<byte[], byte[]> toKafkaRecord(String kafkaTopic, Integer partition, byte[] message) {
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
@@ -27,6 +27,12 @@ import java.util.List;
  */
 @SuppressWarnings("checkstyle:NPathComplexity")
 public class HttpTextMessageConverter implements MessageConverter<byte[], byte[], byte[], byte[]> {
+
+    /**
+     * Constructor
+     */
+    public HttpTextMessageConverter() { }
+
     @Override
     public ProducerRecord<byte[], byte[]> toKafkaRecord(String kafkaTopic, Integer partition, byte[] message) {
         Integer partitionFromBody = null;

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/JsonUtils.java
@@ -23,6 +23,8 @@ public class JsonUtils {
      */
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    private JsonUtils() { }
+
     /**
      * Get the JSON representation of the provided bytes array
      *

--- a/src/main/java/io/strimzi/kafka/bridge/metrics/MetricsCollector.java
+++ b/src/main/java/io/strimzi/kafka/bridge/metrics/MetricsCollector.java
@@ -25,6 +25,9 @@ public abstract class MetricsCollector {
     }
 
     private static class MetricsNamingConvention extends PrometheusNamingConvention {
+
+        MetricsNamingConvention() { }
+
         @Override
         public String name(String name, Meter.Type type, String baseUnit) {
             String metricName = name.startsWith("vertx.") ? name.replace("vertx.", "strimzi.bridge.") : name;

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/NoopTracingHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/NoopTracingHandle.java
@@ -13,6 +13,9 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import java.util.Properties;
 
 final class NoopTracingHandle implements TracingHandle {
+
+    NoopTracingHandle() { }
+
     @Override
     public String envServiceName() {
         return null;
@@ -41,6 +44,9 @@ final class NoopTracingHandle implements TracingHandle {
     }
 
     private static final class NoopSpanHandle<K, V> implements SpanHandle<K, V> {
+
+        NoopSpanHandle() { }
+
         @Override
         public void inject(ProducerRecord<K, V> record) {
         }

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/OpenTelemetryHandle.java
@@ -47,6 +47,8 @@ import static io.strimzi.kafka.bridge.tracing.TracingConstants.OPENTELEMETRY_SER
  */
 class OpenTelemetryHandle implements TracingHandle {
 
+    OpenTelemetryHandle() { }
+
     private Tracer tracer;
 
     static void setCommonAttributes(SpanBuilder builder, RoutingContext routingContext) {

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/TracingConstants.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/TracingConstants.java
@@ -22,4 +22,6 @@ public final class TracingConstants {
     public static final String OPENTELEMETRY_SERVICE_NAME_ENV_KEY = "OTEL_SERVICE_NAME";
     /** OpenTelemetry service name system property */
     public static final String OPENTELEMETRY_SERVICE_NAME_PROPERTY_KEY = "otel.service.name";
+
+    private TracingConstants() { }
 }

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/TracingUtil.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/TracingUtil.java
@@ -27,6 +27,8 @@ public class TracingUtil {
     private static final Logger LOGGER = LogManager.getLogger(TracingUtil.class);
     private static TracingHandle tracing = new NoopTracingHandle();
 
+    private TracingUtil() { }
+
     /**
      * Get the current tracing instance.
      *


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

At is was already done in the Strimzi operator with https://github.com/strimzi/strimzi-kafka-operator/pull/12302, this PR fixes the warnings raised by Java compiler when constructors are missing Javadocs.
This PR adds constructors to all our classes (private for utility classes, public for public classes etc.) to avoid these warnings. It also adds rules to the checkstyles.

### Checklist

- [x] Make sure all tests pass
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
