### PR TITLE
Moved consumers inactivity timestamps map into the bridge context

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -64,7 +64,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
@@ -95,8 +94,6 @@ public class HttpBridge extends AbstractVerticle {
     private Router router;
 
     private Router managementRouter;
-
-    private final Map<ConsumerInstanceId, Long> timestampMap = new ConcurrentHashMap<>();
 
     private MetricsCollector metricsCollector = null;
 
@@ -197,10 +194,10 @@ public class HttpBridge extends AbstractVerticle {
     private void startInactiveConsumerDeletionTimer(long timeout) {
         long timeoutInMs = timeout * 1000L;
         vertx.setPeriodic(timeoutInMs / 2, ignore -> {
-            LOGGER.debug("Looking for stale consumers in {} entries", timestampMap.size());
+            LOGGER.debug("Looking for stale consumers in {} entries", this.httpBridgeContext.getConsumerTimestamps().size());
             long currentTime = System.currentTimeMillis();
             // Collect inactive consumers first
-            List<ConsumerInstanceId> staleConsumers = timestampMap.entrySet().stream()
+            List<ConsumerInstanceId> staleConsumers = this.httpBridgeContext.getConsumerTimestamps().entrySet().stream()
                 .filter(entry -> entry.getValue() + timeoutInMs < currentTime)
                 .map(Map.Entry::getKey)
                 .toList();
@@ -434,7 +431,7 @@ public class HttpBridge extends AbstractVerticle {
                 @SuppressWarnings("unchecked")
                 HttpSinkBridgeEndpoint<byte[], byte[]> httpEndpoint = (HttpSinkBridgeEndpoint<byte[], byte[]>) endpoint;
                 httpBridgeContext.getHttpSinkEndpoints().remove(httpEndpoint.consumerInstanceId());
-                timestampMap.remove(httpEndpoint.consumerInstanceId());
+                httpBridgeContext.getConsumerTimestamps().remove(httpEndpoint.consumerInstanceId());
             });        
             sink.open();
 
@@ -442,7 +439,7 @@ public class HttpBridge extends AbstractVerticle {
                 @SuppressWarnings("unchecked")
                 HttpSinkBridgeEndpoint<byte[], byte[]> httpEndpoint = (HttpSinkBridgeEndpoint<byte[], byte[]>) endpoint;
                 httpBridgeContext.getHttpSinkEndpoints().put(httpEndpoint.consumerInstanceId(), httpEndpoint);
-                timestampMap.put(httpEndpoint.consumerInstanceId(), System.currentTimeMillis());
+                httpBridgeContext.getConsumerTimestamps().put(httpEndpoint.consumerInstanceId(), System.currentTimeMillis());
             });
         } catch (Exception ex) {
             if (sink != null) {
@@ -569,7 +566,7 @@ public class HttpBridge extends AbstractVerticle {
         HttpSinkBridgeEndpoint<byte[], byte[]> sinkEndpoint = this.httpBridgeContext.getHttpSinkEndpoints().get(kafkaConsumerInstanceId);
 
         if (sinkEndpoint != null) {
-            timestampMap.replace(kafkaConsumerInstanceId, System.currentTimeMillis());
+            this.httpBridgeContext.getConsumerTimestamps().replace(kafkaConsumerInstanceId, System.currentTimeMillis());
             sinkEndpoint.handle(routingContext);
         } else {
             HttpBridgeError error = new HttpBridgeError(

--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridgeContext.java
@@ -23,6 +23,7 @@ public class HttpBridgeContext<K, V> {
 
     private final Map<ConsumerInstanceId, HttpSinkBridgeEndpoint<K, V>> httpSinkEndpoints = new ConcurrentHashMap<>();
     private final Map<HttpConnection, HttpSourceBridgeEndpoint<K, V>> httpSourceEndpoints = new HashMap<>();
+    private final Map<ConsumerInstanceId, Long> consumerTimestamps = new ConcurrentHashMap<>();
     private HttpAdminBridgeEndpoint httpAdminBridgeEndpoint;
     private HttpOpenApiOperations openApiOperation;
 
@@ -47,6 +48,15 @@ public class HttpBridgeContext<K, V> {
      */
     public Map<HttpConnection, HttpSourceBridgeEndpoint<K, V>> getHttpSourceEndpoints() {
         return this.httpSourceEndpoints;
+    }
+
+    /**
+     * Get the map with the consumer IDs and the corresponding last activity time
+     *
+     * @return map of the consumer IDs and the corresponding last activity time
+     */
+    public Map<ConsumerInstanceId, Long> getConsumerTimestamps() {
+        return this.consumerTimestamps;
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

To make the code more consistent, this PR moves the map of the inactivity timestamps for the consumers within the `HttpBridgeContext` class alongside the maps with the sink (consumers) endpoints.

### Checklist

- [x] Make sure all tests pass
- [x] Try your changes inside a Kubernetes cluster, not just from unit tests