### PR TITLE
Separate HTTP server and SSL/TLS configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0
 
 * Fixed bug on negative partition id not being rejected (get partition, send to partition and get offsets operations), by adding a `minimum` constraint to the `partitionid` parameter in the OpenAPI spec.
+* Separated HTTP server and SSL/TLS configuration to use the Vert.x `ServerSSLOptions` API, enabling future support for configuring TLS key exchange groups (e.g., for post-quantum cryptography).
 
 ## 1.1.0
 

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -29,9 +29,10 @@ import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
-import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpServerConfig;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.CorsHandler;
@@ -156,12 +157,13 @@ public class HttpBridge extends AbstractVerticle {
     }
 
     private void bindHttpServers(Promise<Void> startPromise) {
-        HttpServerOptions managementServerOptions = new HttpServerOptions();
-        managementServerOptions.setHost(this.bridgeConfig.getHttpConfig().getHost());
-        managementServerOptions.setPort(this.bridgeConfig.getHttpConfig().getManagementPort());
+        HttpServerConfig managementServerConfig = new HttpServerConfig();
+        managementServerConfig.setHost(this.bridgeConfig.getHttpConfig().getHost());
+        managementServerConfig.setPort(this.bridgeConfig.getHttpConfig().getManagementPort());
 
-        HttpServerOptions httpServerOptions = httpServerOptions();
-        this.vertx.createHttpServer(httpServerOptions)
+        HttpServerConfig httpServerConfig = httpServerConfig();
+        ServerSSLOptions serverSSLOptions = this.bridgeConfig.getHttpConfig().isSslEnabled() ? serverSSLOptions() : null;
+        this.vertx.createHttpServer(httpServerConfig, serverSSLOptions)
                 .connectionHandler(this::processConnection)
                 .requestHandler(this.router)
                 .listen()
@@ -178,7 +180,7 @@ public class HttpBridge extends AbstractVerticle {
 
                     this.isReady = true;
                     this.apiServer = apiServer;
-                    return this.vertx.createHttpServer(managementServerOptions)
+                    return this.vertx.createHttpServer(managementServerConfig)
                             .connectionHandler(this::processConnection)
                             .requestHandler(this.managementRouter)
                             .listen()
@@ -355,38 +357,40 @@ public class HttpBridge extends AbstractVerticle {
                 });
     }
 
