### PR TITLE
Fixed bug on message header with null value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Dependency updates (Kafka 4.3.1, Vert.x 5.1.6, Netty 4.2.17.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha, Log4j2 [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844))
 * Fixed bug on deleting more than one inactive consumers.
+* Fixed bug on message header with null value.
 
 ## 1.0.0
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpBinaryMessageConverter.java
@@ -111,7 +111,7 @@ public class HttpBinaryMessageConverter implements MessageConverter<byte[], byte
                 ObjectNode header = JsonUtils.createObjectNode();
 
                 header.put("key", kafkaHeader.key());
-                header.put("value", Base64.getEncoder().encodeToString(kafkaHeader.value()));
+                header.put("value", kafkaHeader.value() != null ? Base64.getEncoder().encodeToString(kafkaHeader.value()) : null);
 
                 headers.add(header);
             }

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpJsonMessageConverter.java
@@ -110,7 +110,7 @@ public class HttpJsonMessageConverter implements MessageConverter<byte[], byte[]
                 ObjectNode header = JsonUtils.createObjectNode();
 
                 header.put("key", kafkaHeader.key());
-                header.put("value", Base64.getEncoder().encodeToString(kafkaHeader.value()));
+                header.put("value", kafkaHeader.value() != null ? Base64.getEncoder().encodeToString(kafkaHeader.value()) : null);
 
                 headers.add(header);
             }

--- a/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/converter/HttpTextMessageConverter.java
@@ -114,7 +114,7 @@ public class HttpTextMessageConverter implements MessageConverter<byte[], byte[]
                 ObjectNode header = JsonUtils.createObjectNode();
 
                 header.set("key", new TextNode(kafkaHeader.key()));
-                header.put("value", Base64.getEncoder().encodeToString(kafkaHeader.value()));
+                header.put("value", kafkaHeader.value() != null ? Base64.getEncoder().encodeToString(kafkaHeader.value()) : null);
                 headers.add(header);
             }
             if (!headers.isEmpty()) {

--- a/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
+++ b/src/test/java/io/strimzi/kafka/bridge/http/ConsumerIT.java
@@ -532,6 +532,54 @@ public class ConsumerIT extends AbstractIT {
         httpConsumerService.deleteConsumer(groupId, name);
     }
 
+    @Test
+    void receiveSimpleMessageWithNullValueHeader(BridgeTestContext bridgeTestContext) {
+        HttpConsumerService httpConsumerService = new HttpConsumerService(bridgeTestContext.getHttpService());
+
+        bridgeTestContext.getAdminClientFacade().createTopic(bridgeTestContext.getTopicName(), 1);
+
+        String sentBody = "Simple message";
+        List<Header> headers = new ArrayList<>();
+        headers.add(new RecordHeader("key1", "value1".getBytes()));
+        headers.add(new RecordHeader("key-with-null-value", null));
+        headers.add(new RecordHeader("key3", "value3".getBytes()));
+
+        bridgeTestContext.getBasicKafkaClient().sendJsonMessagesPlain(bridgeTestContext.getTopicName(), 1, headers, sentBody, true);
+
+        // create consumer
+        // subscribe to a topic
+        httpConsumerService.createConsumer(groupId, consumer);
+        httpConsumerService.subscribeConsumer(groupId, name, bridgeTestContext.getTopicName());
+
+        HttpResponse<String> httpResponse = httpConsumerService.consumeRecordsRequest(groupId, name);
+
+        // The bridge should handle null header values gracefully.
+        assertThat(httpResponse.statusCode(), is(HttpResponseStatus.OK.code()));
+
+        JsonNode receivedMessage = HttpResponseUtils.getResponseAsJsonNode(httpResponse.body()).get(0);
+
+        assertThat(receivedMessage.get("topic").asText(), is(bridgeTestContext.getTopicName()));
+        assertThat(receivedMessage.get("value").asText(), is(sentBody));
+        assertThat(receivedMessage.get("key").isNull(), is(true));
+
+        JsonNode messageHeaders = receivedMessage.get("headers");
+        assertThat(messageHeaders.size(), is(3));
+
+        assertThat(messageHeaders.get(0).get("key").asText(), is("key1"));
+        assertThat(new String(Base64.getDecoder().decode(
+            messageHeaders.get(0).get("value").asText())), is("value1"));
+
+        assertThat(messageHeaders.get(1).get("key").asText(), is("key-with-null-value"));
+        assertThat(messageHeaders.get(1).get("value").isNull(), is(true));
+
+        assertThat(messageHeaders.get(2).get("key").asText(), is("key3"));
+        assertThat(new String(Base64.getDecoder().decode(
+            messageHeaders.get(2).get("value").asText())), is("value3"));
+
+        // consumer deletion
+        httpConsumerService.deleteConsumer(groupId, name);
+    }
+
     @Disabled("Implement it at some point in the future :)")
     @Test
     void receiveBinaryMessage(BridgeTestContext bridgeTestContext) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Kafka headers can have a null value (e.g., new RecordHeader("trace-id", null)).
When an HTTP consumer polls a message containing such a header, all three message converters pass `kafkaHeader.value()` directly to `Base64.getEncoder().encodeToString()`, which throws a NullPointerException.
Because `pollHandler` only catches `JsonDecodeException`, the NPE propagates unhandled into the `CompletableFuture` chain and no HTTP response is ever sent, and the client connection hangs indefinitely.
This PR fixes it. When the header value is null, the JSON output contains null instead of a Base64-encoded string.
It also adds a new IT test that was missing to validate such scenario.

### Checklist

- [x] Update CHANGELOG.md (if present)
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
