### PR TITLE
Fixed timeout and max_bytes query parameters not resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Dependency updates (Kafka 4.3.1, Vert.x 5.1.6, Netty 4.2.17.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha, Log4j2 [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844))
 * Fixed bug on deleting more than one inactive consumers.
 * Fixed bug on message header with null value.
+* Fixed poll timeout and max_bytes query parameters not resetting to defaults when omitted on subsequent consumer poll requests.
 
 ## 1.0.0
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpSinkBridgeEndpoint.java
@@ -388,13 +388,11 @@ public class HttpSinkBridgeEndpoint<K, V> extends HttpBridgeEndpoint {
         // check that the accepted body by the client is the same as the format on creation
         if (accept != null && this.checkAcceptedBody(accept)) {
 
-            if (routingContext.request().getParam("timeout") != null) {
-                this.pollTimeOut = Long.parseLong(routingContext.request().getParam("timeout"));
-            }
+            this.pollTimeOut = routingContext.request().getParam("timeout") != null
+                    ? Long.parseLong(routingContext.request().getParam("timeout")) : 100;
 
-            if (routingContext.request().getParam("max_bytes") != null) {
-                this.maxBytes = Long.parseLong(routingContext.request().getParam("max_bytes"));
-            }
+            this.maxBytes = routingContext.request().getParam("max_bytes") != null
+                    ? Long.parseLong(routingContext.request().getParam("max_bytes")) : Long.MAX_VALUE;
 
             // fulfilling the request in a separate thread to free the Vert.x event loop still in place
             CompletableFuture.supplyAsync(() -> {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When a consumer poll request included `?timeout=` or `?max_bytes=` query parameters, their values were stored in instance fields but never reset to defaults when omitted on subsequent requests using the same endpoint.
This caused the values from an earlier poll to silently use the same value for all following polls on the same consumer, leading to unexpected behavior.
This PR fixes the bug and resets both fields to their defaults (100 ms and Long.MAX_VALUE) on every poll request when the corresponding query parameter is not provided.

### Checklist

- [x] Update CHANGELOG.md (if present)
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests