### PR TITLE
Fixed HTTP sink endpoint cleaning by centralizing the logic

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -62,7 +62,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -199,19 +198,20 @@ public class HttpBridge extends AbstractVerticle {
         long timeoutInMs = timeout * 1000L;
         vertx.setPeriodic(timeoutInMs / 2, ignore -> {
             LOGGER.debug("Looking for stale consumers in {} entries", timestampMap.size());
-            Iterator<Map.Entry<ConsumerInstanceId, Long>> it = timestampMap.entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry<ConsumerInstanceId, Long> item = it.next();
-                if (item.getValue() + timeoutInMs < System.currentTimeMillis()) {
-                    HttpSinkBridgeEndpoint<byte[], byte[]> deleteSinkEndpoint = this.httpBridgeContext.getHttpSinkEndpoints().get(item.getKey());
-                    if (deleteSinkEndpoint != null) {
-                        deleteSinkEndpoint.close();
-                        this.httpBridgeContext.getHttpSinkEndpoints().remove(item.getKey());
-                        LOGGER.warn("Consumer {} deleted after inactivity timeout ({}s).", item.getKey(), timeout);
-                        it.remove();
-                    }
+            long currentTime = System.currentTimeMillis();
+            // Collect inactive consumers first
+            List<ConsumerInstanceId> staleConsumers = timestampMap.entrySet().stream()
+                .filter(entry -> entry.getValue() + timeoutInMs < currentTime)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+            // Close inactive consumers after collection
+            staleConsumers.forEach(consumerId -> {
+                HttpSinkBridgeEndpoint<byte[], byte[]> deleteSinkEndpoint = this.httpBridgeContext.getHttpSinkEndpoints().get(consumerId);
+                if (deleteSinkEndpoint != null) {
+                    LOGGER.warn("Deleting consumer {} after inactivity timeout ({}s).", consumerId, timeout);
+                    deleteSinkEndpoint.close();
                 }
-            }
+            });
         });
     }
 
@@ -434,6 +434,7 @@ public class HttpBridge extends AbstractVerticle {
                 @SuppressWarnings("unchecked")
                 HttpSinkBridgeEndpoint<byte[], byte[]> httpEndpoint = (HttpSinkBridgeEndpoint<byte[], byte[]>) endpoint;
                 httpBridgeContext.getHttpSinkEndpoints().remove(httpEndpoint.consumerInstanceId());
+                timestampMap.remove(httpEndpoint.consumerInstanceId());
             });        
             sink.open();
 
