### PR TITLE
Bump strimzi/github-actions to v2.3 and pin all actions by SHA digest

### DIFF
--- a/.github/actions/build/build-docs/action.yml
+++ b/.github/actions/build/build-docs/action.yml
@@ -15,12 +15,12 @@ runs:
   using: "composite"
   steps:
     - name: Install yq
-      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@v1
+      uses: strimzi/github-actions/.github/actions/dependencies/install-yq@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
       with:
         architecture: ${{ inputs.runnerArch }}
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: '3.2'
         
@@ -39,7 +39,7 @@ runs:
       run: tar -cvpf documentation.tar ./documentation/html ./documentation/htmlnoheader
       
     - name: Upload documentation artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifactName }}
         path: documentation.tar

--- a/.github/actions/build/publish-docs/action.yml
+++ b/.github/actions/build/publish-docs/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Download documentation artifact
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifactName }}
         path: ./

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,15 +29,15 @@ jobs:
             mainBuild: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Java and Maven
-        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
+        uses: strimzi/github-actions/.github/actions/dependencies/setup-java@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           javaVersion: ${{ matrix.java.version }}
 
       - name: Build binaries using build-binaries action
-        uses: strimzi/github-actions/.github/actions/build/build-binaries@v1
+        uses: strimzi/github-actions/.github/actions/build/build-binaries@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           mainJavaBuild: ${{ matrix.java.mainBuild }}
           artifactSuffix: "kafka-bridge"
@@ -48,7 +48,7 @@ jobs:
       - build-kafka-bridge
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/build/build-docs
         with:
           artifactName: "documentation.tar"
@@ -67,18 +67,18 @@ jobs:
           - ppc64le
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@v1
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           architecture: ${{ matrix.architecture }}
           artifactSuffix: "kafka-bridge"
           containerRegistry: "quay.io"
           containerOrg: "strimzi"
           containerTag: "latest"
-          imagesDir: "kafka-bridge-${{ matrix.architecture }}.tar.gz"
+          imagesLocation: "kafka-bridge-${{ matrix.architecture }}.tar.gz"
 
   push-containers:
     name: Push Containers
@@ -91,13 +91,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
+        with:
+          version: "1.20.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/push-containers@v1
+      - uses: strimzi/github-actions/.github/actions/build/push-containers@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           architectures: "amd64,arm64,ppc64le,s390x"
           containerRegistry: "quay.io"
@@ -116,7 +118,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/build/publish-docs
         with:
           artifactName: "documentation.tar"
@@ -130,13 +132,13 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/setup-java@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           javaVersion: "21"
 
-      - uses: strimzi/github-actions/.github/actions/build/deploy-java@v1
+      - uses: strimzi/github-actions/.github/actions/build/deploy-java@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           gpgPassphrase: ${{ secrets.GPG_PASSPHRASE }}
           gpgSigningKey: ${{ secrets.GPG_SIGNING_KEY }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     
     # Setup OpenJDK 21
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: 'temurin'
         java-version: '21'
@@ -51,7 +51,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +62,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -76,4 +76,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -29,10 +29,10 @@ jobs:
     permissions:
       packages: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup ORAS
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
 
       - name: Login to GHCR
         run: echo "${{ github.token }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -45,7 +45,7 @@ jobs:
           REPOSITORY: "strimzi"
 
       - name: Upload as workflow artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binaries-kafka-bridge.tar
           path: binaries-kafka-bridge.tar
@@ -64,18 +64,18 @@ jobs:
           - ppc64le
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
 
-      - uses: strimzi/github-actions/.github/actions/build/build-containers@v1
+      - uses: strimzi/github-actions/.github/actions/build/build-containers@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           architecture: ${{ matrix.architecture }}
           artifactSuffix: "kafka-bridge"
           containerRegistry: "quay.io"
           containerOrg: "strimzi"
           containerTag: "latest"
-          imagesDir: "kafka-bridge-${{ matrix.architecture }}.tar.gz"
+          imagesLocation: "kafka-bridge-${{ matrix.architecture }}.tar.gz"
 
   push-containers-with-suffix:
     name: Push Containers (${{ inputs.releaseVersion }}-${{ inputs.releaseSuffix }})
@@ -88,13 +88,15 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
+        with:
+          version: "1.20.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/push-containers@v1
+      - uses: strimzi/github-actions/.github/actions/build/push-containers@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           architectures: "amd64,arm64,ppc64le,s390x"
           containerRegistry: "quay.io"
@@ -130,13 +132,15 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
+        with:
+          version: "1.20.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/push-containers@v1
+      - uses: strimzi/github-actions/.github/actions/build/push-containers@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           architectures: "amd64,arm64,ppc64le,s390x"
           containerRegistry: "quay.io"

--- a/.github/workflows/github-actions-integration.yml
+++ b/.github/workflows/github-actions-integration.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   test-github-actions-integration:
-    uses: strimzi/github-actions/.github/workflows/reusable-test-integrations.yml@v1
+    uses: strimzi/github-actions/.github/workflows/reusable-test-integrations.yml@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
     with:
       repo: ${{ github.repository }}
       ref: ${{ github.sha }}
@@ -36,6 +36,6 @@ jobs:
       javaVersion: "21"
       helmChartName: "none"
       releaseVersion: "6.6.6"
-      imagesDir: "kafka-bridge-amd64.tar.gz"
-      githubActionsRef: "v1"
+      imagesLocation: "kafka-bridge-amd64.tar.gz"
+      githubActionsRef: "v2.3"
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker://rhysd/actionlint:1.7.10
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # v1.7.12
         with:
           args: -color

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,18 +32,18 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/setup-java@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/setup-java@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           javaVersion: "21"
 
-      - uses: strimzi/github-actions/.github/actions/build/release-artifacts@v1
+      - uses: strimzi/github-actions/.github/actions/build/release-artifacts@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           releaseVersion: ${{ inputs.releaseVersion }}
           artifactSuffix: "kafka-bridge"
 
-      - uses: strimzi/github-actions/.github/actions/build/deploy-java@v1
+      - uses: strimzi/github-actions/.github/actions/build/deploy-java@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           gpgPassphrase: ${{ secrets.GPG_PASSPHRASE }}
           gpgSigningKey: ${{ secrets.GPG_SIGNING_KEY }}
@@ -59,13 +59,13 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup ORAS
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
 
       - name: Download bridge binaries from source build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binaries-kafka-bridge.tar
           run-id: ${{ inputs.sourceBuildRunId }}
@@ -92,13 +92,15 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
+        with:
+          version: "1.20.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/push-containers@v1
+      - uses: strimzi/github-actions/.github/actions/build/push-containers@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           architectures: "amd64,arm64,ppc64le,s390x"
           containerRegistry: "quay.io"
@@ -126,13 +128,15 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-docker@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
 
-      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@v1
+      - uses: strimzi/github-actions/.github/actions/dependencies/install-syft@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
+        with:
+          version: "1.20.0"
 
-      - uses: strimzi/github-actions/.github/actions/build/push-containers@v1
+      - uses: strimzi/github-actions/.github/actions/build/push-containers@52b17c19f3687e37b47c9c64696b96f28f53625b # v2.3
         with:
           architectures: "amd64,arm64,ppc64le,s390x"
           containerRegistry: "quay.io"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Bump our github-actions to v2.3 and pin all actions via sha digest.

### Checklist

- [x] Make sure all tests pass
