### PR TITLE
Fixes and refactoring some dead code

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/ConsumerInstanceId.java
+++ b/src/main/java/io/strimzi/kafka/bridge/ConsumerInstanceId.java
@@ -34,11 +34,11 @@ public class ConsumerInstanceId {
             return false;
         }
 
-        if (groupId != null && !groupId.equals(other.groupId)) {
+        if (groupId != null ? !groupId.equals(other.groupId) : other.groupId != null) {
             return false;
         }
 
-        if (instanceId != null && !instanceId.equals(other.instanceId)) {
+        if (instanceId != null ? !instanceId.equals(other.instanceId) : other.instanceId != null) {
             return false;
         }
 

--- a/src/main/java/io/strimzi/kafka/bridge/converter/MessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/converter/MessageConverter.java
@@ -5,7 +5,6 @@
 
 package io.strimzi.kafka.bridge.converter;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
@@ -40,15 +39,6 @@ public interface MessageConverter<K, V, M, C> {
      * @return Kafka records
      */
     List<ProducerRecord<K, V>> toKafkaRecords(String kafkaTopic, Integer partition, C messages);
-
-    /**
-     * Converts a Kafka record to a message
-     *
-     * @param address address for sending message
-     * @param record Kafka record to convert
-     * @return message
-     */
-    M toMessage(String address, ConsumerRecord<K, V> record);
 
     /**
      * Converts Kafka records to a collection of messages

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpAdminBridgeEndpoint.java
@@ -336,7 +336,7 @@ public class HttpAdminBridgeEndpoint extends HttpBridgeEndpoint {
             Throwable e = null;
             if (t != null && t.getCause() instanceof UnknownTopicOrPartitionException) {
                 e = t;
-            } else if (topicDescriptions.get(topicName).partitions().size() <= partitionId) {
+            } else if (t == null && topicDescriptions.get(topicName).partitions().size() <= partitionId) {
                 e = new UnknownTopicOrPartitionException("Topic '" + topicName + "' does not have partition with id " + partitionId);
             }
             if (e != null) {

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpConfig.java
@@ -189,12 +189,7 @@ public class HttpConfig extends AbstractConfig {
      * @return set of SSL enabled protocols
      */
     public Set<String> getHttpServerSslEnabledProtocols() {
-        String protocols = (String) this.config.getOrDefault(HTTP_SERVER_SSL_ENABLED_PROTOCOLS, DEFAULT_SSL_ENABLED_PROTOCOLS);
-        if (protocols != null) {
-            return Arrays.stream(protocols.split(",")).collect(Collectors.toSet());
-        } else {
-            return null;
-        }
+        return Arrays.stream(((String) this.config.getOrDefault(HTTP_SERVER_SSL_ENABLED_PROTOCOLS, DEFAULT_SSL_ENABLED_PROTOCOLS)).split(",")).collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
@@ -88,11 +88,6 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
     }
 
     @Override
-    public byte[] toMessage(String address, ConsumerRecord<byte[], byte[]> record) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public byte[] toMessages(ConsumerRecords<byte[], byte[]> records) {
 
         ArrayNode jsonArray = JsonUtils.createArrayNode();

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
@@ -87,11 +87,6 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
     }
 
     @Override
-    public byte[] toMessage(String address, ConsumerRecord<byte[], byte[]> record) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public byte[] toMessages(ConsumerRecords<byte[], byte[]> records) {
 
         ArrayNode jsonArray = JsonUtils.createArrayNode();

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
@@ -95,11 +95,6 @@ public class HttpTextMessageConverter implements MessageConverter<byte[], byte[]
     }
 
     @Override
-    public byte[] toMessage(String address, ConsumerRecord<byte[], byte[]> record) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public byte[] toMessages(ConsumerRecords<byte[], byte[]> records) {
         ArrayNode jsonArray = JsonUtils.createArrayNode();
 

--- a/src/main/java/io/strimzi/kafka/bridge/tracing/TracingConstants.java
+++ b/src/main/java/io/strimzi/kafka/bridge/tracing/TracingConstants.java
@@ -20,8 +20,6 @@ public final class TracingConstants {
 
     /** OpenTelemetry service name env var */
     public static final String OPENTELEMETRY_SERVICE_NAME_ENV_KEY = "OTEL_SERVICE_NAME";
-    /** OpenTelemetry service name system property */
-    public static final String OPENTELEMETRY_SERVICE_NAME_PROPERTY_KEY = "otel.service.name";
 
     private TracingConstants() { }
 }


### PR DESCRIPTION
### Type of change

- Bugfix
- Refactoring

### Description

This PR fixes some trivial things:

* Fix NPE in `HttpAdminBridgeEndpoint.doGetOffsets` when `describeTopics` fails with a non UnknownTopicOrPartitionException error.
* Fix `equals()` symmetry violation in `ConsumerInstanceId` when groupId or instanceId is null. A null field was matching any non-null value, breaking the equals contract and causing inconsistency with hashCode.
* Remove dead `toMessage()` method from `MessageConverter` interface and all implementations. It was a left over from the usage within the AMQP bridge part.
* Remove unused `OPENTELEMETRY_SERVICE_NAME_PROPERTY_KEY` constant from `TracingConstants`.
* Remove redundant null check in `HttpConfig.getHttpServerSslEnabledProtocols` because `getOrDefault` is called with a non-null default so the result can never be null.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