@@ -470,9 +471,6 @@ public class HttpBridge extends AbstractVerticle {
 
         if (deleteSinkEndpoint != null) {
             deleteSinkEndpoint.handle(routingContext);
-
-            this.httpBridgeContext.getHttpSinkEndpoints().remove(kafkaConsumerInstanceId);
-            timestampMap.remove(kafkaConsumerInstanceId);
         } else {
             HttpBridgeError error = new HttpBridgeError(
                     HttpResponseStatus.NOT_FOUND.code(),

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -60,11 +60,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
@@ -96,7 +96,7 @@ public class HttpBridge extends AbstractVerticle {
 
     private Router managementRouter;
 
-    private final Map<ConsumerInstanceId, Long> timestampMap = new HashMap<>();
+    private final Map<ConsumerInstanceId, Long> timestampMap = new ConcurrentHashMap<>();
 
     private MetricsCollector metricsCollector = null;
 
@@ -203,7 +203,7 @@ public class HttpBridge extends AbstractVerticle {
             List<ConsumerInstanceId> staleConsumers = timestampMap.entrySet().stream()
                 .filter(entry -> entry.getValue() + timeoutInMs < currentTime)
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                .toList();
             // Close inactive consumers after collection
             staleConsumers.forEach(consumerId -> {
                 HttpSinkBridgeEndpoint<byte[], byte[]> deleteSinkEndpoint = this.httpBridgeContext.getHttpSinkEndpoints().get(consumerId);

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
@@ -10,6 +10,7 @@ import io.vertx.core.http.HttpConnection;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Context class which is used for storing endpoints.
@@ -20,7 +21,7 @@ import java.util.Map;
  */
 public class HttpBridgeContext<K, V> {
 
-    private final Map<ConsumerInstanceId, HttpSinkBridgeEndpoint<K, V>> httpSinkEndpoints = new HashMap<>();
+    private final Map<ConsumerInstanceId, HttpSinkBridgeEndpoint<K, V>> httpSinkEndpoints = new ConcurrentHashMap<>();
     private final Map<HttpConnection, HttpSourceBridgeEndpoint<K, V>> httpSourceEndpoints = new HashMap<>();
     private HttpAdminBridgeEndpoint httpAdminBridgeEndpoint;
     private HttpOpenApiOperations openApiOperation;


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

I enabled some additional log in the current bridge and noticed the following:

```shell
2026-08-19 13:05:37 INFO  [vert.x-eventloop-thread-0] deleteConsumer:49 - [924287670] DELETE_CONSUMER Request: from 0:0:0:0:0:0:0:1:39994, method = DELETE, path = /consumers/my-group/instances/consumer1
2026-08-19 13:05:37 INFO  [vert.x-eventloop-thread-0] HttpBridge:472 - HttpBridge.deleteConsumer (thread = Thread[#53,vert.x-eventloop-thread-0,5,main] remove = ConsumerInstanceId(groupId=my-group, instanceId=consumer1)
2026-08-19 13:05:37 INFO  [vert.x-eventloop-thread-0] HttpBridge:473 - ---> is in the list? true
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] ConsumerCoordinator:1062 - [Consumer clientId=consumer1, groupId=my-group] Resetting generation and member id due to: consumer pro-actively leaving the group
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] ConsumerCoordinator:1109 - [Consumer clientId=consumer1, groupId=my-group] Request joining group due to: consumer pro-actively leaving the group
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] Metrics:684 - Metrics scheduler closed
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] Metrics:688 - Closing reporter org.apache.kafka.common.metrics.JmxReporter
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] Metrics:688 - Closing reporter org.apache.kafka.common.telemetry.internals.ClientTelemetryReporter
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] Metrics:694 - Metrics reporters closed
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] AppInfoParser:89 - App info kafka.consumer for consumer1 unregistered
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] HttpBridge:433 - HttpBridge.createConsumer closeHandler (thread = Thread[#68,kafka-bridge-executor-1,5,main] remove = ConsumerInstanceId(groupId=my-group, instanceId=consumer1)
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] HttpBridge:434 - ---> is in the list? false
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] HttpSinkBridgeEndpoint:310 - Deleted consumer consumer1 from group my-group
2026-08-19 13:05:37 INFO  [kafka-bridge-executor-1] deleteConsumer:58 - [924287670] DELETE_CONSUMER Response: statusCode = 204, message = No Content
```

The removal of a consumer when the DELETE command is issued by the HTTP client happens in two places. On the `deleteConsumer` (on the Vert.x event loop) but also on the sink `closeHandler` (on the async executor thread). The latter does usually nothing (because the consumer was already removed by the first call) but the current design can cause race condition. Finally, another deletion operation happens within the inactive consumer timer.

In more details, the HTTP Bridge maintains two maps for tracking active consumer endpoints: `httpSinkEndpoints` (storing endpoint instances) and `timestampMap` (tracking last activity for timeout detection). The cleanup logic for these maps is duplicated across the three above different locations.
Additionally, the cleanup is inconsistent with `timestampMap` only removed from in `deleteConsumer()` and the timer, but not in the `closeHandler`, while `httpSinkEndpoints` is cleaned up in all three places.

This PR fixes this issue by centralizing all cleanup logic into the `closeHandler` callback, which is the natural owner of this responsibility since it's invoked whenever an endpoint closes. The `deleteConsumer()` method and inactive consumer timer now simply call `close()` on the endpoint, and the `closeHandler` performs all map cleanup for both `httpSinkEndpoints` and `timestampMap`.

As a side benefit, this also eliminates a potential race condition where multiple threads could modify the HashMaps simultaneously.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests
- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