-    private HttpServerOptions httpServerOptions() {
-        HttpServerOptions httpServerOptions = new HttpServerOptions();
-        httpServerOptions.setHost(this.bridgeConfig.getHttpConfig().getHost());
-        httpServerOptions.setPort(this.bridgeConfig.getHttpConfig().getPort());
+    private HttpServerConfig httpServerConfig() {
+        HttpServerConfig httpServerConfig = new HttpServerConfig();
+        httpServerConfig.setHost(this.bridgeConfig.getHttpConfig().getHost());
+        httpServerConfig.setPort(this.bridgeConfig.getHttpConfig().getPort());
+        return httpServerConfig;
+    }
 
-        if (this.bridgeConfig.getHttpConfig().isSslEnabled()) {
-            httpServerOptions.setSsl(true);
+    private ServerSSLOptions serverSSLOptions() {
+        ServerSSLOptions serverSSLOptions = new ServerSSLOptions();
 
-            if (bridgeConfig.getHttpConfig().getHttpServerSslCertificateLocation() != null && this.bridgeConfig.getHttpConfig().getHttpServerSslKeyLocation() != null) {
-                httpServerOptions.setKeyCertOptions(new PemKeyCertOptions()
-                        .setKeyPath(this.bridgeConfig.getHttpConfig().getHttpServerSslKeyLocation())
-                        .setCertPath(this.bridgeConfig.getHttpConfig().getHttpServerSslCertificateLocation()));
-            } else if (bridgeConfig.getHttpConfig().getHttpServerSslCertificate() != null && this.bridgeConfig.getHttpConfig().getHttpServerSslKey() != null) {
-                httpServerOptions.setKeyCertOptions(new PemKeyCertOptions()
-                        .addKeyValue(Buffer.buffer(this.bridgeConfig.getHttpConfig().getHttpServerSslKey()))
-                        .addCertValue(Buffer.buffer(this.bridgeConfig.getHttpConfig().getHttpServerSslCertificate())));
-            } else {
-                LOGGER.error("Required SSL configurations are missing! Either both of http.ssl.certificate.location and http.ssl.key.location " +
-                        "or both of http.ssl.certificate and http.ssl.key should be configured");
-            }
-
-            Set<String> sslEnabledProtocols = this.bridgeConfig.getHttpConfig().getHttpServerSslEnabledProtocols();
-            if (sslEnabledProtocols != null) {
-                httpServerOptions.setEnabledSecureTransportProtocols(sslEnabledProtocols);
-            }
-
-            Set<String> sslCipherSuites = this.bridgeConfig.getHttpConfig().getHttpServerSslCipherSuites();
-            if (sslCipherSuites != null) {
-                sslCipherSuites.forEach(httpServerOptions::addEnabledCipherSuite);
-            }
+        if (bridgeConfig.getHttpConfig().getHttpServerSslCertificateLocation() != null && this.bridgeConfig.getHttpConfig().getHttpServerSslKeyLocation() != null) {
+            serverSSLOptions.setKeyCertOptions(new PemKeyCertOptions()
+                    .setKeyPath(this.bridgeConfig.getHttpConfig().getHttpServerSslKeyLocation())
+                    .setCertPath(this.bridgeConfig.getHttpConfig().getHttpServerSslCertificateLocation()));
+        } else if (bridgeConfig.getHttpConfig().getHttpServerSslCertificate() != null && this.bridgeConfig.getHttpConfig().getHttpServerSslKey() != null) {
+            serverSSLOptions.setKeyCertOptions(new PemKeyCertOptions()
+                    .addKeyValue(Buffer.buffer(this.bridgeConfig.getHttpConfig().getHttpServerSslKey()))
+                    .addCertValue(Buffer.buffer(this.bridgeConfig.getHttpConfig().getHttpServerSslCertificate())));
+        } else {
+            LOGGER.error("Required SSL configurations are missing! Either both of http.ssl.certificate.location and http.ssl.key.location " +
+                    "or both of http.ssl.certificate and http.ssl.key should be configured");
         }
-        return httpServerOptions;
+
+        Set<String> sslEnabledProtocols = this.bridgeConfig.getHttpConfig().getHttpServerSslEnabledProtocols();
+        if (sslEnabledProtocols != null) {
+            serverSSLOptions.setEnabledSecureTransportProtocols(sslEnabledProtocols);
+        }
+
+        Set<String> sslCipherSuites = this.bridgeConfig.getHttpConfig().getHttpServerSslCipherSuites();
+        if (sslCipherSuites != null) {
+            sslCipherSuites.forEach(serverSSLOptions::addEnabledCipherSuite);
+        }
+
+        return serverSSLOptions;
     }
 
     private void send(RoutingContext routingContext) {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Starting from Vert.x 5.1, the HTTP server creation API has been updated to separate the general HTTP server configuration from the SSL/TLS configuration. The previously used `HttpServerOptions` class, which bundled both concerns together, has been replaced (even if not deprecated) by two distinct types: `HttpServerConfig` for plain server settings (i.e. host, port) and `ServerSSLOptions` for all SSL/TLS-related configuration (i.e. certificates, enabled protocols, cipher suites). More details are available on the Vert.x blog post https://vertx.io/blog/whats-new-in-vert-x-5-1/
This PR refactors `HttpBridge` to adopt this new API.

This separation not only aligns the bridge with the latest Vert.x API but also allows configuring hybrid key exchange groups via the `ServerSSLOptions` class exposing the `setTlsKeyExchangeGroups()` method, which is not available through the previous `HttpServerOptions` class. This is useful for a future PQC (Post Quantum Criptography) support.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Update CHANGELOG.md (if present)
- [x] Write tests
- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
