### PR TITLE
Bump strimzi-kafka-oauth to 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0
 
-* Dependency updates (Kafka 4.3.1, Vert.x 5.1.6, Netty 4.2.17.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha, Log4j2 [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844), Metrics Reporter 0.4.0)
+* Dependency updates (Kafka 4.3.1, Vert.x 5.1.6, Netty 4.2.17.Final, JMX Prometheus collector 1.6.0, Micrometer 1.16.6 [CVE-2026-40984](https://nvd.nist.gov/vuln/detail/CVE-2026-40984), OpenTelemetry 1.63.0 [CVE-2026-45292](https://nvd.nist.gov/vuln/detail/CVE-2026-45292), OpenTelemetry Semconv 1.28.0-alpha, Log4j2 [CVE-2026-49844](https://nvd.nist.gov/vuln/detail/CVE-2026-49844), Metrics Reporter 0.4.0, Strimzi Kafka OAuth 0.18.0)
 * Fixed bug on deleting more than one inactive consumers.
 * Fixed bug on message header with null value.
 * Fixed poll timeout and max_bytes query parameters not resetting to defaults when omitted on subsequent consumer poll requests.

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<fasterxml.jackson-core.version>2.22.1</fasterxml.jackson-core.version>
 		<fasterxml.jackson-databind.version>2.22.1</fasterxml.jackson-databind.version>
-		<strimzi-oauth.version>0.18.0-RC1</strimzi-oauth.version>
+		<strimzi-oauth.version>0.18.0</strimzi-oauth.version>
 		<strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
 		<opentelemetry.version>1.63.0</opentelemetry.version>
 		<opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<kafka-env-var-config-provider.version>1.1.0</kafka-env-var-config-provider.version>
 		<fasterxml.jackson-core.version>2.22.1</fasterxml.jackson-core.version>
 		<fasterxml.jackson-databind.version>2.22.1</fasterxml.jackson-databind.version>
-		<strimzi-oauth.version>0.17.1</strimzi-oauth.version>
+		<strimzi-oauth.version>0.18.0-RC1</strimzi-oauth.version>
 		<strimzi-metrics-reporter.version>0.4.0</strimzi-metrics-reporter.version>
 		<opentelemetry.version>1.63.0</opentelemetry.version>
 		<opentelemetry.instrumentation.version>1.32.0-alpha</opentelemetry.instrumentation.version>


### PR DESCRIPTION
### Type of change

- Dependency update

### Description

Bump Strimzi Kafka OAuth version to 0.18.0

### Checklist

- [ ] Update documentation
- [x] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
